### PR TITLE
Handle country detection failures

### DIFF
--- a/custom_components/polleninformation/utils.py
+++ b/custom_components/polleninformation/utils.py
@@ -6,6 +6,7 @@ import re
 import unicodedata
 
 import aiohttp
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     COUNTRY_DISPLAY_NAMES,
@@ -31,11 +32,16 @@ async def async_get_country_code_from_latlon(hass, lat, lon):
         "addressdetails": 1,
     }
     headers = {"User-Agent": "Home Assistant Polleninformation Integration"}
-    async with aiohttp.ClientSession() as session:
+    session = async_get_clientsession(hass)
+
+    try:
         async with session.get(url, params=params, headers=headers, timeout=5) as resp:
             if resp.status == 200:
                 result = await resp.json()
                 return result.get("address", {}).get("country_code", "").upper()
+    except (aiohttp.ClientError, TimeoutError, ValueError):
+        return None
+
     return None
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,12 @@
 """Tests for utility functions (pure, no HA dependency)."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
 from custom_components.polleninformation.utils import (
+    async_get_country_code_from_latlon,
     extract_place_slug,
     find_best_lang_code_for_locale_sync,
     get_allergen_info_by_latin,
@@ -148,3 +154,37 @@ class TestGetLanguageOptionsSync:
         result = get_language_options_sync()
         for code in SUPPORTED_LANGUAGES:
             assert code in result
+
+
+class TestGetCountryCodeFromLatLon:
+    @pytest.mark.asyncio
+    async def test_returns_country_code(self):
+        hass = MagicMock()
+        response = AsyncMock()
+        response.status = 200
+        response.json.return_value = {"address": {"country_code": "be"}}
+
+        session = MagicMock()
+        session.get.return_value.__aenter__.return_value = response
+
+        with patch(
+                "custom_components.polleninformation.utils.async_get_clientsession",
+                return_value=session,
+        ):
+            result = await async_get_country_code_from_latlon(hass, 50.85, 4.35)
+
+        assert result == "BE"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_connection_error(self):
+        hass = MagicMock()
+        session = MagicMock()
+        session.get.side_effect = aiohttp.ClientError
+
+        with patch(
+                "custom_components.polleninformation.utils.async_get_clientsession",
+                return_value=session,
+        ):
+            result = await async_get_country_code_from_latlon(hass, 50.85, 4.35)
+
+        assert result is None


### PR DESCRIPTION
Avoid crashing the config flow when country auto detection fails.

Reverse geocoding now uses Home Assistant's shared aiohttp session and returns None on connection, timeout, or JSON errors so the config flow can fall back to its default country.