### PR TITLE
Handle outdated sensors in polleninformation integration

### DIFF
--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -220,7 +220,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     # Remove outdated sensors no longer provided by the API
     registry = er.async_get(hass)
-    for entity_entry in registry.async_entries_for_config_entry(entry.entry_id):
+    for entity_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
         if entity_entry.domain != "sensor":
             continue
         if entity_entry.unique_id not in new_unique_ids:


### PR DESCRIPTION
## Summary
- Clean old sensors from Home Assistant entity registry when integration setup runs
- Ensure only current API sensors remain active

## Testing
- `scripts/lint.sh`
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_688e33fdaf4c8328a4c4944e818d9b82