### PR TITLE
Remove outdated air quality references

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A Home Assistant integration for monitoring pollen across Europe, data provided through [the Austrian Pollen Information Service](https://www.polleninformation.eu).
 
-> **NOTE:** As of v0.4.0, you must use your own API key. Request it [here](https://www.polleninformation.at/en/data-interface/request-an-api-key).
+> **NOTE:** You must use your own API key. Request it [here](https://www.polleninformation.at/en/data-interface/request-an-api-key).
 
 <table align="center">
   <tr>
@@ -77,15 +77,13 @@ Each sensor includes:
 
 **The integration updates sensor data every 8 hours.** Which is more than enough, as the data usually does not change more frequently than once every 24 hours.
 
-### API usage and v0.4.0 changes
+### API usage
 
-As of **v0.4.0**, this integration uses the new official public API provided by the [Austrian Pollen Information Service](https://www.polleninformation.at/en/data-interface).  
+This integration uses the official public API provided by the [Austrian Pollen Information Service](https://www.polleninformation.at/en/data-interface).
 You **must request a personal API key** to use the integration—get your key [here](https://www.polleninformation.at/en/data-interface/request-an-api-key).
 
-The previous versions of the integration used an undocumented, internal API endpoint. That endpoint is now closed for public use, following [the provider’s announcement](https://www.polleninformation.at/en/data-interface).  
-You will need to update to v0.4.0 or later and configure your new API key to continue receiving pollen data.
+*For more information about the API and its terms of use, see [Austrian Pollen Information Service - Data Interface](https://www.polleninformation.at/en/data-interface).* 
 
-*For more information about the API and its terms of use, see [Austrian Pollen Information Service - Data Interface](https://www.polleninformation.at/en/data-interface).*
 
 ---
 

--- a/info.md
+++ b/info.md
@@ -1,11 +1,10 @@
 # Home Assistant: Pollen Information EU
 
-Pollen Information EU is a Home Assistant integration that provides up-to-date pollen and air quality data for any location in Europe, powered by the Austrian Pollen Information Service.
+Pollen Information EU is a Home Assistant integration that provides up-to-date pollen data for any location in Europe, powered by the Austrian Pollen Information Service.
 
 ## Features
 
 - **Multiple allergens**: Automatically creates a sensor for each detected allergen at your chosen location.
-- **Air quality sensors**: Additional sensors for ozone, particulate matter, nitrogen dioxide, sulphur dioxide, temperature, and more.
 - **Forecast included**: Each sensor exposes a multi-day forecast as an attribute.
 - **Works in multiple European countries**: Choose location by country, and latitude and longitude.
 
@@ -20,7 +19,7 @@ Pollen Information EU is a Home Assistant integration that provides up-to-date p
 1. Go to **Settings → Devices & Services → Add Integration**.
 2. Search for `Pollen Information EU` and add the integration.
 3. Select your country and enter your desired location (latitude/longitude).
-4. Sensors will be created automatically for all available allergens and air quality metrics at the selected location.
+4. Sensors will be created automatically for all available allergens at the selected location.
 
 ## Sensor Attributes
 
@@ -31,7 +30,7 @@ Each sensor exposes attributes such as:
 - **named_state / numeric_state**: Today's level (text and numeric)
 - **location_title / location_slug / location_zip**: Location information
 - **name_en / name_de / name_la**: Allergen name (English, German, Latin)
-- **Icon**: Mapped to allergen or air quality type
+- **Icon**: Mapped to allergen type
 
 ## Data Source & Attribution
 


### PR DESCRIPTION
## Summary
- update info.md to drop mentions of air quality sensors
- clean up README to remove old API references

## Testing
- `python -m hassfest` *(fails: No module named hassfest)*

------
https://chatgpt.com/codex/tasks/task_e_687a55c5d8348328b498e9b5778c65b0