### PR TITLE
Fix hourly allergy risk forecast timestamps

### DIFF
--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -603,7 +603,7 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
                 attrs["stale_since"] = self._stale_since
             return attrs
 
-        base_time = dt_util.utcnow().replace(minute=0, second=0, microsecond=0)
+        base_time = dt_util.now().replace(hour=0, minute=0, second=0, microsecond=0)
         forecast = []
         for day in range(1, 5):
             values = allergyrisk_hourly.get(f"allergyrisk_hourly_{day}", [])

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,7 +1,7 @@
 """Tests for sensor helper functions and sensor classes."""
 
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 
 from custom_components.polleninformation.sensor import (
@@ -264,3 +264,20 @@ class TestAllergyRiskHourlySensor:
         attrs = sensor.extra_state_attributes
         assert "forecast" in attrs
         assert len(attrs["forecast"]) > 0
+
+    def test_forecast_times_start_at_local_midnight(self, mock_api_response):
+        coordinator = _make_coordinator(mock_api_response)
+        sensor = self._make_sensor(coordinator)
+
+        fake_now = datetime(2026, 6, 22, 16, 30, tzinfo=timezone.utc)
+
+        with patch(
+                "custom_components.polleninformation.sensor.dt_util.now",
+                return_value=fake_now,
+        ):
+            forecast = sensor.extra_state_attributes["forecast"]
+
+        assert forecast[0]["time"] == "2026-06-23T00:00:00+00:00"
+        assert forecast[1]["time"] == "2026-06-23T01:00:00+00:00"
+        assert forecast[23]["time"] == "2026-06-23T23:00:00+00:00"
+        assert forecast[24]["time"] == "2026-06-24T00:00:00+00:00"


### PR DESCRIPTION
Fix hourly allergy risk forecast timestamps.

Hourly allergy risk values are day based and start at 00:00. The forecast attributes were built from the current UTC hour, which shifted the timestamps.

They now start from local midnight, matching the hourly values returned by the API.