### PR TITLE
Modernize options flow: drop OptionsFlowWithConfigEntry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@
   the Node.js 20/16 runtime deprecation ahead of GitHub's forced Node 24 cutover
   (2026-06-16).
 
+- **Modernize options flow** — `OptionsFlowHandler` now subclasses the plain
+  `OptionsFlow` base and drops the custom `__init__(config_entry)`, relying on
+  the `self.config_entry` property that Home Assistant provides automatically
+  since 2024.11. `OptionsFlowWithConfigEntry` is deprecated and should be
+  avoided in new code.
+
 ## v0.5.1 — Configurable update interval and attribute fixes (2026-03-31)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@
   `OptionsFlow` base and drops the custom `__init__(config_entry)`, relying on
   the `self.config_entry` property that Home Assistant provides automatically
   since 2024.11. `OptionsFlowWithConfigEntry` is deprecated and should be
-  avoided in new code.
+  avoided in new code. Because the inherited `config_entry` property only exists
+  from HA 2024.11, `hacs.json` now declares `2024.11.0` as the minimum supported
+  Home Assistant version so HACS blocks installs/upgrades on older cores that
+  would hit a broken options flow.
 
 ## v0.5.1 — Configurable update interval and attribute fixes (2026-03-31)
 

--- a/custom_components/polleninformation/config_flow.py
+++ b/custom_components/polleninformation/config_flow.py
@@ -297,4 +297,4 @@ class PolleninformationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry):
         """Return the options flow handler."""
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()

--- a/custom_components/polleninformation/options_flow.py
+++ b/custom_components/polleninformation/options_flow.py
@@ -31,11 +31,8 @@ from .utils import async_get_country_options, async_get_language_options
 _LOGGER = logging.getLogger(__name__)
 
 
-class OptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
+class OptionsFlowHandler(config_entries.OptionsFlow):
     """Options flow handler for polleninformation.at integration."""
-
-    def __init__(self, config_entry):
-        super().__init__(config_entry)
 
     async def async_step_init(self, user_input=None):
         """Initial step for options flow."""

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "Polleninformation EU",
+  "homeassistant": "2024.11.0",
   "hide_default_branch": true,
   "zip_release": true,
   "filename": "polleninformation.zip",


### PR DESCRIPTION
Switches `OptionsFlowHandler` to the plain `OptionsFlow` base and drops the custom `__init__(config_entry)`, relying on the `self.config_entry` property Home Assistant provides automatically since 2024.11 ([New options flow properties](https://developers.home-assistant.io/blog/2024/11/12/options-flow/)).

`OptionsFlowWithConfigEntry` is deprecated and "should be avoided in new code". We forwarded `config_entry` to `super().__init__()` rather than assigning `self.config_entry`, so the HA 2025.12 hard break did not apply to us — this is low-urgency tech debt cleanup, not a compliance break.

## Changes

- `options_flow.py`: subclass `config_entries.OptionsFlow`, remove the custom `__init__`. All existing `self.config_entry.data` / `.options` / `getattr(self.config_entry, "hass", None)` accesses keep working via the inherited property.
- `config_flow.py`: `async_get_options_flow` now constructs `OptionsFlowHandler()` with no argument.
- `CHANGELOG.md`: noted under `v0.5.2` → Internal.

## Verification

Deployed to local hass-test (HA running, API 200). The integration loads with no `OptionsFlow`/`config_entry` deprecation warnings and no errors. Drove the real options-flow code path via the HA API for a configured entry: the `init` form renders correctly (exercising `OptionsFlowHandler()` construction and `self.config_entry` access), with no warnings or tracebacks.

Closes #55