### PR TITLE
Bump first-party GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/api-status.yaml
+++ b/.github/workflows/api-status.yaml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -35,7 +35,7 @@ jobs:
         run: python scripts/check_api_status.py
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/
 
@@ -48,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Hassfest validation
         uses: home-assistant/actions/hassfest@master
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: HACS Validation
         uses: hacs/action@main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Get version
         id: version

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -12,13 +12,13 @@ jobs:
     name: HACS hassfest
     runs-on: "ubuntu-latest"
     steps:
-        - uses: "actions/checkout@v4"
+        - uses: "actions/checkout@v5"
         - uses: "home-assistant/actions/hassfest@master"
   hacs:
     name: HACS Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: HACS validation
         uses: hacs/action@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
   under `docs/` and referenced relatively, so the status page no longer depends
   on their site.
 
+### Internal
+
+- **CI: bump first-party GitHub Actions to Node 24 majors** — `actions/checkout`
+  → v5, `actions/setup-python` → v6, `actions/upload-pages-artifact` → v5,
+  `actions/deploy-pages` → v5. Drops the Node.js 20 runtime deprecation ahead of
+  GitHub's forced Node 24 cutover (2026-06-16).
+
 ## v0.5.1 — Configurable update interval and attribute fixes (2026-03-31)
 
 ### Bug fixes


### PR DESCRIPTION
## Why

GitHub forces Node.js 20 actions to Node 24 on **2026-06-16** and removes Node 20 from runners on **2026-09-16**. The `api-status` workflow already emits the deprecation annotation (`actions/checkout@v4`, `actions/setup-python@v5`, `actions/upload-artifact@v4`), and `cron.yaml`/`release.yaml` carry even older `checkout@v2`/`@v3`.

## Changes

Bump all **first-party `actions/*`** to their minimal Node 24-ready major:

| Action | From | To | Target runtime |
|---|---|---|---|
| `actions/checkout` | v2 / v3 / v4 | **v5** | node24 |
| `actions/setup-python` | v5 | **v6** | node24 |
| `actions/upload-pages-artifact` | v3 | **v5** | composite → pins `upload-artifact@v7` (node24) |
| `actions/deploy-pages` | v4 | **v5** | node24 |

`upload-pages-artifact@v3` is composite and pins `upload-artifact@v4` internally — that's the source of the `upload-artifact@v4` warning; v5 pulls in `upload-artifact@v7`.

Third-party actions (`home-assistant/actions/*`, `hacs/action`, `verify-pr-label-action`, `svenstaro/upload-release-action`, `release-drafter`) are unchanged — not flagged and not first-party.

Files touched: `api-status.yaml`, `validate.yaml`, `cron.yaml`, `release.yaml`, plus a CHANGELOG entry under `v0.5.2`.