### PR TITLE
Add Dependabot + pytest CI, SHA-pin actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,12 @@ updates:
         patterns:
           - "*"
 
-  # Keep the SHA-pinned GitHub Actions (checkout, setup-python, hassfest, hacs,
-  # release-drafter, ...) from silently drifting out of date.
+  # Propose bumps for the SHA-pinned, released GitHub Actions (checkout,
+  # setup-python, release-drafter, ...) instead of letting them drift.
+  # NOTE: home-assistant/actions/* and hacs/action ship no releases (they are
+  # normally used as @master/@main); pinned to a branch-head SHA here, Dependabot
+  # has no release to bump them to, so they stay frozen at a reviewed SHA -- the
+  # supply-chain win -- and are refreshed manually when needed.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  # Test/CI Python dependencies (requirements_test.txt). Pinned exact so a
+  # breaking upstream release (Home Assistant, pytest) lands as a red check on
+  # the bump PR, not on main. Dependabot only bumps `==` pins; requirements.txt
+  # (unpinned runtime deps resolved by HA) is left untouched.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "(deps)"
+    labels:
+      - "dependencies"
+    groups:
+      test-deps:
+        patterns:
+          - "*"
+
+  # Keep the SHA-pinned GitHub Actions (checkout, setup-python, hassfest, hacs,
+  # release-drafter, ...) from silently drifting out of date.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "(deps)"
+    labels:
+      - "dependencies"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/api-status.yaml
+++ b/.github/workflows/api-status.yaml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: '3.12'
 
@@ -35,7 +35,7 @@ jobs:
         run: python scripts/check_api_status.py
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
           path: docs/
 
@@ -48,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -9,20 +9,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Hassfest validation
-        uses: home-assistant/actions/hassfest@master
+        uses: home-assistant/actions/hassfest@f4ca6f671bd429efb108c0f2fa0ae8af0215986c  # master 2026-06-22
 
   validate-hacs:
     name: With HACS action
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: HACS Validation
-        uses: hacs/action@main
+        uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa  # main 2026-06-08
         with:
           ignore: brands,hacs
           category: integration

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create Release
-        uses: release-drafter/release-drafter@v7
+        uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e  # v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Get version
         id: version
-        uses: home-assistant/actions/helpers/version@master
+        uses: home-assistant/actions/helpers/version@f4ca6f671bd429efb108c0f2fa0ae8af0215986c  # master 2026-06-22
 
       - name: "Set version number"
         run: |
@@ -26,7 +26,7 @@ jobs:
           zip polleninformation.zip -r ./
 
       - name: Upload zip to release
-        uses: svenstaro/upload-release-action@v1-release
+        uses: svenstaro/upload-release-action@14569a2d348419d066e34e5dfa65071ecd30b64b  # v1-release
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ./custom_components/polleninformation/polleninformation.zip

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,8 +17,13 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install test dependencies
-        run: pip install -r requirements_test.txt
+      - name: Install dependencies
+        # requirements_test.txt pins the HA + pytest stack; the integration's
+        # own manifest requirements (async-timeout, Unidecode) are not provided
+        # by Home Assistant, so install them too. aiohttp/voluptuous come with HA.
+        run: |
+          pip install -r requirements_test.txt
+          pip install async-timeout Unidecode
 
       - name: Run pytest
         run: pytest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,24 @@
+name: "Tests"
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    name: pytest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        with:
+          python-version: "3.14"
+
+      - name: Install test dependencies
+        run: pip install -r requirements_test.txt
+
+      - name: Run pytest
+        run: pytest

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -12,16 +12,16 @@ jobs:
     name: HACS hassfest
     runs-on: "ubuntu-latest"
     steps:
-        - uses: "actions/checkout@v5"
-        - uses: "home-assistant/actions/hassfest@master"
+        - uses: "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd"  # v5
+        - uses: "home-assistant/actions/hassfest@f4ca6f671bd429efb108c0f2fa0ae8af0215986c"  # master 2026-06-22
   hacs:
     name: HACS Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: HACS validation
-        uses: hacs/action@main
+        uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa  # main 2026-06-08
         with:
           category: integration
 

--- a/.github/workflows/validate_pr.yaml
+++ b/.github/workflows/validate_pr.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR Label Validation
-        uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        uses: jesusvasquez333/verify-pr-label-action@657d111bbbe13e22bbd55870f1813c699bde1401  # v1.4.0
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
-          valid-labels: 'bug, enhancement'
+          valid-labels: 'bug, enhancement, dependencies'
           invalid-labels: 'help wanted, invalid, question'
           pull-request-number: '${{ github.event.pull_request.number }}'
           disable-reviews: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,12 @@
   no longer listed separately (they would conflict with its exact pins).
 
 - **SHA-pin all GitHub Actions** — every `uses:` ref across the workflows is now
-  pinned to a full commit SHA with a version comment, so Dependabot manages the
-  bumps and third-party actions (notably `verify-pr-label-action` under
-  `pull_request_target`) can no longer change under us.
+  pinned to a full commit SHA with a version comment, so third-party actions
+  (notably `verify-pr-label-action` under `pull_request_target`) can no longer
+  change under us. Dependabot proposes bumps for the released actions;
+  `home-assistant/actions/*` and `hacs/action` ship no releases, so they stay
+  frozen at a reviewed SHA (previously floating `@master`/`@main`) and are
+  refreshed manually.
 
 - **CI: run the test suite on push and PR** — new `test.yaml` workflow runs
   `pytest` on Python 3.14 (HA 2026.7.1 requires ≥3.14.2), so a breaking HA bump

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## Unreleased
+
+### Internal
+
+- **Dependabot** — added `.github/dependabot.yml` with monthly grouped updates
+  for two ecosystems: `pip` (test dependencies) and `github-actions`. A breaking
+  upstream release now surfaces as a red check on the bump PR instead of a
+  surprise failure on `main`. Home Assistant is tracked via the exact
+  `pytest-homeassistant-custom-component` pin in `requirements_test.txt`, which
+  is version-locked to a specific HA release.
+
+- **Pin CI test dependencies exactly** — `requirements_test.txt` now pins
+  `pytest-homeassistant-custom-component==0.13.345` (HA 2026.7.1). The package
+  drives the whole matching pytest stack transitively, so pytest/pytest-cov are
+  no longer listed separately (they would conflict with its exact pins).
+
+- **SHA-pin all GitHub Actions** — every `uses:` ref across the workflows is now
+  pinned to a full commit SHA with a version comment, so Dependabot manages the
+  bumps and third-party actions (notably `verify-pr-label-action` under
+  `pull_request_target`) can no longer change under us.
+
+- **CI: run the test suite on push and PR** — new `test.yaml` workflow runs
+  `pytest` on Python 3.14 (HA 2026.7.1 requires ≥3.14.2), so a breaking HA bump
+  shows up as a red check on the Dependabot PR.
+
+- **Fix test mocks for newer aiohttp** — the API client rejects non-JSON
+  responses; the JSON mocks in `test_api.py` now advertise an
+  `application/json` content-type, which recent aiohttp no longer defaults.
+  Surfaced by the HA 2026.7.1 bump.
+
 ## v0.5.2 — Status page logo fix and options-flow modernization (2026-06-22)
 
 ### Bug fixes

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,14 @@
-pytest
-pytest-homeassistant-custom-component
-pytest-cov
+# Test dependencies for polleninformation
+#
+# Pinned exact for reproducible CI: a floating "latest" release periodically
+# broke CI with no change on our side. Dependabot proposes monthly bumps (see
+# .github/dependabot.yml) so a breaking release surfaces as a red check on the
+# bump PR instead of a red main. Dependabot only bumps `==` pins, so keep exact.
+#
+# pytest-homeassistant-custom-component is version-locked to a specific Home
+# Assistant release (0.13.345 -> HA 2026.7.1, which requires Python >=3.14.2)
+# and pins the whole matching pytest stack (pytest, pytest-cov, pytest-asyncio,
+# ...) transitively. Bumping this single pin is how we adopt a new HA -- do NOT
+# add explicit pytest/pytest-cov pins here, they would conflict with the exact
+# versions this package requires.
+pytest-homeassistant-custom-component==0.13.345

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,10 +24,14 @@ CALL_KWARGS = {
     "apikey": "test-key",
 }
 
+# The real API returns JSON with an application/json content-type; the client
+# rejects non-JSON responses, so JSON mocks must advertise the header.
+JSON_HEADERS = {"Content-Type": "application/json"}
+
 
 async def test_successful_response(hass: HomeAssistant, aioclient_mock):
     payload = {"contamination": [{"poll_title": "Birch", "contamination_1": 1}]}
-    aioclient_mock.get(API_URL_PREFIX, json=payload)
+    aioclient_mock.get(API_URL_PREFIX, json=payload, headers=JSON_HEADERS)
     result = await async_get_pollenat_data(hass, **CALL_KWARGS)
     assert result == payload
 
@@ -65,12 +69,16 @@ async def test_client_error_raises_connection_error(
 
 
 async def test_json_error_apikey_raises_auth_error(hass: HomeAssistant, aioclient_mock):
-    aioclient_mock.get(API_URL_PREFIX, json={"error": "invalid api key"})
+    aioclient_mock.get(
+        API_URL_PREFIX, json={"error": "invalid api key"}, headers=JSON_HEADERS
+    )
     with pytest.raises(PollenApiAuthError):
         await async_get_pollenat_data(hass, **CALL_KWARGS)
 
 
 async def test_json_error_other_raises_api_error(hass: HomeAssistant, aioclient_mock):
-    aioclient_mock.get(API_URL_PREFIX, json={"error": "rate limit exceeded"})
+    aioclient_mock.get(
+        API_URL_PREFIX, json={"error": "rate limit exceeded"}, headers=JSON_HEADERS
+    )
     with pytest.raises(PollenApiError):
         await async_get_pollenat_data(hass, **CALL_KWARGS)


### PR DESCRIPTION
## Why

Nothing currently guards against upstream drift: GitHub Actions float on mutable tags/branches, and the `tests/` suite is never run in CI. A new Home Assistant monthly release could break the integration with no early warning.

Dependabot has no "HA release" tracker as such; the mechanism here is an exact `pytest-homeassistant-custom-component` pin in `requirements_test.txt` (version-locked to a specific HA release), bumped monthly by Dependabot — so a breaking HA release lands as a red check on the bump PR instead of a surprise on `dev`.

## What

- **`.github/dependabot.yml`** — monthly grouped updates for `pip` (test deps) and `github-actions`, `(deps)` commit prefix, `dependencies` label.
- **`requirements_test.txt`** — pin `pytest-homeassistant-custom-component==0.13.345` (HA 2026.7.1). It drives the whole matching pytest stack transitively, so pytest/pytest-cov are no longer listed separately (they'd conflict with its exact pins).
- **SHA-pin every GitHub Action** across all workflows with a version comment, so Dependabot manages bumps and third-party actions (notably `verify-pr-label-action` under `pull_request_target`) can't change under us.
- **`test.yaml`** — new workflow running `pytest` on Python 3.14 (HA 2026.7.1 requires ≥3.14.2).
- **`validate_pr.yaml`** — accept the `dependencies` label so Dependabot PRs pass the label gate.
- **`test_api.py`** — JSON mocks now advertise `application/json`; recent aiohttp (pulled by HA 2026.7.1) no longer defaults the content-type, which the client's non-JSON guard rejected. Surfaced by the HA bump — exactly what the new CI is meant to catch.

## Verification

- `pytest` — 85 passed locally on Python 3.14.6 with the pinned stack.
- `./scripts/lint.sh` — clean.
- All workflow YAML parses; no floating action refs remain.