### PR TITLE
Use named state for allergy risk sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ The integration will create sensors named like:
 
 Each sensor includes:
 
-- Current pollen level (numerical and descriptive string)
-- Multi-day forecast as an attribute
-- Human-friendly names and icons for all entities
+ - Current pollen level as text (numeric value available in attributes)
+ - Multi-day forecast as an attribute
+ - Human-friendly names and icons for all entities
 
 ### Understanding the values
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -380,9 +380,12 @@ class AllergyRiskSensor(SensorEntity):
 
     @property
     def state(self):
-        """Return allergy risk value for day 1, scaled to 0-4."""
+        """Return allergy risk for day 1 as named level."""
         value = self._allergyrisk.get("allergyrisk_1", None)
-        return scale_allergy_risk(value) if value is not None else None
+        scaled = scale_allergy_risk(value) if value is not None else None
+        if scaled is not None and scaled < len(self._levels_current):
+            return self._levels_current[scaled]
+        return None
 
     @property
     def extra_state_attributes(self):
@@ -397,15 +400,11 @@ class AllergyRiskSensor(SensorEntity):
                 "value": scaled,
                 "named_state": named,
             })
-        named_state = (
-            self._levels_current[self.state]
-            if self.state is not None and self.state < len(self._levels_current)
-            else None
-        )
         raw_value = self._allergyrisk.get("allergyrisk_1", None)
+        scaled_today = scale_allergy_risk(raw_value) if raw_value is not None else None
         return {
-            "named_state": named_state,
-            "numeric_state": self.state,
+            "named_state": self.state,
+            "numeric_state": scaled_today,
             "numeric_state_raw": raw_value,
             "forecast": forecast,
             "location_title": self._location_title,

--- a/info.md
+++ b/info.md
@@ -27,7 +27,7 @@ Each sensor exposes attributes such as:
 
 - **level_en**: Current state as text (`none`, `low`, `moderate`, etc.)
 - **forecast**: Array with daily forecast (each entry includes date, numeric and named level)
-- **named_state / numeric_state**: Today's level (text and numeric)
+ - **named_state / numeric_state**: Current level (sensor state is `named_state`)
 - **location_title / location_slug / location_zip**: Location information
 - **name_en / name_de / name_la**: Allergen name (English, German, Latin)
 - **Icon**: Mapped to allergen type


### PR DESCRIPTION
## Summary
- keep sensor states consistent by returning the named level for `allergy_risk`
- document that numeric level is now in attributes

## Testing
- `./scripts/lint.sh` *(fails: E402 and other errors)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_688c69b629748328812669f6dbfc93b1