### PR TITLE
Bump release-drafter to v7 (Node 24)

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create Release
-        uses: release-drafter/release-drafter@v5
+        uses: release-drafter/release-drafter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@
 
 ### Internal
 
-- **CI: bump first-party GitHub Actions to Node 24 majors** — `actions/checkout`
-  → v5, `actions/setup-python` → v6, `actions/upload-pages-artifact` → v5,
-  `actions/deploy-pages` → v5. Drops the Node.js 20 runtime deprecation ahead of
-  GitHub's forced Node 24 cutover (2026-06-16).
+- **CI: bump GitHub Actions to Node 24 runtimes** — `actions/checkout` → v5,
+  `actions/setup-python` → v6, `actions/upload-pages-artifact` → v5,
+  `actions/deploy-pages` → v5, and `release-drafter/release-drafter` → v7. Drops
+  the Node.js 20/16 runtime deprecation ahead of GitHub's forced Node 24 cutover
+  (2026-06-16).
 
 ## v0.5.1 — Configurable update interval and attribute fixes (2026-03-31)
 


### PR DESCRIPTION
## Why

Follow-up to #53. While verifying that PR, the workflow annotations showed `release-drafter/release-drafter@v5` is still on the deprecated **Node.js 16** runtime — the last remaining deprecated action in the repo, and the oldest (breaks before the Node 20 ones at GitHub's 2026-06-16 forced cutover).

## Change

`release-drafter/release-drafter@v5` → **v7** (minimal Node 24-ready major; v6 is still Node 20). Only `release-drafter.yaml` and a CHANGELOG note touched.

After this, no workflow in the repo uses a deprecated Node runtime.