### PR TITLE
Distinct allergen icons grouped by pollen source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@
   photography set and looked like nothing in particular at sensor size
   (thanks @zeus86).
 
+- **Distinct icons per pollen source** — the allergens went from 9 to 13
+  distinct icons, so a list of sensors can be scanned at a glance. Catkin
+  trees, broadleaf trees, evergreens, grasses, cereals, weeds, herbs and fungal
+  spores are now told apart, and several allergens got an icon of their own:
+  hazel a hop cone for its catkins, plane tree a maple-like leaf, ragweed a
+  poppy, sorrel a sprout, mugwort a flower, and fungal spores a mushroom in
+  place of a warning cloud. Mugwort also no longer shares its icon with the
+  fallback used for an unrecognized allergen. The icons that are still shared
+  are shared on purpose — Material Design Icons has no species-specific plant
+  icons, and a shared icon beats one that depicts the wrong plant.
+
 ## v0.5.3 — English entity IDs in every language (2026-08-05)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.5.4 — Allergen icons (2026-08-05)
+## v0.5.4 — Allergen icons (2026-08-12)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.5.4 — Allergen icons (2026-08-05)
+
+### Bug fixes
+
+- **Rye now uses the barley icon** — `mdi:barley` reads as a cereal ear, where
+  the previous `mdi:grain` is a film-grain icon from Material Design Icons'
+  photography set and looked like nothing in particular at sensor size
+  (thanks @zeus86).
+
 ## v0.5.3 — English entity IDs in every language (2026-08-05)
 
 ### Bug fixes

--- a/custom_components/polleninformation/manifest.json
+++ b/custom_components/polleninformation/manifest.json
@@ -11,6 +11,6 @@
     "async-timeout>=4.0.0",
     "Unidecode>=1.3.6"
   ],
-  "version": "0.5.3"
+  "version": "0.5.4"
 }
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -77,30 +77,40 @@ LATIN_TO_ENGLISH_NAME = {
     "Urticaceae": "nettle family",
 }
 
+# Icons group the allergens by pollen source, which is what makes a list of
+# them scannable: the name next to the icon already says which species it is.
+# Material Design Icons has no species-specific plant icons, so a shared icon
+# is preferred over one that would depict the wrong plant.
 ALLERGEN_ICON_MAP = {
+    # Catkin trees, the early-spring group
     "alder": "mdi:tree-outline",
+    "birch": "mdi:tree-outline",
+    "willow": "mdi:tree-outline",
+    "hazel": "mdi:hops",  # a hazel catkin has the shape of a hop cone
+    # Broadleaf trees
     "ash": "mdi:tree",
-    "beech": "mdi:leaf",
-    "birch": "mdi:tree",
-    "cypress_family": "mdi:pine-tree",
-    "default": "mdi:flower-pollen",
-    "dock_sorrel": "mdi:leaf",
+    "beech": "mdi:tree",
     "elm": "mdi:tree",
-    "grasses": "mdi:grass",
-    "hazel": "mdi:nature",
-    "linden": "mdi:leaf",
-    "fungal_spores": "mdi:cloud-alert",
-    "mugwort": "mdi:flower-pollen",
-    "nettle_family": "mdi:leaf",
-    "oak": "mdi:leaf",
-    "olive": "mdi:leaf",
-    "plane_tree": "mdi:tree",
-    "plantain": "mdi:leaf",
-    "ragweed": "mdi:flower-pollen",
-    "rye": "mdi:barley",
+    "linden": "mdi:tree",
+    "oak": "mdi:tree",
     "sweet_chestnut": "mdi:tree",
     "tree_of_heaven": "mdi:tree",
-    "willow": "mdi:tree",
+    "plane_tree": "mdi:leaf-maple",  # the one species whose leaf is maple-like
+    # Evergreens
+    "cypress_family": "mdi:pine-tree",
+    "olive": "mdi:leaf-circle",
+    # Grasses and cereals
+    "grasses": "mdi:grass",
+    "rye": "mdi:barley",
+    # Weeds and herbs
+    "mugwort": "mdi:flower",
+    "ragweed": "mdi:flower-poppy",
+    "dock_sorrel": "mdi:sprout",
+    "nettle_family": "mdi:leaf",
+    "plantain": "mdi:leaf",
+    # Not a plant at all
+    "fungal_spores": "mdi:mushroom",
+    "default": "mdi:flower-pollen",
 }
 
 RISK_SLUGS = ("allergy_risk", "allergy_risk_hourly")

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -97,7 +97,7 @@ ALLERGEN_ICON_MAP = {
     "plane_tree": "mdi:tree",
     "plantain": "mdi:leaf",
     "ragweed": "mdi:flower-pollen",
-    "rye": "mdi:grain",
+    "rye": "mdi:barley",
     "sweet_chestnut": "mdi:tree",
     "tree_of_heaven": "mdi:tree",
     "willow": "mdi:tree",


### PR DESCRIPTION
Addresses #68 (do not auto-close; the issue tracks the 0.5.4 release).

Icon improvements for all allergen sensors, spun off from feedback in #63:

- **rye:** `mdi:grain` → `mdi:barley`. The old icon is MDI's film-grain pattern (tagged Photography), not a cereal.
- **Icon differentiation across the map:** from 9 distinct icons to 13, grouped by pollen source: catkin trees (`mdi:tree-outline`), deciduous trees (`mdi:tree`), conifer (`mdi:pine-tree`), evergreen olive (`mdi:leaf-circle`), plane tree (`mdi:leaf-maple`, its leaf is maple-like), hazel (`mdi:hops`, the catkin resembles a hop cone), grasses (`mdi:grass`), rye (`mdi:barley`), weeds (`mdi:flower` mugwort, `mdi:flower-poppy` ragweed, `mdi:sprout` dock/sorrel), leafy herbs (`mdi:leaf`), fungal spores (`mdi:mushroom`).
- No allergen shares an icon with the unknown-allergen fallback (`mdi:flower-pollen`) anymore.
- Manifest bumped to 0.5.4. Release is planned about a week out; this PR is merged ahead of time.

MDI has no species-specific plant icons (no oak, birch, olive and so on), so meaningful groups beat arbitrary uniqueness. The groups roughly follow cross-reactivity. All 22 icon names are verified against the MDI catalog's meta.json. These icons only show in Home Assistant's own UI; pollenprognos-card uses its own icons and is unaffected.

Tests: full suite green (203 passed). The slug contract test is unaffected (it pins keys, not icon values).