### PR TITLE
(release) v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.5.2 (unreleased)
+## v0.5.2 — Status page logo fix and options-flow modernization (2026-06-22)
 
 ### Bug fixes
 


### PR DESCRIPTION
Promote v0.5.2 to stable. Dates the CHANGELOG entry; release content already soaked as v0.5.2-beta1 in prod ~2.5 weeks.