### PR TITLE
Normalize allergy risk forecast structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ integration scales this value to the same `0`–`4` range by applying
 `round(value / 2.5)` so that all sensors share a common scale.
 The original `0`–`10` value is available as the `numeric_state_raw`
 attribute of both the `allergy_risk` and `allergy_risk_hourly`
-sensors.
+sensors. Within their forecast attribute the same raw value is exposed
+as `level_raw` for each forecast entry.
 
 **The integration updates sensor data every 8 hours.** Which is more than enough, as the data usually does not change more frequently than once every 24 hours.
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -442,6 +442,7 @@ class AllergyRiskSensor(SensorEntity):
                     ),
                     "level": scaled,
                     "level_name": level_name,
+                    "level_raw": value_raw,
                 }
             )
         raw_value = self._allergyrisk.get("allergyrisk_1", None)
@@ -528,11 +529,10 @@ class AllergyRiskHourlySensor(SensorEntity):
                 )
                 forecast.append(
                     {
-                        "datetime": dt.isoformat(),
-                        "condition": named,
-                        "named_state": named,
-                        "numeric_state": scaled,
-                        "numeric_state_raw": raw,
+                        "time": dt.isoformat(),
+                        "level": scaled,
+                        "level_name": named,
+                        "level_raw": raw,
                     }
                 )
 

--- a/info.md
+++ b/info.md
@@ -27,6 +27,7 @@ Each sensor exposes attributes such as:
 
 - **level_en**: Current state as text (`none`, `low`, `moderate`, etc.)
 - **forecast**: Array with daily forecast (each entry includes date, numeric and named level)
+  - For the allergy risk sensors the original 0–10 value is included as `level_raw` in each entry
  - **named_state / numeric_state**: Current level (sensor state is `named_state`)
 - **location_title / location_slug / location_zip**: Location information
 - **name_en / name_de / name_la**: Allergen name (English, German, Latin)
@@ -39,7 +40,8 @@ The allergy risk returned by the API uses a **0–10** scale. The integration
 converts this to the same **0–4** range using `round(value / 2.5)` so that
 all values are comparable.
 The original `0`–`10` value can be found in the `numeric_state_raw` attribute
-of both the `allergy_risk` and `allergy_risk_hourly` sensors.
+of both the `allergy_risk` and `allergy_risk_hourly` sensors. The same raw value
+is available per forecast entry as `level_raw`.
 
 ## Data Source & Attribution
 


### PR DESCRIPTION
## Summary
- add `level_raw` to daily allergy risk forecast
- harmonize allergy risk hourly forecast keys (time, level, level_name, level_raw)
- document new `level_raw` field for allergy risk forecasts

## Testing
- `ruff format custom_components/polleninformation/sensor.py`
- `ruff check custom_components/polleninformation/sensor.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_688d07c539e083288576806fd12f1907