### PR TITLE
Stable English entity_ids for all sensors, with registry migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,24 @@
 # Changelog
 
-## v0.5.3 — Entity IDs for the allergy risk sensors (2026-08-05)
+## v0.5.3 — English entity IDs in every language (2026-08-05)
 
 ### Bug fixes
+
+- **Allergen entity IDs are English again** (issue #63) — the allergen slug,
+  which decides both the unique ID and the entity ID, came from an English name
+  looked up by latin name in `language_map.json`. That file only covers twelve
+  allergens, so the ten it does not know about fell back to the name the API
+  sent in the configured language: a German installation got
+  `sensor.polleninformation_<location>_esche` rather than `..._ash`, and a
+  Swedish one `..._ask`. The slug now comes from a static latin-to-English map
+  covering every allergen the API returns, with the old lookup kept as a
+  fallback. The displayed name is unaffected and stays in the configured
+  language.
+
+- **Icons for the allergens the API has added** — dock/sorrel, plantain, sweet
+  chestnut and tree of heaven had no icon and fell back to the generic pollen
+  icon. Linden was listed under a slug the API never returns (`lime`), so it
+  had no icon either.
 
 - **Allergy risk sensors get English entity IDs again** (issue #63) — v0.5.2
   gave the two allergy risk sensors translatable names, and Home Assistant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@
   icon. Linden was listed under a slug the API never returns (`lime`), so it
   had no icon either.
 
+- **Localized allergen IDs are renamed automatically** (issue #63) — an
+  installation that got a localized unique ID and entity ID has both renamed to
+  the English form on the next start. The rename is derived from the current API
+  response, so nothing outside this integration's own output can match it. An
+  entity ID you renamed yourself is kept, and a rename is skipped when the
+  target is already taken.
+
 - **Allergy risk sensors get English entity IDs again** (issue #63) — v0.5.2
   gave the two allergy risk sensors translatable names, and Home Assistant
   derives an entity ID from the name it sees when the entity is first created.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@
   follows the displayed name. Installations that upgraded from an earlier
   version were never affected. The names themselves are still translated.
 
+- **Entity IDs created from a translated name are renamed automatically**
+  (issue #63) — an installation that already got a localized entity ID from
+  v0.5.2 has it renamed to the canonical `..._allergy_risk` /
+  `..._allergy_risk_hourly` on the next start. Only entity IDs matching a
+  translation of the sensor name are touched, so an entity ID you renamed
+  yourself is left alone; a rename is also skipped if the target entity ID is
+  already taken.
+
 ## v0.5.2 — Entity name translations, contributor fixes, CI (2026-08-05)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   fallback. The displayed name is unaffected and stays in the configured
   language.
 
+- **An allergen no map knows about is now logged** — it still gets a sensor,
+  named and slugged from the configured language as before, but a warning names
+  it and its latin name and asks for a bug report, so an addition to the API
+  surfaces instead of quietly producing a localized entity ID.
+
 - **Icons for the allergens the API has added** — dock/sorrel, plantain, sweet
   chestnut and tree of heaven had no icon and fell back to the generic pollen
   icon. Linden was listed under a slug the API never returns (`lime`), so it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.5.3 — Entity IDs for the allergy risk sensors (2026-08-05)
+
+### Bug fixes
+
+- **Allergy risk sensors get English entity IDs again** (issue #63) — v0.5.2
+  gave the two allergy risk sensors translatable names, and Home Assistant
+  derives an entity ID from the name it sees when the entity is first created.
+  A new installation on a non-English Home Assistant therefore ended up with
+  entity IDs such as `sensor.polleninformation_<location>_allergierisiko`
+  instead of `..._allergy_risk`, which breaks dashboards and the pollen
+  forecast card. The entity ID is now pinned to the English slug and no longer
+  follows the displayed name. Installations that upgraded from an earlier
+  version were never affected. The names themselves are still translated.
+
 ## v0.5.2 — Entity name translations, contributor fixes, CI (2026-08-05)
 
 ### New features

--- a/custom_components/polleninformation/manifest.json
+++ b/custom_components/polleninformation/manifest.json
@@ -11,6 +11,6 @@
     "async-timeout>=4.0.0",
     "Unidecode>=1.3.6"
   ],
-  "version": "0.5.2"
+  "version": "0.5.3"
 }
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -168,8 +168,11 @@ def migrate_localized_allergen_ids(hass, location_slug, renames) -> None:
 
     The renames are (legacy_slug, canonical_slug) pairs derived from the
     current API response, so only ids this integration can itself have
-    produced are ever considered. Both the unique_id and the entity_id are
-    migrated; either is skipped with a warning when the target is taken.
+    produced are ever considered. The unique_id is always migrated; the
+    entity_id only when it is exactly what this integration would have
+    generated, so an entity_id the user chose is kept even when it happens to
+    end in the old slug. Either step is skipped with a warning when its
+    target is taken.
     """
     if not renames:
         return
@@ -191,9 +194,9 @@ def migrate_localized_allergen_ids(hass, location_slug, renames) -> None:
             continue
 
         updates: dict[str, str] = {"new_unique_id": canonical_unique_id}
-        object_id = entity_id.split(".", 1)[1]
-        if object_id.endswith(f"_{legacy_slug}"):
-            new_entity_id = f"sensor.{object_id[: -len(legacy_slug)]}{canonical_slug}"
+        prefix = f"polleninformation_{location_slug}_"
+        if entity_id == f"sensor.{prefix}{legacy_slug}":
+            new_entity_id = f"sensor.{prefix}{canonical_slug}"
             if ent_reg.async_get(new_entity_id) is not None:
                 _LOGGER.warning(
                     "Keeping entity_id %s: %s is already taken",
@@ -202,6 +205,12 @@ def migrate_localized_allergen_ids(hass, location_slug, renames) -> None:
                 )
             else:
                 updates["new_entity_id"] = new_entity_id
+        else:
+            _LOGGER.debug(
+                "Keeping entity_id %s: it is not the generated one for %s",
+                entity_id,
+                legacy_slug,
+            )
 
         _LOGGER.info(
             "Migrating localized allergen sensor %s (%s) to %s",
@@ -245,11 +254,12 @@ def localized_risk_object_id_suffixes() -> dict[str, frozenset[str]]:
     return {slug: frozenset(values) for slug, values in suffixes.items()}
 
 
-async def async_migrate_localized_risk_entity_ids(hass, entry) -> None:
+async def async_migrate_localized_risk_entity_ids(hass, entry, location_slug) -> None:
     """Rename risk sensor entity_ids that were created from a translated name.
 
-    Only entity_ids whose suffix matches a known translation of the sensor
-    name are touched; a user-chosen entity_id never matches and is left alone.
+    Only an entity_id that is exactly what this integration would itself have
+    generated from a translated name is touched, so an entity_id the user
+    chose is left alone even when it happens to end in a translated name.
     """
     ent_reg = er.async_get(hass)
     candidates = []
@@ -263,18 +273,17 @@ async def async_migrate_localized_risk_entity_ids(hass, entry) -> None:
         return
 
     suffixes = await hass.async_add_executor_job(localized_risk_object_id_suffixes)
+    prefix = f"polleninformation_{location_slug}_"
 
     for reg_entry, slug in candidates:
         object_id = reg_entry.entity_id.split(".", 1)[1]
-        if object_id.endswith(f"_{slug}"):
-            continue
         localized = next(
-            (s for s in suffixes[slug] if object_id.endswith(f"_{s}")), None
+            (s for s in suffixes[slug] if object_id == f"{prefix}{s}"), None
         )
         if localized is None:
             continue
 
-        new_entity_id = f"{reg_entry.domain}.{object_id[: -len(localized)]}{slug}"
+        new_entity_id = f"{reg_entry.domain}.{prefix}{slug}"
         if ent_reg.async_get(new_entity_id) is not None:
             _LOGGER.warning(
                 "Cannot rename %s to %s: target entity_id already exists",
@@ -318,8 +327,6 @@ def scale_allergy_risk(value: Any) -> int | None:
 async def async_setup_entry(hass, entry, async_add_entities):
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
-    await async_migrate_localized_risk_entity_ids(hass, entry)
-
     # Get existing entities from registry to handle stale data scenarios
     ent_reg = er.async_get(hass)
     existing_entities = er.async_entries_for_config_entry(ent_reg, entry.entry_id)
@@ -352,6 +359,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
         lon_str = f"{lon:.4f}" if lon is not None else "?"
         location_title = f"{country_name} ({lat_str}, {lon_str})"
     location_slug = normalize(location_title)
+
+    # Needs location_slug: a rename only happens for the entity_id this
+    # integration would itself have generated for this location.
+    await async_migrate_localized_risk_entity_ids(hass, entry, location_slug)
 
     language_block_current = await async_get_language_block(hass, lang)
     language_block_en = await async_get_language_block(hass, "en")

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -233,7 +233,7 @@ def localized_risk_object_id_suffixes() -> dict[str, frozenset[str]]:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
-            _LOGGER.debug("Could not read translation file %s", path)
+            _LOGGER.debug("Could not read translation file %s", path, exc_info=True)
             continue
         sensors = data.get("entity", {}).get("sensor", {})
         for slug in RISK_SLUGS:

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -163,6 +163,19 @@ def english_name_for_latin(latin: str | None) -> str | None:
     return index.get(key.split()[0]) if key.split() else None
 
 
+def entity_id_available(hass, ent_reg, entity_id: str) -> bool:
+    """Return True when the registry would accept this entity_id.
+
+    Mirrors the registry's own rule: async_update_entity raises when the
+    target is registered OR occupied in the state machine. A YAML or template
+    entity holds an entity_id without a registry entry, so checking the
+    registry alone lets that call raise and abort setup.
+    """
+    return not ent_reg.async_is_registered(entity_id) and hass.states.async_available(
+        entity_id
+    )
+
+
 def migrate_localized_allergen_ids(hass, location_slug, renames) -> None:
     """Rename allergen ids that were derived from a localized allergen name.
 
@@ -197,14 +210,14 @@ def migrate_localized_allergen_ids(hass, location_slug, renames) -> None:
         prefix = f"polleninformation_{location_slug}_"
         if entity_id == f"sensor.{prefix}{legacy_slug}":
             new_entity_id = f"sensor.{prefix}{canonical_slug}"
-            if ent_reg.async_get(new_entity_id) is not None:
+            if entity_id_available(hass, ent_reg, new_entity_id):
+                updates["new_entity_id"] = new_entity_id
+            else:
                 _LOGGER.warning(
                     "Keeping entity_id %s: %s is already taken",
                     entity_id,
                     new_entity_id,
                 )
-            else:
-                updates["new_entity_id"] = new_entity_id
         else:
             _LOGGER.debug(
                 "Keeping entity_id %s: it is not the generated one for %s",
@@ -284,7 +297,7 @@ async def async_migrate_localized_risk_entity_ids(hass, entry, location_slug) ->
             continue
 
         new_entity_id = f"{reg_entry.domain}.{prefix}{slug}"
-        if ent_reg.async_get(new_entity_id) is not None:
+        if not entity_id_available(hass, ent_reg, new_entity_id):
             _LOGGER.warning(
                 "Cannot rename %s to %s: target entity_id already exists",
                 reg_entry.entity_id,

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -12,10 +12,14 @@ See official API documentation: https://www.polleninformation.at/en/data-interfa
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import timedelta
+from functools import lru_cache
+from pathlib import Path
 
 from homeassistant.util import dt as dt_util
+from homeassistant.util import slugify as ha_slugify
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
@@ -64,10 +68,9 @@ ALLERGEN_ICON_MAP = {
     "willow": "mdi:tree",
 }
 
-KNOWN_ALLERGEN_SLUGS = set(ALLERGEN_ICON_MAP.keys()) - {"default"} | {
-    "allergy_risk",
-    "allergy_risk_hourly",
-}
+RISK_SLUGS = ("allergy_risk", "allergy_risk_hourly")
+
+KNOWN_ALLERGEN_SLUGS = set(ALLERGEN_ICON_MAP.keys()) - {"default"} | set(RISK_SLUGS)
 
 
 def capitalize_first(s: str) -> str:
@@ -90,6 +93,82 @@ def extract_allergen_slug_from_unique_id(unique_id: str) -> str | None:
         if unique_id.endswith(suffix):
             return slug
     return None
+
+
+@lru_cache(maxsize=1)
+def localized_risk_object_id_suffixes() -> dict[str, frozenset[str]]:
+    """Return the localized object_id suffixes the risk sensors can have produced.
+
+    Home Assistant derives an entity_id from the entity name, so a translated
+    risk sensor name yields a translated object_id. Every translated name --
+    from the translation files as well as from RISK_SENSOR_NAMES -- is a
+    suffix a released version may have written to the registry. The canonical
+    slug itself is excluded so it is never treated as a rename candidate.
+    """
+    suffixes: dict[str, set[str]] = {slug: set() for slug in RISK_SLUGS}
+
+    for names in RISK_SENSOR_NAMES.values():
+        for slug in RISK_SLUGS:
+            if name := names.get(slug):
+                suffixes[slug].add(ha_slugify(name))
+
+    for path in sorted((Path(__file__).parent / "translations").glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            _LOGGER.debug("Could not read translation file %s", path)
+            continue
+        sensors = data.get("entity", {}).get("sensor", {})
+        for slug in RISK_SLUGS:
+            if name := sensors.get(slug, {}).get("name"):
+                suffixes[slug].add(ha_slugify(name))
+
+    for slug in RISK_SLUGS:
+        suffixes[slug].discard(slug)
+    return {slug: frozenset(values) for slug, values in suffixes.items()}
+
+
+async def async_migrate_localized_risk_entity_ids(hass, entry) -> None:
+    """Rename risk sensor entity_ids that were created from a translated name.
+
+    Only entity_ids whose suffix matches a known translation of the sensor
+    name are touched; a user-chosen entity_id never matches and is left alone.
+    """
+    ent_reg = er.async_get(hass)
+    candidates = []
+    for reg_entry in er.async_entries_for_config_entry(ent_reg, entry.entry_id):
+        if reg_entry.domain != "sensor":
+            continue
+        slug = extract_allergen_slug_from_unique_id(reg_entry.unique_id)
+        if slug in RISK_SLUGS:
+            candidates.append((reg_entry, slug))
+    if not candidates:
+        return
+
+    suffixes = await hass.async_add_executor_job(localized_risk_object_id_suffixes)
+
+    for reg_entry, slug in candidates:
+        object_id = reg_entry.entity_id.split(".", 1)[1]
+        if object_id.endswith(f"_{slug}"):
+            continue
+        localized = next(
+            (s for s in suffixes[slug] if object_id.endswith(f"_{s}")), None
+        )
+        if localized is None:
+            continue
+
+        new_entity_id = f"{reg_entry.domain}.{object_id[: -len(localized)]}{slug}"
+        if ent_reg.async_get(new_entity_id) is not None:
+            _LOGGER.warning(
+                "Cannot rename %s to %s: target entity_id already exists",
+                reg_entry.entity_id,
+                new_entity_id,
+            )
+            continue
+        _LOGGER.info(
+            "Renaming localized entity_id %s to %s", reg_entry.entity_id, new_entity_id
+        )
+        ent_reg.async_update_entity(reg_entry.entity_id, new_entity_id=new_entity_id)
 
 
 def pollen_forecast_for_allergen(
@@ -121,6 +200,8 @@ def scale_allergy_risk(value: Any) -> int | None:
 
 async def async_setup_entry(hass, entry, async_add_entities):
     coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    await async_migrate_localized_risk_entity_ids(hass, entry)
 
     # Get existing entities from registry to handle stale data scenarios
     ent_reg = er.async_get(hass)

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -46,6 +46,37 @@ from .utils import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# English allergen name per latin name, as the API returns it for lang=en.
+# This is the source of the allergen slug, and therefore of the unique_id and
+# the entity_id. Deriving the slug from the localized response instead would
+# give a different unique_id per interface language. language_map.json only
+# covers the twelve allergens that had a localized name when it was
+# generated, so the API is the authority here.
+LATIN_TO_ENGLISH_NAME = {
+    "Ailanthus altissima": "tree of heaven",
+    "Alnus": "alder",
+    "Alternaria": "fungal spores",
+    "Ambrosia": "ragweed",
+    "Artemisia": "mugwort",
+    "Betula": "birch",
+    "Castanea": "sweet chestnut",
+    "Corylus": "hazel",
+    "Cupressaceae": "cypress family",
+    "Fagus": "beech",
+    "Fraxinus": "ash",
+    "Olea": "olive",
+    "Plantago": "plantain",
+    "Platanus": "plane tree",
+    "Poaceae": "grasses",
+    "Quercus": "oak",
+    "Rumex": "dock/sorrel",
+    "Salix": "willow",
+    "Secale": "rye",
+    "Tilia": "linden",
+    "Ulmus": "elm",
+    "Urticaceae": "nettle family",
+}
+
 ALLERGEN_ICON_MAP = {
     "alder": "mdi:tree-outline",
     "ash": "mdi:tree",
@@ -53,24 +84,32 @@ ALLERGEN_ICON_MAP = {
     "birch": "mdi:tree",
     "cypress_family": "mdi:pine-tree",
     "default": "mdi:flower-pollen",
+    "dock_sorrel": "mdi:leaf",
     "elm": "mdi:tree",
     "grasses": "mdi:grass",
     "hazel": "mdi:nature",
-    "lime": "mdi:leaf",
+    "linden": "mdi:leaf",
     "fungal_spores": "mdi:cloud-alert",
     "mugwort": "mdi:flower-pollen",
     "nettle_family": "mdi:leaf",
     "oak": "mdi:leaf",
     "olive": "mdi:leaf",
     "plane_tree": "mdi:tree",
+    "plantain": "mdi:leaf",
     "ragweed": "mdi:flower-pollen",
     "rye": "mdi:grain",
+    "sweet_chestnut": "mdi:tree",
+    "tree_of_heaven": "mdi:tree",
     "willow": "mdi:tree",
 }
 
 RISK_SLUGS = ("allergy_risk", "allergy_risk_hourly")
 
-KNOWN_ALLERGEN_SLUGS = set(ALLERGEN_ICON_MAP.keys()) - {"default"} | set(RISK_SLUGS)
+KNOWN_ALLERGEN_SLUGS = (
+    set(ALLERGEN_ICON_MAP.keys()) - {"default"}
+    | {slugify(name) for name in LATIN_TO_ENGLISH_NAME.values()}
+    | set(RISK_SLUGS)
+)
 
 
 def capitalize_first(s: str) -> str:
@@ -93,6 +132,35 @@ def extract_allergen_slug_from_unique_id(unique_id: str) -> str | None:
         if unique_id.endswith(suffix):
             return slug
     return None
+
+
+@lru_cache(maxsize=1)
+def _latin_name_index() -> dict[str, str]:
+    """Case-insensitive latin lookup, extended with genus-only keys.
+
+    The API spells a latin name with the genus alone for most allergens but
+    with genus and species for others, and the case is not consistent between
+    languages.
+    """
+    index = {latin.lower(): name for latin, name in LATIN_TO_ENGLISH_NAME.items()}
+    for latin, name in LATIN_TO_ENGLISH_NAME.items():
+        index.setdefault(latin.split()[0].lower(), name)
+    return index
+
+
+def english_name_for_latin(latin: str | None) -> str | None:
+    """Return the English allergen name for a latin name, or None if unknown.
+
+    A latin name that carries a species falls back to its genus, so both
+    "Ambrosia" and "Ambrosia artemisiifolia" resolve.
+    """
+    if not latin:
+        return None
+    index = _latin_name_index()
+    key = latin.strip().lower()
+    if name := index.get(key):
+        return name
+    return index.get(key.split()[0]) if key.split() else None
 
 
 @lru_cache(maxsize=1)
@@ -268,10 +336,15 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 if allergen.get("name") == poll_title_local:
                     latin = allergen.get("latin")
                     break
+        # Resolution order: the static latin map, then the English language
+        # block, then the name the API sent in the configured language. Only
+        # the last of these varies with the language, so it stays a last
+        # resort for an allergen no released map knows about.
         allergen_en_obj = (
             get_allergen_info_by_latin(latin, language_block_en) if latin else None
         )
-        allergen_en = allergen_en_obj["name"] if allergen_en_obj else poll_title_local
+        legacy_en = allergen_en_obj["name"] if allergen_en_obj else poll_title_local
+        allergen_en = english_name_for_latin(latin) or legacy_en
         allergen_la = latin if latin else ""
         slug_en = slugify(allergen_en) if allergen_en else slugify(poll_title_local)
         icon = ALLERGEN_ICON_MAP.get(slug_en, ALLERGEN_ICON_MAP["default"])

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -394,7 +394,16 @@ async def async_setup_entry(hass, entry, async_add_entities):
             get_allergen_info_by_latin(latin, language_block_en) if latin else None
         )
         legacy_en = allergen_en_obj["name"] if allergen_en_obj else poll_title_local
-        allergen_en = english_name_for_latin(latin) or legacy_en
+        mapped_en = english_name_for_latin(latin)
+        if mapped_en is None and allergen_en_obj is None:
+            _LOGGER.warning(
+                "Unknown allergen %r (latin %r); its entity_id will follow the "
+                "configured language. Please report this at "
+                "https://github.com/krissen/polleninformation/issues",
+                poll_title_local,
+                latin or "",
+            )
+        allergen_en = mapped_en or legacy_en
         allergen_la = latin if latin else ""
         slug_en = slugify(allergen_en) if allergen_en else slugify(poll_title_local)
         legacy_slug = slugify(legacy_en) if legacy_en else slug_en

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -487,6 +487,12 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
         }
 
     @property
+    def suggested_object_id(self) -> str:
+        # Pins the object_id to the English slug so the entity_id does not
+        # follow the translated or explicitly set name.
+        return "allergy_risk"
+
+    @property
     def available(self) -> bool:
         return self.coordinator.last_update_success is not False
 
@@ -594,6 +600,12 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
             "name": f"Polleninformation ({location_title})",
             "manufacturer": "Austrian Pollen Information Service",
         }
+
+    @property
+    def suggested_object_id(self) -> str:
+        # Pins the object_id to the English slug so the entity_id does not
+        # follow the translated or explicitly set name.
+        return "allergy_risk_hourly"
 
     @property
     def available(self) -> bool:

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -163,6 +163,55 @@ def english_name_for_latin(latin: str | None) -> str | None:
     return index.get(key.split()[0]) if key.split() else None
 
 
+def migrate_localized_allergen_ids(hass, location_slug, renames) -> None:
+    """Rename allergen ids that were derived from a localized allergen name.
+
+    The renames are (legacy_slug, canonical_slug) pairs derived from the
+    current API response, so only ids this integration can itself have
+    produced are ever considered. Both the unique_id and the entity_id are
+    migrated; either is skipped with a warning when the target is taken.
+    """
+    if not renames:
+        return
+
+    ent_reg = er.async_get(hass)
+    for legacy_slug, canonical_slug in renames:
+        legacy_unique_id = f"polleninformation_{location_slug}_{legacy_slug}"
+        entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, legacy_unique_id)
+        if entity_id is None:
+            continue
+
+        canonical_unique_id = f"polleninformation_{location_slug}_{canonical_slug}"
+        if ent_reg.async_get_entity_id("sensor", DOMAIN, canonical_unique_id):
+            _LOGGER.warning(
+                "Not migrating %s: an entity with unique_id %s already exists",
+                entity_id,
+                canonical_unique_id,
+            )
+            continue
+
+        updates: dict[str, str] = {"new_unique_id": canonical_unique_id}
+        object_id = entity_id.split(".", 1)[1]
+        if object_id.endswith(f"_{legacy_slug}"):
+            new_entity_id = f"sensor.{object_id[: -len(legacy_slug)]}{canonical_slug}"
+            if ent_reg.async_get(new_entity_id) is not None:
+                _LOGGER.warning(
+                    "Keeping entity_id %s: %s is already taken",
+                    entity_id,
+                    new_entity_id,
+                )
+            else:
+                updates["new_entity_id"] = new_entity_id
+
+        _LOGGER.info(
+            "Migrating localized allergen sensor %s (%s) to %s",
+            entity_id,
+            legacy_slug,
+            canonical_slug,
+        )
+        ent_reg.async_update_entity(entity_id, **updates)
+
+
 @lru_cache(maxsize=1)
 def localized_risk_object_id_suffixes() -> dict[str, frozenset[str]]:
     """Return the localized object_id suffixes the risk sensors can have produced.
@@ -324,6 +373,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     entities: list[SensorEntity] = []
     new_unique_ids: set[str] = set()
+    allergen_renames: list[tuple[str, str]] = []
 
     for item in contamination:
         poll_title_full = item.get("poll_title", "<unknown>")
@@ -347,6 +397,9 @@ async def async_setup_entry(hass, entry, async_add_entities):
         allergen_en = english_name_for_latin(latin) or legacy_en
         allergen_la = latin if latin else ""
         slug_en = slugify(allergen_en) if allergen_en else slugify(poll_title_local)
+        legacy_slug = slugify(legacy_en) if legacy_en else slug_en
+        if legacy_slug and legacy_slug != slug_en:
+            allergen_renames.append((legacy_slug, slug_en))
         icon = ALLERGEN_ICON_MAP.get(slug_en, ALLERGEN_ICON_MAP["default"])
 
         sensor = PolleninformationSensor(
@@ -366,6 +419,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
         entities.append(sensor)
         if sensor.unique_id:
             new_unique_ids.add(sensor.unique_id)
+
+    migrate_localized_allergen_ids(hass, location_slug, allergen_renames)
 
     # Allergy risk daily sensor - only if contamination has data (otherwise allergyrisk is meaningless)
     allergyrisk = (

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,5 +1,6 @@
 """Tests for sensor helper functions and sensor classes."""
 
+import logging
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
@@ -1157,3 +1158,41 @@ class TestCanonicalSlugSet:
 
     def test_risk_slugs(self):
         assert set(RISK_SLUGS) == {"allergy_risk", "allergy_risk_hourly"}
+
+
+class TestTranslationFileReadFailure:
+    """A broken translation file must not hide why it was skipped."""
+
+    def test_debug_log_carries_the_exception(self, caplog):
+        localized_risk_object_id_suffixes.cache_clear()
+        try:
+            with (
+                caplog.at_level(logging.DEBUG),
+                patch(
+                    "custom_components.polleninformation.sensor.Path.read_text",
+                    side_effect=OSError("boom"),
+                ),
+            ):
+                localized_risk_object_id_suffixes()
+            records = [
+                r
+                for r in caplog.records
+                if "Could not read translation file" in r.getMessage()
+            ]
+            assert records
+            assert all(r.exc_info for r in records)
+        finally:
+            localized_risk_object_id_suffixes.cache_clear()
+
+    def test_names_survive_from_the_static_map(self):
+        """RISK_SENSOR_NAMES still supplies candidates without the files."""
+        localized_risk_object_id_suffixes.cache_clear()
+        try:
+            with patch(
+                "custom_components.polleninformation.sensor.Path.read_text",
+                side_effect=OSError("boom"),
+            ):
+                suffixes = localized_risk_object_id_suffixes()
+            assert "allergierisiko" in suffixes["allergy_risk"]
+        finally:
+            localized_risk_object_id_suffixes.cache_clear()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1014,3 +1014,81 @@ class TestMigrateLocalizedAllergenIds:
             )
             == "sensor.polleninformation_hamburg_ash"
         )
+
+
+UNKNOWN_ALLERGEN_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Kiefer (Pinus)",
+            "contamination_1": 1,
+            "contamination_2": 0,
+            "contamination_3": 0,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+
+class TestUnknownAllergenFallback:
+    """An allergen no map knows about still gets a sensor, plus a warning."""
+
+    async def _setup(self, hass):
+        return await _setup_entities(
+            hass,
+            "de",
+            response=UNKNOWN_ALLERGEN_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+
+    async def test_falls_back_to_the_localized_name(self, hass):
+        entities = await self._setup(hass)
+        unique_ids = {e.unique_id for e in entities}
+        assert "polleninformation_hamburg_kiefer" in unique_ids
+
+    async def test_warns_once_with_the_latin_name(self, hass, caplog):
+        await self._setup(hass)
+        warnings = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelname == "WARNING" and "Unknown allergen" in r.getMessage()
+        ]
+        assert len(warnings) == 1
+        assert "Kiefer" in warnings[0]
+        assert "Pinus" in warnings[0]
+
+    async def test_no_warning_for_a_mapped_allergen(self, hass, caplog):
+        await _setup_entities(
+            hass,
+            "de",
+            response=GERMAN_TREE_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        assert not [r for r in caplog.records if "Unknown allergen" in r.getMessage()]
+
+    async def test_no_migration_for_an_unknown_allergen(self, hass):
+        """Nothing to rename: the fallback slug is the only one we ever had."""
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_kiefer",
+            suggested_object_id="polleninformation_hamburg_kiefer",
+            config_entry=entry,
+        )
+        await _setup_entities(
+            hass,
+            "de",
+            entry=entry,
+            response=UNKNOWN_ALLERGEN_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_kiefer"
+            )
+            == "sensor.polleninformation_hamburg_kiefer"
+        )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -16,6 +16,7 @@ from custom_components.polleninformation.sensor import (
     async_setup_entry,
     capitalize_first,
     extract_allergen_slug_from_unique_id,
+    localized_risk_object_id_suffixes,
     pollen_forecast_for_allergen,
     scale_allergy_risk,
 )
@@ -430,10 +431,11 @@ def _make_entry(lang, options=None):
     )
 
 
-async def _setup_entities(hass, lang, options=None):
+async def _setup_entities(hass, lang, options=None, entry=None):
     """Run sensor setup for a Ragweed-only response and return the entities."""
-    entry = _make_entry(lang, options)
-    entry.add_to_hass(hass)
+    if entry is None:
+        entry = _make_entry(lang, options)
+        entry.add_to_hass(hass)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _make_coordinator(
         RAGWEED_RESPONSE
     )
@@ -574,4 +576,129 @@ class TestRiskSensorEntityIdCreation:
         assert (
             ent_reg.async_get_entity_id("sensor", DOMAIN, HOURLY_UNIQUE_ID)
             == "sensor.polleninformation_hamburg_allergy_risk_hourly"
+        )
+
+
+class TestLocalizedRiskObjectIdSuffixes:
+    def test_translated_names_are_candidates(self):
+        suffixes = localized_risk_object_id_suffixes()
+        assert "allergierisiko" in suffixes["allergy_risk"]
+        assert "allergirisk" in suffixes["allergy_risk"]
+        assert "allergierisiko_stundlich" in suffixes["allergy_risk_hourly"]
+
+    def test_canonical_slug_is_not_a_candidate(self):
+        suffixes = localized_risk_object_id_suffixes()
+        assert "allergy_risk" not in suffixes["allergy_risk"]
+        assert "allergy_risk_hourly" not in suffixes["allergy_risk_hourly"]
+
+
+class TestMigrateLocalizedRiskEntityIds:
+    """Entity_ids created from a translated name are renamed back (issue #63)."""
+
+    def _seed(self, hass, entry, unique_id, object_id):
+        ent_reg = er.async_get(hass)
+        return ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            unique_id,
+            suggested_object_id=object_id,
+            config_entry=entry,
+        ).entity_id
+
+    async def _run(self, hass, seeds, lang="de", options=None):
+        entry = _make_entry(lang, options)
+        entry.add_to_hass(hass)
+        for unique_id, object_id in seeds:
+            self._seed(hass, entry, unique_id, object_id)
+        await _setup_entities(hass, lang, entry=entry)
+        return er.async_get(hass)
+
+    async def test_localized_ids_are_renamed(self, hass):
+        ent_reg = await self._run(
+            hass,
+            [
+                (DAILY_UNIQUE_ID, "polleninformation_hamburg_allergierisiko"),
+                (
+                    HOURLY_UNIQUE_ID,
+                    "polleninformation_hamburg_allergierisiko_stundlich",
+                ),
+            ],
+        )
+        assert (
+            ent_reg.async_get_entity_id("sensor", DOMAIN, DAILY_UNIQUE_ID)
+            == "sensor.polleninformation_hamburg_allergy_risk"
+        )
+        assert (
+            ent_reg.async_get_entity_id("sensor", DOMAIN, HOURLY_UNIQUE_ID)
+            == "sensor.polleninformation_hamburg_allergy_risk_hourly"
+        )
+
+    async def test_swedish_id_is_renamed(self, hass):
+        ent_reg = await self._run(
+            hass,
+            [(DAILY_UNIQUE_ID, "polleninformation_hamburg_allergirisk")],
+            lang="sv",
+        )
+        assert (
+            ent_reg.async_get_entity_id("sensor", DOMAIN, DAILY_UNIQUE_ID)
+            == "sensor.polleninformation_hamburg_allergy_risk"
+        )
+
+    async def test_canonical_id_is_left_alone(self, hass):
+        ent_reg = await self._run(
+            hass, [(DAILY_UNIQUE_ID, "polleninformation_hamburg_allergy_risk")]
+        )
+        assert (
+            ent_reg.async_get_entity_id("sensor", DOMAIN, DAILY_UNIQUE_ID)
+            == "sensor.polleninformation_hamburg_allergy_risk"
+        )
+
+    async def test_user_chosen_id_is_left_alone(self, hass):
+        """A rename the user made themselves does not match a translation."""
+        ent_reg = await self._run(
+            hass, [(DAILY_UNIQUE_ID, "pollen_hamburg_my_own_name")]
+        )
+        assert (
+            ent_reg.async_get_entity_id("sensor", DOMAIN, DAILY_UNIQUE_ID)
+            == "sensor.pollen_hamburg_my_own_name"
+        )
+
+    async def test_pollen_sensor_is_left_alone(self, hass):
+        """Only the two risk sensors are in scope."""
+        ent_reg = await self._run(
+            hass, [("polleninformation_hamburg_ragweed", "polleninformation_ambrosia")]
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_ragweed"
+            )
+            == "sensor.polleninformation_ambrosia"
+        )
+
+    async def test_collision_is_skipped(self, hass):
+        """An occupied target entity_id must not raise or steal the id."""
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            "other_integration",
+            "other_unique_id",
+            suggested_object_id="polleninformation_hamburg_allergy_risk",
+        )
+        self._seed(
+            hass, entry, DAILY_UNIQUE_ID, "polleninformation_hamburg_allergierisiko"
+        )
+
+        await _setup_entities(hass, "de", entry=entry)
+
+        assert (
+            ent_reg.async_get_entity_id("sensor", DOMAIN, DAILY_UNIQUE_ID)
+            == "sensor.polleninformation_hamburg_allergierisiko"
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", "other_integration", "other_unique_id"
+            )
+            == "sensor.polleninformation_hamburg_allergy_risk"
         )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1196,3 +1196,102 @@ class TestTranslationFileReadFailure:
             assert "allergierisiko" in suffixes["allergy_risk"]
         finally:
             localized_risk_object_id_suffixes.cache_clear()
+
+
+class TestOnlyGeneratedEntityIdsAreRenamed:
+    """A suffix match is not enough: the entity_id must be the generated one.
+
+    A user-chosen entity_id can end in the old slug without this integration
+    ever having produced it, and renaming it would be a rename the user did
+    not ask for.
+    """
+
+    def _seed(self, hass, entry, unique_id, object_id):
+        return er.async_get(hass).async_get_or_create(
+            "sensor",
+            DOMAIN,
+            unique_id,
+            suggested_object_id=object_id,
+            config_entry=entry,
+        )
+
+    async def test_allergen_entity_id_with_a_different_prefix_is_kept(self, hass):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        # Ends with "_esche", but the prefix is not ours.
+        self._seed(
+            hass, entry, "polleninformation_hamburg_esche", "pollen_hamburg_esche"
+        )
+
+        await _setup_entities(
+            hass,
+            "de",
+            entry=entry,
+            response=GERMAN_TREE_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+
+        ent_reg = er.async_get(hass)
+        # The unique_id is still corrected; only the entity_id is left alone.
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_ash"
+            )
+            == "sensor.pollen_hamburg_esche"
+        )
+
+    async def test_allergen_entity_id_for_another_location_is_kept(self, hass):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        self._seed(
+            hass,
+            entry,
+            "polleninformation_hamburg_esche",
+            "polleninformation_bremen_esche",
+        )
+
+        await _setup_entities(
+            hass,
+            "de",
+            entry=entry,
+            response=GERMAN_TREE_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+
+        ent_reg = er.async_get(hass)
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_ash"
+            )
+            == "sensor.polleninformation_bremen_esche"
+        )
+
+    async def test_risk_entity_id_with_a_different_prefix_is_kept(self, hass):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        # Ends with the German translation, but we never generated it.
+        self._seed(hass, entry, DAILY_UNIQUE_ID, "my_own_allergierisiko")
+
+        await _setup_entities(hass, "de", entry=entry)
+
+        ent_reg = er.async_get(hass)
+        assert (
+            ent_reg.async_get_entity_id("sensor", DOMAIN, DAILY_UNIQUE_ID)
+            == "sensor.my_own_allergierisiko"
+        )
+
+    async def test_generated_risk_entity_id_is_still_renamed(self, hass):
+        """The strictness must not stop the migration it exists for."""
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        self._seed(
+            hass, entry, DAILY_UNIQUE_ID, "polleninformation_hamburg_allergierisiko"
+        )
+
+        await _setup_entities(hass, "de", entry=entry)
+
+        ent_reg = er.async_get(hass)
+        assert (
+            ent_reg.async_get_entity_id("sensor", DOMAIN, DAILY_UNIQUE_ID)
+            == "sensor.polleninformation_hamburg_allergy_risk"
+        )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -10,16 +10,20 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.polleninformation.const import DOMAIN
 from custom_components.polleninformation.sensor import (
+    ALLERGEN_ICON_MAP,
+    LATIN_TO_ENGLISH_NAME,
     AllergyRiskHourlySensor,
     AllergyRiskSensor,
     PolleninformationSensor,
     async_setup_entry,
     capitalize_first,
+    english_name_for_latin,
     extract_allergen_slug_from_unique_id,
     localized_risk_object_id_suffixes,
     pollen_forecast_for_allergen,
     scale_allergy_risk,
 )
+from custom_components.polleninformation.utils import slugify
 
 
 # --- Helper function tests (pure, no HA dependency) ---
@@ -431,13 +435,15 @@ def _make_entry(lang, options=None):
     )
 
 
-async def _setup_entities(hass, lang, options=None, entry=None):
+async def _setup_entities(
+    hass, lang, options=None, entry=None, response=None, language_block=None
+):
     """Run sensor setup for a Ragweed-only response and return the entities."""
     if entry is None:
         entry = _make_entry(lang, options)
         entry.add_to_hass(hass)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _make_coordinator(
-        RAGWEED_RESPONSE
+        RAGWEED_RESPONSE if response is None else response
     )
 
     entities = []
@@ -447,7 +453,11 @@ async def _setup_entities(hass, lang, options=None, entry=None):
 
     with patch(
         "custom_components.polleninformation.sensor.async_get_language_block",
-        AsyncMock(return_value=RAGWEED_LANGUAGE_BLOCK),
+        AsyncMock(
+            return_value=RAGWEED_LANGUAGE_BLOCK
+            if language_block is None
+            else language_block
+        ),
     ):
         await async_setup_entry(hass, entry, _add)
     return entities
@@ -702,3 +712,154 @@ class TestMigrateLocalizedRiskEntityIds:
             )
             == "sensor.polleninformation_hamburg_allergy_risk"
         )
+
+
+# --- Allergen slugs come from the latin name, not the localized name ---
+
+
+# Latin name and English name for every allergen the API returns, sampled from
+# the live API for AT, SE, DE and IT with lang=en.
+API_LATIN_NAMES = {
+    "Ailanthus altissima": "tree of heaven",
+    "Alnus": "alder",
+    "Alternaria": "fungal spores",
+    "Ambrosia": "ragweed",
+    "Artemisia": "mugwort",
+    "Betula": "birch",
+    "Castanea": "sweet chestnut",
+    "Corylus": "hazel",
+    "Cupressaceae": "cypress family",
+    "Fagus": "beech",
+    "Fraxinus": "ash",
+    "Olea": "olive",
+    "Plantago": "plantain",
+    "Platanus": "plane tree",
+    "Poaceae": "grasses",
+    "Quercus": "oak",
+    "Rumex": "dock/sorrel",
+    "Salix": "willow",
+    "Secale": "rye",
+    "Tilia": "linden",
+    "Ulmus": "elm",
+    "Urticaceae": "nettle family",
+}
+
+# German response for the allergens that language_map.json does not cover, so
+# the pre-fix code fell back to the German name for the slug.
+GERMAN_TREE_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Esche (Fraxinus)",
+            "contamination_1": 2,
+            "contamination_2": 1,
+            "contamination_3": 0,
+            "contamination_4": 0,
+        },
+        {
+            "poll_title": "Götterbaum (Ailanthus altissima)",
+            "contamination_1": 1,
+            "contamination_2": 1,
+            "contamination_3": 0,
+            "contamination_4": 0,
+        },
+    ],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+# language_map.json has no entry for these, which is what the fix works around.
+EMPTY_LANGUAGE_BLOCK = {"poll_titles": []}
+
+
+class TestEnglishNameForLatin:
+    def test_exact(self):
+        assert english_name_for_latin("Fraxinus") == "ash"
+
+    def test_case_insensitive(self):
+        assert english_name_for_latin("fraxinus") == "ash"
+
+    def test_surrounding_whitespace(self):
+        assert english_name_for_latin("  Tilia ") == "linden"
+
+    def test_genus_and_species_falls_back_to_genus(self):
+        assert english_name_for_latin("Ambrosia artemisiifolia") == "ragweed"
+
+    def test_genus_only_for_a_species_keyed_entry(self):
+        assert english_name_for_latin("Ailanthus") == "tree of heaven"
+
+    def test_unknown(self):
+        assert english_name_for_latin("Pinus") is None
+
+    def test_empty(self):
+        assert english_name_for_latin("") is None
+
+    def test_whitespace_only(self):
+        assert english_name_for_latin("   ") is None
+
+    def test_none(self):
+        assert english_name_for_latin(None) is None
+
+
+class TestLatinMapCoverage:
+    def test_every_api_latin_name_is_mapped(self):
+        assert LATIN_TO_ENGLISH_NAME == API_LATIN_NAMES
+
+    @pytest.mark.parametrize(("latin", "name"), sorted(API_LATIN_NAMES.items()))
+    def test_every_allergen_has_an_icon(self, latin, name):
+        """A missing icon silently degrades to the generic pollen icon."""
+        assert slugify(name) in ALLERGEN_ICON_MAP
+
+    def test_slugs_are_distinct(self):
+        slugs = [slugify(name) for name in LATIN_TO_ENGLISH_NAME.values()]
+        assert len(slugs) == len(set(slugs))
+
+
+class TestAllergenSlugFromLatin:
+    async def test_slug_is_english_for_german_response(self, hass):
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=GERMAN_TREE_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        unique_ids = {e.unique_id for e in entities}
+        assert "polleninformation_hamburg_ash" in unique_ids
+        assert "polleninformation_hamburg_tree_of_heaven" in unique_ids
+
+    async def test_display_name_stays_localized(self, hass):
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=GERMAN_TREE_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        names = {e.name for e in entities if isinstance(e, PolleninformationSensor)}
+        assert "Esche" in names
+
+    async def test_english_name_attribute_and_icon(self, hass):
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=GERMAN_TREE_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        ash = next(
+            e for e in entities if e.unique_id == "polleninformation_hamburg_ash"
+        )
+        assert ash.extra_state_attributes["name_en"] == "ash"
+        assert ash.extra_state_attributes["allergen_slug"] == "ash"
+        assert ash.icon == "mdi:tree"
+
+    async def test_state_still_resolves(self, hass):
+        """The value lookup matches on the name the API sent, not the slug."""
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=GERMAN_TREE_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        ash = next(
+            e for e in entities if e.unique_id == "polleninformation_hamburg_ash"
+        )
+        # German levels, because the entry is configured for German.
+        assert ash.native_value == "mäßig"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -863,3 +863,154 @@ class TestAllergenSlugFromLatin:
         )
         # German levels, because the entry is configured for German.
         assert ash.native_value == "mäßig"
+
+
+class TestMigrateLocalizedAllergenIds:
+    """Localized allergen unique_ids and entity_ids are renamed (issue #63)."""
+
+    def _seed(self, hass, entry, unique_id, object_id):
+        return er.async_get(hass).async_get_or_create(
+            "sensor",
+            DOMAIN,
+            unique_id,
+            suggested_object_id=object_id,
+            config_entry=entry,
+        )
+
+    async def _run(self, hass, seeds):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        for unique_id, object_id in seeds:
+            self._seed(hass, entry, unique_id, object_id)
+        await _setup_entities(
+            hass,
+            "de",
+            entry=entry,
+            response=GERMAN_TREE_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        return er.async_get(hass)
+
+    async def test_unique_id_and_entity_id_are_renamed(self, hass):
+        ent_reg = await self._run(
+            hass,
+            [
+                ("polleninformation_hamburg_esche", "polleninformation_hamburg_esche"),
+                (
+                    "polleninformation_hamburg_gotterbaum",
+                    "polleninformation_hamburg_gotterbaum",
+                ),
+            ],
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_ash"
+            )
+            == "sensor.polleninformation_hamburg_ash"
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_tree_of_heaven"
+            )
+            == "sensor.polleninformation_hamburg_tree_of_heaven"
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_esche"
+            )
+            is None
+        )
+
+    async def test_user_renamed_entity_id_is_kept(self, hass):
+        """The unique_id is still fixed, but a chosen entity_id is not touched."""
+        ent_reg = await self._run(
+            hass, [("polleninformation_hamburg_esche", "pollen_ash_tree")]
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_ash"
+            )
+            == "sensor.pollen_ash_tree"
+        )
+
+    async def test_canonical_id_is_untouched(self, hass):
+        """An English installation already has the canonical ids."""
+        ent_reg = await self._run(
+            hass, [("polleninformation_hamburg_ash", "polleninformation_hamburg_ash")]
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_ash"
+            )
+            == "sensor.polleninformation_hamburg_ash"
+        )
+
+    async def test_unrelated_entity_is_untouched(self, hass):
+        ent_reg = await self._run(
+            hass, [("polleninformation_hamburg_birch", "polleninformation_birke")]
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_birch"
+            )
+            == "sensor.polleninformation_birke"
+        )
+
+    async def test_taken_unique_id_is_skipped(self, hass):
+        ent_reg = await self._run(
+            hass,
+            [
+                ("polleninformation_hamburg_esche", "polleninformation_hamburg_esche"),
+                ("polleninformation_hamburg_ash", "polleninformation_hamburg_ash"),
+            ],
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_esche"
+            )
+            == "sensor.polleninformation_hamburg_esche"
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_ash"
+            )
+            == "sensor.polleninformation_hamburg_ash"
+        )
+
+    async def test_taken_entity_id_keeps_entity_id_but_fixes_unique_id(self, hass):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            "other_integration",
+            "other_unique_id",
+            suggested_object_id="polleninformation_hamburg_ash",
+        )
+        self._seed(
+            hass,
+            entry,
+            "polleninformation_hamburg_esche",
+            "polleninformation_hamburg_esche",
+        )
+
+        await _setup_entities(
+            hass,
+            "de",
+            entry=entry,
+            response=GERMAN_TREE_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_ash"
+            )
+            == "sensor.polleninformation_hamburg_esche"
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", "other_integration", "other_unique_id"
+            )
+            == "sensor.polleninformation_hamburg_ash"
+        )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -21,6 +21,7 @@ from custom_components.polleninformation.sensor import (
     async_setup_entry,
     capitalize_first,
     english_name_for_latin,
+    entity_id_available,
     extract_allergen_slug_from_unique_id,
     localized_risk_object_id_suffixes,
     pollen_forecast_for_allergen,
@@ -1294,4 +1295,78 @@ class TestOnlyGeneratedEntityIdsAreRenamed:
         assert (
             ent_reg.async_get_entity_id("sensor", DOMAIN, DAILY_UNIQUE_ID)
             == "sensor.polleninformation_hamburg_allergy_risk"
+        )
+
+
+class TestStateMachineCollision:
+    """A YAML or template entity holds an entity_id without a registry entry.
+
+    The registry refuses to move an entity_id onto one that is occupied in the
+    state machine, so a registry-only check let async_update_entity raise and
+    abort setup.
+    """
+
+    def _seed(self, hass, entry, unique_id, object_id):
+        return er.async_get(hass).async_get_or_create(
+            "sensor",
+            DOMAIN,
+            unique_id,
+            suggested_object_id=object_id,
+            config_entry=entry,
+        )
+
+    def test_availability_sees_the_state_machine(self, hass):
+        ent_reg = er.async_get(hass)
+        hass.states.async_set("sensor.polleninformation_hamburg_ash", "low")
+        assert not entity_id_available(
+            hass, ent_reg, "sensor.polleninformation_hamburg_ash"
+        )
+        assert entity_id_available(
+            hass, ent_reg, "sensor.polleninformation_hamburg_birch"
+        )
+
+    async def test_allergen_setup_survives_a_state_only_collision(self, hass):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        self._seed(
+            hass,
+            entry,
+            "polleninformation_hamburg_esche",
+            "polleninformation_hamburg_esche",
+        )
+        hass.states.async_set("sensor.polleninformation_hamburg_ash", "low")
+
+        # Must not raise.
+        await _setup_entities(
+            hass,
+            "de",
+            entry=entry,
+            response=GERMAN_TREE_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+
+        ent_reg = er.async_get(hass)
+        # unique_id corrected, entity_id kept because the target is occupied.
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_ash"
+            )
+            == "sensor.polleninformation_hamburg_esche"
+        )
+
+    async def test_risk_setup_survives_a_state_only_collision(self, hass):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        self._seed(
+            hass, entry, DAILY_UNIQUE_ID, "polleninformation_hamburg_allergierisiko"
+        )
+        hass.states.async_set("sensor.polleninformation_hamburg_allergy_risk", "low")
+
+        # Must not raise.
+        await _setup_entities(hass, "de", entry=entry)
+
+        ent_reg = er.async_get(hass)
+        assert (
+            ent_reg.async_get_entity_id("sensor", DOMAIN, DAILY_UNIQUE_ID)
+            == "sensor.polleninformation_hamburg_allergierisiko"
         )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -11,7 +11,9 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.polleninformation.const import DOMAIN
 from custom_components.polleninformation.sensor import (
     ALLERGEN_ICON_MAP,
+    KNOWN_ALLERGEN_SLUGS,
     LATIN_TO_ENGLISH_NAME,
+    RISK_SLUGS,
     AllergyRiskHourlySensor,
     AllergyRiskSensor,
     PolleninformationSensor,
@@ -1092,3 +1094,66 @@ class TestUnknownAllergenFallback:
             )
             == "sensor.polleninformation_hamburg_kiefer"
         )
+
+
+# The canonical slug for every allergen, pinned. These slugs are a public
+# contract: they are the entity_id suffix, they are in every unique_id, and
+# the pollen forecast card matches on them. A change to an API display name or
+# to slugify() must fail here rather than silently rename entities.
+CANONICAL_ALLERGEN_SLUGS = {
+    "Ailanthus altissima": "tree_of_heaven",
+    "Alnus": "alder",
+    "Alternaria": "fungal_spores",
+    "Ambrosia": "ragweed",
+    "Artemisia": "mugwort",
+    "Betula": "birch",
+    "Castanea": "sweet_chestnut",
+    "Corylus": "hazel",
+    "Cupressaceae": "cypress_family",
+    "Fagus": "beech",
+    "Fraxinus": "ash",
+    "Olea": "olive",
+    "Plantago": "plantain",
+    "Platanus": "plane_tree",
+    "Poaceae": "grasses",
+    "Quercus": "oak",
+    "Rumex": "dock_sorrel",
+    "Salix": "willow",
+    "Secale": "rye",
+    "Tilia": "linden",
+    "Ulmus": "elm",
+    "Urticaceae": "nettle_family",
+}
+
+EXPECTED_KNOWN_SLUGS = frozenset(CANONICAL_ALLERGEN_SLUGS.values()) | {
+    "allergy_risk",
+    "allergy_risk_hourly",
+}
+
+
+class TestCanonicalSlugSet:
+    """Pins the slug set so a rename cannot happen unnoticed."""
+
+    def test_known_allergen_slugs(self):
+        assert KNOWN_ALLERGEN_SLUGS == EXPECTED_KNOWN_SLUGS
+
+    def test_slugs_from_the_latin_map(self):
+        """A set comparison, so two allergens collapsing onto one slug fails."""
+        assert {slugify(name) for name in LATIN_TO_ENGLISH_NAME.values()} == set(
+            CANONICAL_ALLERGEN_SLUGS.values()
+        )
+
+    @pytest.mark.parametrize(
+        ("latin", "slug"), sorted(CANONICAL_ALLERGEN_SLUGS.items())
+    )
+    def test_slug_per_latin_name(self, latin, slug):
+        assert slugify(english_name_for_latin(latin)) == slug
+
+    def test_icon_map_covers_exactly_the_canonical_slugs(self):
+        """An icon for a slug that cannot occur is as wrong as a missing one."""
+        assert set(ALLERGEN_ICON_MAP) - {"default"} == set(
+            CANONICAL_ALLERGEN_SLUGS.values()
+        )
+
+    def test_risk_slugs(self):
+        assert set(RISK_SLUGS) == {"allergy_risk", "allergy_risk_hourly"}

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
 
 import pytest
+from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.polleninformation.const import DOMAIN
@@ -412,9 +413,8 @@ RAGWEED_LANGUAGE_BLOCK = {
 }
 
 
-async def _setup_entities(hass, lang, options=None):
-    """Run sensor setup for a Ragweed-only response and return the entities."""
-    entry = MockConfigEntry(
+def _make_entry(lang, options=None):
+    return MockConfigEntry(
         domain=DOMAIN,
         title="Hamburg",
         data={
@@ -428,6 +428,11 @@ async def _setup_entities(hass, lang, options=None):
         },
         options=options or {},
     )
+
+
+async def _setup_entities(hass, lang, options=None):
+    """Run sensor setup for a Ragweed-only response and return the entities."""
+    entry = _make_entry(lang, options)
     entry.add_to_hass(hass)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _make_coordinator(
         RAGWEED_RESPONSE
@@ -489,3 +494,84 @@ class TestSetupEntryNaming:
             hass, "xx", options={"names_in_integration_language": True}
         )
         assert _by_type(entities, AllergyRiskSensor).name == "Allergy risk"
+
+
+# --- entity_id stability for the risk sensors (issue #63) ---
+
+
+DAILY_UNIQUE_ID = "polleninformation_hamburg_allergy_risk"
+HOURLY_UNIQUE_ID = "polleninformation_hamburg_allergy_risk_hourly"
+
+
+class TestRiskSensorSuggestedObjectId:
+    """The object_id must stay English regardless of the displayed name."""
+
+    def _kwargs(self):
+        return {
+            "coordinator": _make_coordinator(None),
+            "levels_current": ["none", "low", "moderate", "high", "very high"],
+            "location_slug": "hamburg",
+            "location_title": "Hamburg",
+        }
+
+    def test_daily(self):
+        sensor = AllergyRiskSensor(**self._kwargs())
+        assert sensor.suggested_object_id == "allergy_risk"
+
+    def test_hourly(self):
+        sensor = AllergyRiskHourlySensor(**self._kwargs())
+        assert sensor.suggested_object_id == "allergy_risk_hourly"
+
+    def test_daily_with_explicit_name(self):
+        sensor = AllergyRiskSensor(name="Allergierisiko", **self._kwargs())
+        assert sensor.suggested_object_id == "allergy_risk"
+
+    def test_hourly_with_explicit_name(self):
+        sensor = AllergyRiskHourlySensor(
+            name="Allergierisiko (stündlich)", **self._kwargs()
+        )
+        assert sensor.suggested_object_id == "allergy_risk_hourly"
+
+    async def test_setup_entry_keeps_object_id(self, hass):
+        """Also with the integration-language option, which sets a name."""
+        entities = await _setup_entities(
+            hass, "de", options={"names_in_integration_language": True}
+        )
+        assert _by_type(entities, AllergyRiskSensor).suggested_object_id == (
+            "allergy_risk"
+        )
+        assert _by_type(entities, AllergyRiskHourlySensor).suggested_object_id == (
+            "allergy_risk_hourly"
+        )
+
+
+class TestRiskSensorEntityIdCreation:
+    """Newly created risk sensors get English entity_ids in a localized HA."""
+
+    @pytest.mark.parametrize("language", ["en", "de"])
+    @patch(
+        "custom_components.polleninformation.async_get_pollenat_data",
+        new_callable=AsyncMock,
+    )
+    async def test_entity_ids(self, mock_api, hass, language):
+        mock_api.return_value = RAGWEED_RESPONSE
+        hass.config.language = language
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+
+        with patch(
+            "custom_components.polleninformation.sensor.async_get_language_block",
+            AsyncMock(return_value=RAGWEED_LANGUAGE_BLOCK),
+        ):
+            await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+        ent_reg = er.async_get(hass)
+        assert (
+            ent_reg.async_get_entity_id("sensor", DOMAIN, DAILY_UNIQUE_ID)
+            == "sensor.polleninformation_hamburg_allergy_risk"
+        )
+        assert (
+            ent_reg.async_get_entity_id("sensor", DOMAIN, HOURLY_UNIQUE_ID)
+            == "sensor.polleninformation_hamburg_allergy_risk_hourly"
+        )


### PR DESCRIPTION
Fixes #63.

## Problem

Two related defects made entity_ids depend on language settings, breaking pollenprognos-card and badge matching:

1. **Regression in 0.5.2** (#63): switching the allergy risk sensors to translation keys made Home Assistant derive their entity_ids from the *translated* name at first creation. Fresh installs on a non-English server got e.g. `sensor.polleninformation_<loc>_allergierisiko` instead of `..._allergy_risk`. Upgrades were unaffected (registry keeps existing ids), which is why this slipped through testing.
2. **Pre-existing gap**: `language_map.json` only covers 12 allergens, while the API currently returns up to 18. Allergens missing from the English block fell back to a slug derived from the localized API name (`_esche`, `_ampfer`, `_linde`, …), so allergen entity_ids and unique_ids varied with the integration language.

## Fix

- Both risk sensor classes now override `suggested_object_id` with the English slug (same mechanism `PolleninformationSensor` has used since 0.4.0), decoupling entity_ids from the UI language while friendly names keep following it.
- New `LATIN_TO_ENGLISH_NAME` map (verified against the live API with `lang=en`) is the authoritative source for allergen slugs and the `name_en` attribute. Unknown allergens fall back as before, now with a warning log. This also corrects Tilia, which was listed as `lime` although the API only ever produces `linden`.
- Icons added for the four allergens new to the map: dock/sorrel, plantain, sweet chestnut, tree of heaven.

## Migration

On setup the integration renames registry entries created with localized ids:

- Risk sensors: entity_id is renamed when its suffix matches a slugified translation of the sensor name (from `translations/*.json` + `RISK_SENSOR_NAMES`). User-customized entity_ids never match and are left alone; collisions are skipped with a warning.
- Allergens: rename pairs are computed from the coordinator's own API response (old localized slug vs canonical slug), updating **both unique_id and entity_id** so no orphans or duplicates are created. Only ids the integration itself generated can match.

**Note for existing installs:** integrations configured with a non-English language will see their affected allergen entity_ids renamed once (e.g. `_esche` → `_ash`); automations referencing the old ids need updating. This is deliberate — the localized ids were never matched by pollenprognos-card and diverged between languages.

## Tests

73 new tests (121 → 194): regression tests for object_id pinning, migration rename/no-touch/collision cases, and a contract test pinning the full canonical slug set so any drift in API strings or slugify behavior fails loudly instead of silently renaming entities. Verified end-to-end in a live HA instance (German and Swedish server language): migrations applied exactly as expected, fresh entries get English slugs, logs clean.