### PR TITLE
Expose unscaled allergy risk value

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ All allergen sensors use a scale from `0` to `4`:
 The allergy risk provided by the API ranges from `0` to `10`. The
 integration scales this value to the same `0`–`4` range by applying
 `round(value / 2.5)` so that all sensors share a common scale.
+The original `0`–`10` value is available as the `raw_numeric_state`
+attribute of the `allergy_risk` sensor.
 
 **The integration updates sensor data every 8 hours.** Which is more than enough, as the data usually does not change more frequently than once every 24 hours.
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ All allergen sensors use a scale from `0` to `4`:
 The allergy risk provided by the API ranges from `0` to `10`. The
 integration scales this value to the same `0`–`4` range by applying
 `round(value / 2.5)` so that all sensors share a common scale.
-The original `0`–`10` value is available as the `raw_numeric_state`
+The original `0`–`10` value is available as the `numeric_state_raw`
 attribute of the `allergy_risk` sensor.
 
 **The integration updates sensor data every 8 hours.** Which is more than enough, as the data usually does not change more frequently than once every 24 hours.
@@ -100,8 +100,7 @@ attribute of the `allergy_risk` sensor.
 This integration uses the official public API provided by the [Austrian Pollen Information Service](https://www.polleninformation.at/en/data-interface).
 You **must request a personal API key** to use the integration—get your key [here](https://www.polleninformation.at/en/data-interface/request-an-api-key).
 
-*For more information about the API and its terms of use, see [Austrian Pollen Information Service - Data Interface](https://www.polleninformation.at/en/data-interface).* 
-
+*For more information about the API and its terms of use, see [Austrian Pollen Information Service - Data Interface](https://www.polleninformation.at/en/data-interface).*
 
 ---
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -397,10 +397,16 @@ class AllergyRiskSensor(SensorEntity):
                 "value": scaled,
                 "named_state": named,
             })
-        named_state = self._levels_current[self.state] if self.state is not None and self.state < len(self._levels_current) else None
+        named_state = (
+            self._levels_current[self.state]
+            if self.state is not None and self.state < len(self._levels_current)
+            else None
+        )
+        raw_value = self._allergyrisk.get("allergyrisk_1", None)
         return {
             "named_state": named_state,
             "numeric_state": self.state,
+            "raw_numeric_state": raw_value,
             "forecast": forecast,
             "location_title": self._location_title,
             "location_slug": self._location_slug,

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -406,7 +406,7 @@ class AllergyRiskSensor(SensorEntity):
         return {
             "named_state": named_state,
             "numeric_state": self.state,
-            "raw_numeric_state": raw_value,
+            "numeric_state_raw": raw_value,
             "forecast": forecast,
             "location_title": self._location_title,
             "location_slug": self._location_slug,

--- a/info.md
+++ b/info.md
@@ -38,7 +38,7 @@ All allergen sensors report values from **0** (none) to **4** (very high).
 The allergy risk returned by the API uses a **0–10** scale. The integration
 converts this to the same **0–4** range using `round(value / 2.5)` so that
 all values are comparable.
-The original `0`–`10` value can be found in the `raw_numeric_state` attribute
+The original `0`–`10` value can be found in the `numeric_state_raw` attribute
 of the `allergy_risk` sensor.
 
 ## Data Source & Attribution

--- a/info.md
+++ b/info.md
@@ -38,6 +38,8 @@ All allergen sensors report values from **0** (none) to **4** (very high).
 The allergy risk returned by the API uses a **0–10** scale. The integration
 converts this to the same **0–4** range using `round(value / 2.5)` so that
 all values are comparable.
+The original `0`–`10` value can be found in the `raw_numeric_state` attribute
+of the `allergy_risk` sensor.
 
 ## Data Source & Attribution
 


### PR DESCRIPTION
## Summary
- add `raw_numeric_state` attribute to `allergy_risk` sensor
- document raw value in README and info docs

## Testing
- `python -m py_compile custom_components/polleninformation/sensor.py`
- `ruff check custom_components/polleninformation/sensor.py` *(fails: E402, F401)*

------
https://chatgpt.com/codex/tasks/task_e_688c64f065148328841ba68580b03eea