### PR TITLE
Harden allergen resolution and let stale sensors recover in every language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@
   its allergen slug, which is the same in every language, and it reports its
   real latin name instead of a blank one.
 
+- **A recovered sensor no longer reports its data as stale** — when the API
+  returns nothing, the integration keeps its sensors and marks them stale so
+  automations can tell. That mark was set once and never cleared, so a sensor
+  that found its allergen again kept reporting `data_stale` and a `stale_since`
+  timestamp from hours earlier next to a perfectly current pollen level. The
+  mark now follows the data and is reported only while the sensor really is
+  without a reading, the way the allergy risk sensors already worked.
+
 ## v0.5.4 — Allergen icons (2026-08-10)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## v0.5.5 — Allergen identification (2026-08-18)
+
+### Bug fixes
+
+- **Mugwort is recognized again** (issue #71) — the API sometimes sends an
+  allergen's latin genus as its display name ("Artemisia") and leaves the latin
+  field empty. The integration looks allergens up by their latin name, so this
+  one was not found: the sensor was slugged `artemisia` instead of the
+  canonical `mugwort`, it got the generic pollen icon rather than the flower
+  icon, and an "Unknown allergen" warning was logged for it at every restart.
+  The display name is now tried against the same map when the API sends no
+  latin name of its own, and an entity already created as `..._artemisia` is
+  renamed to `..._mugwort`, so its history is kept. The lookup only runs once
+  nothing else has identified the allergen, so it can never override an
+  allergen the integration already knows.
+  (PR #72 by @ethanhawkes-gif, thanks @robercrack)
+
+- **The latin name is reported even when the API omits it** — an allergen
+  identified from its display name was left with an empty `name_la` attribute,
+  because the API had sent no latin name of its own. It now reports the genus
+  the lookup found.
+
+- **Sensors recover on their own after an empty API response** (issue #73) —
+  when the API returns no data the integration keeps the existing sensors and
+  marks them stale. It matched such a sensor back to the API's allergens by
+  English name, but the API sends allergen names in the language configured for
+  the integration, so on a non-English installation the sensor never found its
+  allergen again and stayed empty even after the API recovered, until Home
+  Assistant was restarted or the entry reloaded. English installations were
+  unaffected apart from dock/sorrel. A recreated sensor is now also matched on
+  its allergen slug, which is the same in every language, and it reports its
+  real latin name instead of a blank one.
+
 ## v0.5.4 — Allergen icons (2026-08-10)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@
   sensor that has always had a reading and then loses it is marked too, where
   before only sensors kept through an outage ever were.
 
+- **A sensor with nothing to show says so** — a response that carried a risk
+  block but nothing usable for today, only a later day or an empty value, left
+  the allergy risk sensors showing no value while reporting their data as
+  current. The stale marker now follows the value each sensor actually shows,
+  so an empty sensor is always marked as such. A risk of zero is a real
+  reading and is not affected.
+
 - **A new outage is timed from when it started** — the `stale_since`
   timestamp was recorded once, when Home Assistant happened to start during an
   outage, and was reused for every later outage of the same sensor. A card or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@
   icon, and an "Unknown allergen" warning was logged for it at every restart.
   The display name is now tried against the same map when the API sends no
   latin name of its own, and an entity already created as `..._artemisia` is
-  renamed to `..._mugwort`, so its history is kept. The lookup only runs once
-  nothing else has identified the allergen, so it can never override an
-  allergen the integration already knows.
+  renamed to `..._mugwort`, so its history is kept. The lookup only runs when
+  the API sent no latin name at all, so a latin name it did send is never
+  overridden by the display name.
   (PR #72 by @ethanhawkes-gif, thanks @robercrack)
 
 - **The latin name is reported even when the API omits it** — an allergen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@
   sensor that has always had a reading and then loses it is marked too, where
   before only sensors kept through an outage ever were.
 
+- **Two allergens that share a name no longer read each other's values** —
+  the API can send one allergen's name for two entries, one with a latin name
+  in brackets and one without. Both sensors then looked for their allergen by
+  that shared name and both found whichever entry came first, so one of them
+  showed the other's level and forecast. Sensors are now matched on their
+  latin name first, and a name is only used for an entry no other sensor
+  claims.
+
 - **A sensor with nothing to show says so** — a response that carried a risk
   block but nothing usable for today, only a later day or an empty value, left
   the allergy risk sensors showing no value while reporting their data as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,9 @@
   that found its allergen again kept reporting `data_stale` and a `stale_since`
   timestamp from hours earlier next to a perfectly current pollen level. The
   mark now follows the data and is reported only while the sensor really is
-  without a reading.
+  without a reading. It also follows the data for every sensor now, so a
+  sensor that has always had a reading and then loses it is marked too, where
+  before only sensors kept through an outage ever were.
 
 - **A new outage is timed from when it started** — the `stale_since`
   timestamp was recorded once, when Home Assistant happened to start during an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 
 - **A new outage is timed from when it started** — the `stale_since`
   timestamp was recorded once, when Home Assistant happened to start during an
-  outage, and was reused for every later outage. A card or automation
+  outage, and was reused for every later outage. An automation or template
   measuring how long data had been missing could therefore be told it had been
   missing since a gap that ended hours ago. Each outage now carries its own
   timestamp.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,15 +37,16 @@
   language you configured, where it used to fall back to English until Home
   Assistant was restarted.
 
-- **A recovered sensor no longer reports its data as stale** — when the API
-  returns nothing, the integration keeps its sensors and marks them stale so
-  automations can tell. That mark was set once and never cleared, so a sensor
-  that found its allergen again kept reporting `data_stale` and a `stale_since`
-  timestamp from hours earlier next to a perfectly current pollen level. The
-  mark now follows the data and is reported only while the sensor really is
-  without a reading. It also follows the data for every sensor now, so a
-  sensor that has always had a reading and then loses it is marked too, where
-  before only sensors kept through an outage ever were.
+- **The stale marker follows the API, and clears when data returns** — when a
+  refresh succeeds but the API returns no pollen data at all, every sensor for
+  that location reports `data_stale` together with a `stale_since` timestamp,
+  and all of them report the same timestamp for the same outage. The marker
+  used to be set once, when Home Assistant happened to start during such an
+  outage, and was never cleared afterwards, so a sensor whose data had long
+  since come back still reported itself stale next to a perfectly current
+  pollen level. A sensor that is merely missing a value of its own, while the
+  API is answering normally, now shows `unknown` and carries no marker, which
+  is what Home Assistant expects of an entity in that state.
 
 - **Two allergens that share a name no longer read each other's values** —
   the API can send one allergen's name for two entries, one with a latin name
@@ -55,19 +56,12 @@
   latin name first, and a name is only used for an entry no other sensor
   claims.
 
-- **A sensor with nothing to show says so** — a response that carried a risk
-  block but nothing usable for today, only a later day or an empty value, left
-  the allergy risk sensors showing no value while reporting their data as
-  current. The stale marker now follows the value each sensor actually shows,
-  so an empty sensor is always marked as such. A risk of zero is a real
-  reading and is not affected.
-
 - **A new outage is timed from when it started** — the `stale_since`
   timestamp was recorded once, when Home Assistant happened to start during an
-  outage, and was reused for every later outage of the same sensor. A card or
-  automation measuring how long data had been missing could therefore be told
-  it had been missing since a gap that ended hours ago. Each outage now
-  carries its own timestamp. This applies to the allergy risk sensors as well.
+  outage, and was reused for every later outage. A card or automation
+  measuring how long data had been missing could therefore be told it had been
+  missing since a gap that ended hours ago. Each outage now carries its own
+  timestamp.
 
 ## v0.5.4 — Allergen icons (2026-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
   latin name of its own, and an entity already created as `..._artemisia` is
   renamed to `..._mugwort`, so its history is kept. The lookup only runs when
   the API sent no latin name at all, so a latin name it did send is never
-  overridden by the display name.
+  overridden by the display name, and it only accepts a display name that is
+  itself a latin name, so an ordinary allergen name that happens to begin with
+  one is left alone.
   (PR #72 by @ethanhawkes-gif, thanks @robercrack)
 
 - **The latin name is reported even when the API omits it** — an allergen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,14 @@
   that found its allergen again kept reporting `data_stale` and a `stale_since`
   timestamp from hours earlier next to a perfectly current pollen level. The
   mark now follows the data and is reported only while the sensor really is
-  without a reading, the way the allergy risk sensors already worked.
+  without a reading.
+
+- **A new outage is timed from when it started** — the `stale_since`
+  timestamp was recorded once, when Home Assistant happened to start during an
+  outage, and was reused for every later outage of the same sensor. A card or
+  automation measuring how long data had been missing could therefore be told
+  it had been missing since a gap that ended hours ago. Each outage now
+  carries its own timestamp. This applies to the allergy risk sensors as well.
 
 ## v0.5.4 — Allergen icons (2026-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,9 @@
   Assistant was restarted or the entry reloaded. English installations were
   unaffected apart from dock/sorrel. A recreated sensor is now also matched on
   its allergen slug, which is the same in every language, and it reports its
-  real latin name instead of a blank one.
+  real latin name instead of a blank one. It also keeps its name in the
+  language you configured, where it used to fall back to English until Home
+  Assistant was restarted.
 
 - **A recovered sensor no longer reports its data as stale** — when the API
   returns nothing, the integration keeps its sensors and marks them stale so

--- a/custom_components/polleninformation/__init__.py
+++ b/custom_components/polleninformation/__init__.py
@@ -156,6 +156,8 @@ class PollenInformationDataUpdateCoordinator(DataUpdateCoordinator):
         self.lang = lang
         self.apikey = apikey
         self.last_updated = None
+        # Response-level staleness: see _track_empty_response.
+        self.empty_since: str | None = None
 
     def _is_valid_api_response(self, result: dict | None) -> bool:
         if result is None:
@@ -167,6 +169,23 @@ class PollenInformationDataUpdateCoordinator(DataUpdateCoordinator):
         if not isinstance(result.get("contamination"), list):
             return False
         return True
+
+    def _track_empty_response(self, result: dict) -> None:
+        """Record when the API started answering with nothing usable.
+
+        data_stale is response level BY DEFINITION: it means the fetch
+        succeeded and the response carried no data at all, not that one
+        sensor is missing a reading. A sensor with no reading of its own is
+        unknown and carries no marker, which is what Home Assistant expects.
+
+        The timestamp is taken on the way into an outage and cleared on the
+        way out, so it dates the outage being reported and every entity of
+        the location reports the same value for it.
+        """
+        if result.get("contamination"):
+            self.empty_since = None
+        elif self.empty_since is None:
+            self.empty_since = dt_util.now().isoformat()
 
     async def _async_update_data(self) -> dict:
         """Fetch latest pollen data from API."""
@@ -191,6 +210,7 @@ class PollenInformationDataUpdateCoordinator(DataUpdateCoordinator):
                 )
 
             self.last_updated = dt_util.now()
+            self._track_empty_response(result)  # type: ignore[arg-type]
             return result  # type: ignore[return-value]
         except UpdateFailed:
             raise

--- a/custom_components/polleninformation/__init__.py
+++ b/custom_components/polleninformation/__init__.py
@@ -181,8 +181,16 @@ class PollenInformationDataUpdateCoordinator(DataUpdateCoordinator):
         The timestamp is taken on the way into an outage and cleared on the
         way out, so it dates the outage being reported and every entity of
         the location reports the same value for it.
+
+        Every block counts, not just contamination: a response carrying only
+        risk data still carried data, and marking it stale would tell the
+        risk sensors they are stale while they report a current reading.
         """
-        if result.get("contamination"):
+        if (
+            result.get("contamination")
+            or result.get("allergyrisk")
+            or result.get("allergyrisk_hourly")
+        ):
             self.empty_since = None
         elif self.empty_since is None:
             self.empty_since = dt_util.now().isoformat()

--- a/custom_components/polleninformation/manifest.json
+++ b/custom_components/polleninformation/manifest.json
@@ -11,6 +11,6 @@
     "async-timeout>=4.0.0",
     "Unidecode>=1.3.6"
   ],
-  "version": "0.5.4"
+  "version": "0.5.5"
 }
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -173,6 +173,21 @@ def english_name_for_latin(latin: str | None) -> str | None:
     return index.get(key.split()[0]) if key.split() else None
 
 
+def allergen_slug_for_item(item: dict) -> str | None:
+    """Return the canonical allergen slug for a contamination entry, or None.
+
+    The latin name in poll_title is the only part of the entry that does not
+    vary with the configured language, so it is what identifies an allergen
+    for a sensor that only knows its own slug.
+    """
+    poll_title = item.get("poll_title", "")
+    if "(" not in poll_title or ")" not in poll_title:
+        return None
+    latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
+    name_en = english_name_for_latin(latin)
+    return slugify(name_en) if name_en else None
+
+
 def entity_id_available(hass, ent_reg, entity_id: str) -> bool:
     """Return True when the registry would accept this entity_id.
 
@@ -634,17 +649,28 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
         # Stale/empty data still shows as available but with state "unknown"
         return self.coordinator.last_update_success is not False
 
+    def _find_item(self, contamination: list) -> dict | None:
+        """Return this allergen's contamination entry, or None.
+
+        The name matches for a sensor built from the current response. A
+        sensor recreated from the registry while the API returned no data
+        knows only the English name behind its slug, so it also matches on
+        the slug, which holds in every language.
+        """
+        for item in contamination:
+            poll_title = item.get("poll_title", "").split("(", 1)[0].strip()
+            if poll_title.lower() == self._allergen_name.lower():
+                return item
+            if allergen_slug_for_item(item) == self._allergen_slug:
+                return item
+        return None
+
     @property
     def native_value(self) -> str | None:
         if not self.coordinator.data:
             return None
         contamination = self.coordinator.data.get("contamination", [])
-        found = None
-        for item in contamination:
-            poll_title = item.get("poll_title", "").split("(", 1)[0].strip()
-            if poll_title.lower() == self._allergen_name.lower():
-                found = item
-                break
+        found = self._find_item(contamination)
         if not found:
             return None
         raw_val = found.get("contamination_1", 0)
@@ -665,26 +691,23 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
         contamination = self.coordinator.data.get("contamination", [])
         forecast = []
         base_date = dt_util.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        for item in contamination:
-            poll_title = item.get("poll_title", "").split("(", 1)[0].strip()
-            if poll_title.lower() == self._allergen_name.lower():
-                for day in range(1, 5):
-                    val = item.get(f"contamination_{day}", 0)
-                    level_name = (
-                        self._levels_current[val]
-                        if isinstance(val, int) and val < len(self._levels_current)
-                        else str(val)
-                    )
-                    forecast.append(
-                        {
-                            "time": (base_date + timedelta(days=day - 1)).strftime(
-                                "%Y-%m-%dT%H:%M:%S"
-                            ),
-                            "level": val,
-                            "level_name": level_name,
-                        }
-                    )
-                break
+        if item := self._find_item(contamination):
+            for day in range(1, 5):
+                val = item.get(f"contamination_{day}", 0)
+                level_name = (
+                    self._levels_current[val]
+                    if isinstance(val, int) and val < len(self._levels_current)
+                    else str(val)
+                )
+                forecast.append(
+                    {
+                        "time": (base_date + timedelta(days=day - 1)).strftime(
+                            "%Y-%m-%dT%H:%M:%S"
+                        ),
+                        "level": val,
+                        "level_name": level_name,
+                    }
+                )
 
         today_raw = forecast[0] if forecast else None
         tomorrow_raw = forecast[1] if len(forecast) > 1 else None

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -173,6 +173,17 @@ def english_name_for_latin(latin: str | None) -> str | None:
     return index.get(key.split()[0]) if key.split() else None
 
 
+def english_name_for_display_name(name: str | None) -> str | None:
+    """Return the English allergen name for a display name that IS a latin name.
+
+    Unlike english_name_for_latin this does not fall back to the first token:
+    a display name that merely begins with a genus is prose, not an identity.
+    A latin name the map knows is matched whole, genus-plus-species keys
+    included.
+    """
+    return _latin_name_index().get(name.strip().lower()) if name else None
+
+
 @lru_cache(maxsize=1)
 def _slug_index() -> dict[str, tuple[str, str]]:
     """Canonical English name and latin name per allergen slug."""
@@ -191,17 +202,13 @@ def allergen_slug_for_item(item: dict) -> str | None:
     poll_title = item.get("poll_title", "")
     if "(" in poll_title and ")" in poll_title:
         latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
+        name_en = english_name_for_latin(latin)
     else:
-        # No latin at all: the API sometimes sends the latin genus as the
+        # No latin at all: the API sometimes sends the latin name as the
         # display name instead (e.g. "Artemisia"), so the name itself is the
         # last chance to identify the entry. Only tried when no latin was
-        # sent, so an entry that carries one is identified by that alone, and
-        # only for a single word, since a genus is one word: prose that merely
-        # begins with a genus would otherwise resolve through the genus
-        # fallback in english_name_for_latin.
-        stripped = poll_title.strip()
-        latin = stripped if len(stripped.split()) == 1 else ""
-    name_en = english_name_for_latin(latin)
+        # sent, so an entry that carries one is identified by that alone.
+        name_en = english_name_for_display_name(poll_title)
     return slugify(name_en) if name_en else None
 
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -173,6 +173,14 @@ def english_name_for_latin(latin: str | None) -> str | None:
     return index.get(key.split()[0]) if key.split() else None
 
 
+@lru_cache(maxsize=1)
+def _slug_index() -> dict[str, tuple[str, str]]:
+    """Canonical English name and latin name per allergen slug."""
+    return {
+        slugify(name): (name, latin) for latin, name in LATIN_TO_ENGLISH_NAME.items()
+    }
+
+
 def allergen_slug_for_item(item: dict) -> str | None:
     """Return the canonical allergen slug for a contamination entry, or None.
 
@@ -566,23 +574,28 @@ async def async_setup_entry(hass, entry, async_add_entities):
                     stale_since=stale_since,
                 )
             else:
-                allergen_en = allergen_slug.replace("_", " ").title()
+                # The slug is all the registry keeps, so the names are
+                # derived back from it; the API is not answering right now.
+                allergen_en, allergen_la = _slug_index().get(
+                    allergen_slug, (allergen_slug.replace("_", " "), "")
+                )
+                allergen_name = capitalize_first(allergen_en)
                 icon = ALLERGEN_ICON_MAP.get(
                     allergen_slug, ALLERGEN_ICON_MAP["default"]
                 )
                 sensor = PolleninformationSensor(
                     coordinator=coordinator,
                     sensor_type="pollen",
-                    allergen_name=allergen_en,
+                    allergen_name=allergen_name,
                     allergen_en=allergen_en,
                     allergen_slug=allergen_slug,
-                    allergen_latin="",
+                    allergen_latin=allergen_la,
                     levels_current=levels_current,
                     levels_en=levels_en,
                     location_slug=location_slug,
                     location_title=location_title,
                     icon=icon,
-                    display_name=display_overrides.get(allergen_slug, allergen_en),
+                    display_name=display_overrides.get(allergen_slug, allergen_name),
                     is_stale=True,
                     stale_since=stale_since,
                 )

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -795,8 +795,10 @@ class PolleninformationSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
             if self.coordinator.last_updated
             else None,
         }
-        # An empty forecast is what "no data for this allergen" looks like.
-        attrs.update(self._stale_attrs(has_data=bool(forecast)))
+        # Staleness follows the value the sensor reports: a forecast can be
+        # built from a level the level names do not cover, and a sensor
+        # showing unknown is not fresh whatever else the response held.
+        attrs.update(self._stale_attrs(has_data=self.native_value is not None))
         return attrs
 
 
@@ -911,7 +913,10 @@ class AllergyRiskSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
             if self.coordinator.last_updated
             else None,
         }
-        attrs.update(self._stale_attrs(has_data=True))
+        # The block being present is not a reading: it can carry only a later
+        # day, or a null, and leave the sensor unknown. Staleness therefore
+        # follows the value, so the two can never disagree.
+        attrs.update(self._stale_attrs(has_data=self.native_value is not None))
         return attrs
 
 
@@ -1037,5 +1042,8 @@ class AllergyRiskHourlySensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
             if self.coordinator.last_updated
             else None,
         }
-        attrs.update(self._stale_attrs(has_data=True))
+        # The block being present is not a reading: it can carry only a later
+        # day, or a null, and leave the sensor unknown. Staleness therefore
+        # follows the value, so the two can never disagree.
+        attrs.update(self._stale_attrs(has_data=self.native_value is not None))
         return attrs

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -189,9 +189,14 @@ def allergen_slug_for_item(item: dict) -> str | None:
     for a sensor that only knows its own slug.
     """
     poll_title = item.get("poll_title", "")
-    if "(" not in poll_title or ")" not in poll_title:
-        return None
-    latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
+    if "(" in poll_title and ")" in poll_title:
+        latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
+    else:
+        # No latin at all: the API sometimes sends the latin genus as the
+        # display name instead (e.g. "Artemisia"), so the name itself is the
+        # last chance to identify the entry. Only tried when no latin was
+        # sent, so an entry that carries one is identified by that alone.
+        latin = poll_title.strip()
     name_en = english_name_for_latin(latin)
     return slugify(name_en) if name_en else None
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -429,14 +429,16 @@ async def async_setup_entry(hass, entry, async_add_entities):
         )
         legacy_en = allergen_en_obj["name"] if allergen_en_obj else poll_title_local
         mapped_en = english_name_for_latin(latin)
-        if mapped_en is None:
+        if mapped_en is None and allergen_en_obj is None:
             # The API sometimes sends the latin genus as the display name and
-            # leaves the latin field empty (e.g. "Artemisia"). The static map
-            # is keyed by latin name, so try the display name against it too
-            # before giving up: this keeps the canonical English slug and icon
-            # and avoids a spurious "unknown allergen" warning. A localized
-            # display name that is not a latin genus stays unresolved here, so
-            # behaviour for a genuinely unknown allergen is unchanged.
+            # leaves the latin field empty (e.g. "Artemisia"), which is why no
+            # latin lookup found anything. The static map is keyed by latin
+            # name, so try the display name against it too before giving up:
+            # this keeps the canonical English slug and icon and avoids a
+            # spurious "unknown allergen" warning. The English language block
+            # keeps precedence, so this only runs once both latin lookups have
+            # failed and a localized name that is not a latin genus stays
+            # unresolved.
             mapped_en = english_name_for_latin(poll_title_local)
         if mapped_en is None and allergen_en_obj is None:
             _LOGGER.warning(

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -469,18 +469,18 @@ async def async_setup_entry(hass, entry, async_add_entities):
         legacy_en = allergen_en_obj["name"] if allergen_en_obj else poll_title_local
         mapped_en = english_name_for_latin(latin)
         if not latin:
-            # The API sometimes sends the latin genus as the display name and
+            # The API sometimes sends the latin name as the display name and
             # leaves the latin field empty (e.g. "Artemisia"), so nothing above
             # had a latin name to look up. The static map is keyed by latin
             # name, so try the display name against it before giving up: this
             # keeps the canonical English slug and icon and avoids a spurious
             # "unknown allergen" warning. A latin name the API did send is
             # authoritative even when no map knows it, so this never runs then;
-            # a localized display name that is not a latin genus stays
+            # a localized display name that is not itself a latin name stays
             # unresolved.
-            mapped_en = english_name_for_latin(poll_title_local)
+            mapped_en = english_name_for_display_name(poll_title_local)
             if mapped_en is not None:
-                # The display name is a latin genus, so report it as one
+                # The display name is a latin name, so report it as one
                 # instead of the empty latin field the API sent.
                 latin = poll_title_local
         if mapped_en is None and allergen_en_obj is None:

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -195,8 +195,12 @@ def allergen_slug_for_item(item: dict) -> str | None:
         # No latin at all: the API sometimes sends the latin genus as the
         # display name instead (e.g. "Artemisia"), so the name itself is the
         # last chance to identify the entry. Only tried when no latin was
-        # sent, so an entry that carries one is identified by that alone.
-        latin = poll_title.strip()
+        # sent, so an entry that carries one is identified by that alone, and
+        # only for a single word, since a genus is one word: prose that merely
+        # begins with a genus would otherwise resolve through the genus
+        # fallback in english_name_for_latin.
+        stripped = poll_title.strip()
+        latin = stripped if len(stripped.split()) == 1 else ""
     name_en = english_name_for_latin(latin)
     return slugify(name_en) if name_en else None
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -440,6 +440,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
             # failed and a localized name that is not a latin genus stays
             # unresolved.
             mapped_en = english_name_for_latin(poll_title_local)
+            if mapped_en is not None:
+                # The display name is a latin genus, so report it as one
+                # instead of the empty latin field the API sent.
+                latin = poll_title_local
         if mapped_en is None and allergen_en_obj is None:
             _LOGGER.warning(
                 "Unknown allergen %r (latin %r); its entity_id will follow the "

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -615,7 +615,34 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities(entities, update_before_add=True)
 
 
-class PolleninformationSensor(CoordinatorEntity, SensorEntity):
+class StaleDataMarker:
+    """Tracks which outage the data_stale attributes describe.
+
+    An entity recreated while the API returned nothing carries the timestamp
+    of the outage that was ongoing at setup, and setup does not run again when
+    the API recovers. The transition therefore has to be observed here: the
+    timestamp is taken on the way into an outage and cleared on the way out,
+    so a later outage is dated by itself rather than by the first one. Only
+    the transition assigns it, so the repeated reads Home Assistant makes of
+    an attributes property report the same value throughout one outage.
+    """
+
+    _is_stale: bool
+    _stale_since: str | None
+
+    def _stale_attrs(self, has_data: bool) -> dict[str, Any]:
+        """Return the data_stale pair to publish, empty while data is present."""
+        if has_data:
+            self._is_stale = False
+            self._stale_since = None
+            return {}
+        if not self._is_stale:
+            self._is_stale = True
+            self._stale_since = dt_util.now().isoformat()
+        return {"data_stale": True, "stale_since": self._stale_since}
+
+
+class PolleninformationSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
     """Pollen allergen sensor."""
 
     _attr_has_entity_name = True
@@ -712,11 +739,7 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         if not self.coordinator.data:
-            attrs: dict[str, Any] = {}
-            if self._is_stale:
-                attrs["data_stale"] = True
-                attrs["stale_since"] = self._stale_since
-            return attrs
+            return self._stale_attrs(has_data=False)
 
         contamination = self.coordinator.data.get("contamination", [])
         forecast = []
@@ -765,17 +788,12 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
             if self.coordinator.last_updated
             else None,
         }
-        # Staleness is derived, not remembered: the flag is set once when the
-        # entity is recreated during an empty response, and setup does not run
-        # again when the API recovers. An empty forecast is what "no data for
-        # this allergen" looks like here.
-        if self._is_stale and not forecast:
-            attrs["data_stale"] = True
-            attrs["stale_since"] = self._stale_since
+        # An empty forecast is what "no data for this allergen" looks like.
+        attrs.update(self._stale_attrs(has_data=bool(forecast)))
         return attrs
 
 
-class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
+class AllergyRiskSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
     """Daily allergy risk sensor."""
 
     _attr_has_entity_name = True
@@ -848,9 +866,7 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
                 "location_slug": self._location_slug,
                 "attribution": "Austrian Pollen Information Service",
             }
-            if self._is_stale:
-                attrs["data_stale"] = True
-                attrs["stale_since"] = self._stale_since
+            attrs.update(self._stale_attrs(has_data=False))
             return attrs
 
         forecast = []
@@ -875,7 +891,7 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
             )
         raw_value = allergyrisk.get("allergyrisk_1", None)
         scaled_today = scale_allergy_risk(raw_value) if raw_value is not None else None
-        return {
+        attrs = {
             "named_state": self.native_value,
             "numeric_state": scaled_today,
             "numeric_state_raw": raw_value,
@@ -888,9 +904,11 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
             if self.coordinator.last_updated
             else None,
         }
+        attrs.update(self._stale_attrs(has_data=True))
+        return attrs
 
 
-class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
+class AllergyRiskHourlySensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
     """Hourly allergy risk sensor."""
 
     _attr_has_entity_name = True
@@ -966,9 +984,7 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
                 "location_slug": self._location_slug,
                 "attribution": "Austrian Pollen Information Service",
             }
-            if self._is_stale:
-                attrs["data_stale"] = True
-                attrs["stale_since"] = self._stale_since
+            attrs.update(self._stale_attrs(has_data=False))
             return attrs
 
         base_time = dt_util.now().replace(hour=0, minute=0, second=0, microsecond=0)
@@ -1001,7 +1017,7 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
             if scaled_now is not None and scaled_now < len(self._levels_current)
             else None
         )
-        return {
+        attrs = {
             "named_state": named_now,
             "numeric_state": scaled_now,
             "numeric_state_raw": raw_now,
@@ -1014,3 +1030,5 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
             if self.coordinator.last_updated
             else None,
         }
+        attrs.update(self._stale_attrs(has_data=True))
+        return attrs

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -457,15 +457,15 @@ async def async_setup_entry(hass, entry, async_add_entities):
         )
         legacy_en = allergen_en_obj["name"] if allergen_en_obj else poll_title_local
         mapped_en = english_name_for_latin(latin)
-        if mapped_en is None and allergen_en_obj is None:
+        if not latin:
             # The API sometimes sends the latin genus as the display name and
-            # leaves the latin field empty (e.g. "Artemisia"), which is why no
-            # latin lookup found anything. The static map is keyed by latin
-            # name, so try the display name against it too before giving up:
-            # this keeps the canonical English slug and icon and avoids a
-            # spurious "unknown allergen" warning. The English language block
-            # keeps precedence, so this only runs once both latin lookups have
-            # failed and a localized name that is not a latin genus stays
+            # leaves the latin field empty (e.g. "Artemisia"), so nothing above
+            # had a latin name to look up. The static map is keyed by latin
+            # name, so try the display name against it before giving up: this
+            # keeps the canonical English slug and icon and avoids a spurious
+            # "unknown allergen" warning. A latin name the API did send is
+            # authoritative even when no map knows it, so this never runs then;
+            # a localized display name that is not a latin genus stays
             # unresolved.
             mapped_en = english_name_for_latin(poll_title_local)
             if mapped_en is not None:

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -678,6 +678,14 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
         sensor recreated from the registry while the API returned no data
         knows only the English name behind its slug, so it also matches on
         the slug, which holds in every language.
+
+        Both criteria are tested per entry, which is safe because at most one
+        entry can match either way: two entries resolving to one allergen
+        already collide on unique_id at setup, and no localized name in the
+        language map equals another allergen's canonical English name. Were
+        this ever split into two passes, the slug pass belongs first, since
+        the slug comes from the language-invariant latin name while the name
+        compare is the fuzzy one.
         """
         for item in contamination:
             poll_title = item.get("poll_title", "").split("(", 1)[0].strip()

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -595,7 +595,20 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 allergen_en, allergen_la = _slug_index().get(
                     allergen_slug, (allergen_slug.replace("_", " "), "")
                 )
-                allergen_name = capitalize_first(allergen_en)
+                # The API sends poll_title in the configured language, and it
+                # does not always carry the latin name, so the match key has
+                # to be the localized name. It comes from the same language
+                # block the setup path reads it from. An allergen the block
+                # does not carry keeps the English name and stays matchable
+                # through the latin name in poll_title.
+                localized = (
+                    get_allergen_info_by_latin(allergen_la, language_block_current)
+                    if allergen_la
+                    else None
+                )
+                allergen_name = capitalize_first(
+                    (localized or {}).get("name") or allergen_en
+                )
                 icon = ALLERGEN_ICON_MAP.get(
                     allergen_slug, ALLERGEN_ICON_MAP["default"]
                 )

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -721,24 +721,27 @@ class PolleninformationSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
     def _find_item(self, contamination: list) -> dict | None:
         """Return this allergen's contamination entry, or None.
 
-        The name matches for a sensor built from the current response. A
-        sensor recreated from the registry while the API returned no data
-        knows only the English name behind its slug, so it also matches on
-        the slug, which holds in every language.
+        The slug comes from the language-invariant latin name, so it
+        identifies an entry outright and is searched first, across every
+        entry. The name is only a fallback, for an entry no map can place
+        and for a sensor recreated from the registry.
 
-        Both criteria are tested per entry, which is safe because at most one
-        entry can match either way: two entries resolving to one allergen
-        already collide on unique_id at setup, and no localized name in the
-        language map equals another allergen's canonical English name. Were
-        this ever split into two passes, the slug pass belongs first, since
-        the slug comes from the language-invariant latin name while the name
-        compare is the fuzzy one.
+        Two entries can share a name: poll_title_local drops the
+        parenthesized latin, so "Artemisia (Asteraceae)" and a bare
+        "Artemisia" both leave "Artemisia" as the match key while resolving
+        to different allergens. The name pass therefore skips any entry that
+        identifies as a different allergen, and a name match only ever lands
+        on an entry that nothing else claims.
         """
         for item in contamination:
+            if allergen_slug_for_item(item) == self._allergen_slug:
+                return item
+        for item in contamination:
+            slug = allergen_slug_for_item(item)
+            if slug is not None and slug != self._allergen_slug:
+                continue
             poll_title = item.get("poll_title", "").split("(", 1)[0].strip()
             if poll_title.lower() == self._allergen_name.lower():
-                return item
-            if allergen_slug_for_item(item) == self._allergen_slug:
                 return item
         return None
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -536,7 +536,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
             new_unique_ids.add(sensor.unique_id)
 
     # Recreate stale entities from registry when API returns empty data
-    stale_since = dt_util.now().isoformat() if is_data_empty else None
     if is_data_empty and existing_unique_ids:
         _LOGGER.warning(
             "API returned empty data for %s, recreating %d entities as stale",
@@ -556,8 +555,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
                     location_slug=location_slug,
                     location_title=location_title,
                     name=risk_name,
-                    is_stale=True,
-                    stale_since=stale_since,
                 )
             elif allergen_slug == "allergy_risk_hourly":
                 sensor = AllergyRiskHourlySensor(
@@ -566,8 +563,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
                     location_slug=location_slug,
                     location_title=location_title,
                     name=risk_name_hourly,
-                    is_stale=True,
-                    stale_since=stale_since,
                 )
             else:
                 # The slug is all the registry keeps, so the names are
@@ -605,8 +600,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
                     location_title=location_title,
                     icon=icon,
                     display_name=display_overrides.get(allergen_slug, allergen_name),
-                    is_stale=True,
-                    stale_since=stale_since,
                 )
             entities.append(sensor)
             if sensor.unique_id:
@@ -615,34 +608,21 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities(entities, update_before_add=True)
 
 
-class StaleDataMarker:
-    """Tracks which outage the data_stale attributes describe.
+def stale_attrs(coordinator) -> dict[str, Any]:
+    """Return the staleness attributes for a response that carried no data.
 
-    An entity recreated while the API returned nothing carries the timestamp
-    of the outage that was ongoing at setup, and setup does not run again when
-    the API recovers. The transition therefore has to be observed here: the
-    timestamp is taken on the way into an outage and cleared on the way out,
-    so a later outage is dated by itself rather than by the first one. Only
-    the transition assigns it, so the repeated reads Home Assistant makes of
-    an attributes property report the same value throughout one outage.
+    data_stale is response level BY DEFINITION: it says this location's fetch
+    succeeded and returned nothing usable, not that one sensor is missing a
+    reading. A sensor with no reading of its own is unknown and carries no
+    marker. The coordinator owns the timestamp, so every entity of a location
+    reports the same one for the same outage.
     """
-
-    _is_stale: bool
-    _stale_since: str | None
-
-    def _stale_attrs(self, has_data: bool) -> dict[str, Any]:
-        """Return the data_stale pair to publish, empty while data is present."""
-        if has_data:
-            self._is_stale = False
-            self._stale_since = None
-            return {}
-        if not self._is_stale:
-            self._is_stale = True
-            self._stale_since = dt_util.now().isoformat()
-        return {"data_stale": True, "stale_since": self._stale_since}
+    if not coordinator.empty_since:
+        return {}
+    return {"data_stale": True, "stale_since": coordinator.empty_since}
 
 
-class PolleninformationSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
+class PolleninformationSensor(CoordinatorEntity, SensorEntity):
     """Pollen allergen sensor."""
 
     _attr_has_entity_name = True
@@ -661,8 +641,6 @@ class PolleninformationSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
         location_title: str,
         icon: str,
         display_name: str | None = None,
-        is_stale: bool = False,
-        stale_since: str | None = None,
     ) -> None:
         super().__init__(coordinator)
         self.sensor_type = sensor_type
@@ -676,8 +654,6 @@ class PolleninformationSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
         self._levels_en = levels_en
         self._location_slug = location_slug
         self._location_title = location_title
-        self._is_stale = is_stale
-        self._stale_since = stale_since
 
         self._attr_name = self._display_name
         self._attr_unique_id = f"polleninformation_{location_slug}_{allergen_slug}"
@@ -742,7 +718,7 @@ class PolleninformationSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         if not self.coordinator.data:
-            return self._stale_attrs(has_data=False)
+            return stale_attrs(self.coordinator)
 
         contamination = self.coordinator.data.get("contamination", [])
         forecast = []
@@ -794,11 +770,11 @@ class PolleninformationSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
         # Staleness follows the value the sensor reports: a forecast can be
         # built from a level the level names do not cover, and a sensor
         # showing unknown is not fresh whatever else the response held.
-        attrs.update(self._stale_attrs(has_data=self.native_value is not None))
+        attrs.update(stale_attrs(self.coordinator))
         return attrs
 
 
-class AllergyRiskSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
+class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
     """Daily allergy risk sensor."""
 
     _attr_has_entity_name = True
@@ -811,15 +787,11 @@ class AllergyRiskSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
         location_slug: str,
         location_title: str,
         name: str | None = None,
-        is_stale: bool = False,
-        stale_since: str | None = None,
     ) -> None:
         super().__init__(coordinator)
         self._levels_current = levels_current
         self._location_slug = location_slug
         self._location_title = location_title
-        self._is_stale = is_stale
-        self._stale_since = stale_since
 
         # An explicit name wins over the translation key; leaving it unset
         # lets the name follow the Home Assistant UI language.
@@ -871,7 +843,7 @@ class AllergyRiskSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
                 "location_slug": self._location_slug,
                 "attribution": "Austrian Pollen Information Service",
             }
-            attrs.update(self._stale_attrs(has_data=False))
+            attrs.update(stale_attrs(self.coordinator))
             return attrs
 
         forecast = []
@@ -912,11 +884,11 @@ class AllergyRiskSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
         # The block being present is not a reading: it can carry only a later
         # day, or a null, and leave the sensor unknown. Staleness therefore
         # follows the value, so the two can never disagree.
-        attrs.update(self._stale_attrs(has_data=self.native_value is not None))
+        attrs.update(stale_attrs(self.coordinator))
         return attrs
 
 
-class AllergyRiskHourlySensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
+class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
     """Hourly allergy risk sensor."""
 
     _attr_has_entity_name = True
@@ -929,15 +901,11 @@ class AllergyRiskHourlySensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
         location_slug: str,
         location_title: str,
         name: str | None = None,
-        is_stale: bool = False,
-        stale_since: str | None = None,
     ) -> None:
         super().__init__(coordinator)
         self._levels_current = levels_current
         self._location_slug = location_slug
         self._location_title = location_title
-        self._is_stale = is_stale
-        self._stale_since = stale_since
 
         # An explicit name wins over the translation key; leaving it unset
         # lets the name follow the Home Assistant UI language.
@@ -992,7 +960,7 @@ class AllergyRiskHourlySensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
                 "location_slug": self._location_slug,
                 "attribution": "Austrian Pollen Information Service",
             }
-            attrs.update(self._stale_attrs(has_data=False))
+            attrs.update(stale_attrs(self.coordinator))
             return attrs
 
         base_time = dt_util.now().replace(hour=0, minute=0, second=0, microsecond=0)
@@ -1041,5 +1009,5 @@ class AllergyRiskHourlySensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
         # The block being present is not a reading: it can carry only a later
         # day, or a null, and leave the sensor unknown. Staleness therefore
         # follows the value, so the two can never disagree.
-        attrs.update(self._stale_attrs(has_data=self.native_value is not None))
+        attrs.update(stale_attrs(self.coordinator))
         return attrs

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -359,26 +359,6 @@ async def async_migrate_localized_risk_entity_ids(hass, entry, location_slug) ->
         ent_reg.async_update_entity(reg_entry.entity_id, new_entity_id=new_entity_id)
 
 
-def pollen_forecast_for_allergen(
-    contamination: list, allergen_name: str, levels: list
-) -> list:
-    out = []
-    allergen_name_lower = allergen_name.lower()
-    for item in contamination:
-        poll_title = item.get("poll_title", "").split("(", 1)[0].strip().lower()
-        if poll_title == allergen_name_lower:
-            for day in range(1, 5):
-                val = item.get(f"contamination_{day}", 0)
-                level_name = (
-                    levels[val]
-                    if isinstance(val, int) and val < len(levels)
-                    else str(val)
-                )
-                out.append({"day": day, "level_name": level_name, "level": val})
-            break
-    return out
-
-
 def scale_allergy_risk(value: Any) -> int | None:
     try:
         return int(round(value / 2.5))

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -767,9 +767,6 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
             if self.coordinator.last_updated
             else None,
         }
-        # Staleness follows the value the sensor reports: a forecast can be
-        # built from a level the level names do not cover, and a sensor
-        # showing unknown is not fresh whatever else the response held.
         attrs.update(stale_attrs(self.coordinator))
         return attrs
 
@@ -882,8 +879,8 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
             else None,
         }
         # The block being present is not a reading: it can carry only a later
-        # day, or a null, and leave the sensor unknown. Staleness therefore
-        # follows the value, so the two can never disagree.
+        # day, or a null, and leave this sensor unknown while the response as
+        # a whole was fine. That is unknown, not stale.
         attrs.update(stale_attrs(self.coordinator))
         return attrs
 
@@ -1007,7 +1004,7 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
             else None,
         }
         # The block being present is not a reading: it can carry only a later
-        # day, or a null, and leave the sensor unknown. Staleness therefore
-        # follows the value, so the two can never disagree.
+        # day, or a null, and leave this sensor unknown while the response as
+        # a whole was fine. That is unknown, not stale.
         attrs.update(stale_attrs(self.coordinator))
         return attrs

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -753,7 +753,11 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
             if self.coordinator.last_updated
             else None,
         }
-        if self._is_stale:
+        # Staleness is derived, not remembered: the flag is set once when the
+        # entity is recreated during an empty response, and setup does not run
+        # again when the API recovers. An empty forecast is what "no data for
+        # this allergen" looks like here.
+        if self._is_stale and not forecast:
             attrs["data_stale"] = True
             attrs["stale_since"] = self._stale_since
         return attrs

--- a/docs/entity_naming.md
+++ b/docs/entity_naming.md
@@ -18,8 +18,8 @@ For an allergen the slug comes from the allergen's latin name, looked up in
 accepts both genus-only and genus-plus-species spellings. When the API sends no
 latin name at all, which happens when it puts the genus in the display name
 instead (`poll_title` "Artemisia"), the display name is looked up in the same
-map. That lookup runs only once the latin lookup and the English language block
-have both come up empty, so it cannot outrank them. If a latin name is not
+map. That lookup is gated on the missing latin name, so a latin name the API
+did send stays authoritative even when no map knows it. If a latin name is not
 in the map, the code falls back to the English language block and then to the
 name the API sent in the configured language. It also logs a warning asking for
 a bug report, so a new allergen surfaces instead of quietly producing a

--- a/docs/entity_naming.md
+++ b/docs/entity_naming.md
@@ -15,7 +15,11 @@ matching properties on `AllergyRiskSensor` and `AllergyRiskHourlySensor`).
 For an allergen the slug comes from the allergen's latin name, looked up in
 `LATIN_TO_ENGLISH_NAME` (`sensor.py`) and slugified: `Fraxinus` becomes `ash`,
 `Poaceae` becomes `grasses`. The map covers all 22 allergens the API returns and
-accepts both genus-only and genus-plus-species spellings. If a latin name is not
+accepts both genus-only and genus-plus-species spellings. When the API sends no
+latin name at all, which happens when it puts the genus in the display name
+instead (`poll_title` "Artemisia"), the display name is looked up in the same
+map. That lookup runs only once the latin lookup and the English language block
+have both come up empty, so it cannot outrank them. If a latin name is not
 in the map, the code falls back to the English language block and then to the
 name the API sent in the configured language. It also logs a warning asking for
 a bug report, so a new allergen surfaces instead of quietly producing a

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -188,6 +188,11 @@ class TestOptionsReloadConsistency:
 
 EMPTY_PAYLOAD = {"contamination": []}
 FULL_PAYLOAD = {"contamination": [{"poll_title": "Birch (Betula)"}]}
+RISK_ONLY_PAYLOAD = {
+    "contamination": [],
+    "allergyrisk": {"allergyrisk_1": 7.5},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [7.5] * 24},
+}
 
 E1 = datetime(2026, 8, 18, 6, 0, tzinfo=timezone.utc)
 E2 = datetime(2026, 8, 18, 18, 0, tzinfo=timezone.utc)
@@ -253,6 +258,33 @@ class TestEmptySince:
         await self._fetch(coordinator, FULL_PAYLOAD, E1)
         await self._fetch(coordinator, EMPTY_PAYLOAD, E2)
         assert coordinator.empty_since == E2.isoformat()
+
+    async def test_a_risk_only_response_is_not_empty(self, hass):
+        """A response with risk data carried data, whatever contamination says.
+
+        The risk sensors would otherwise report a current value while the
+        whole location advertised itself stale.
+        """
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, RISK_ONLY_PAYLOAD, E1)
+        assert coordinator.empty_since is None
+
+    async def test_a_risk_only_response_ends_an_outage(self, hass):
+        """The other side of it: such a response clears an existing mark."""
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, EMPTY_PAYLOAD, E1)
+        await self._fetch(coordinator, RISK_ONLY_PAYLOAD, E2)
+        assert coordinator.empty_since is None
+
+    async def test_every_block_empty_is_an_outage(self, hass):
+        """Only a response with nothing in any block is stale."""
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(
+            coordinator,
+            {"contamination": [], "allergyrisk": {}, "allergyrisk_hourly": {}},
+            E1,
+        )
+        assert coordinator.empty_since == E1.isoformat()
 
     async def test_a_failed_fetch_does_not_stamp_it(self, hass):
         """A fetch that never returned says nothing about the response."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -263,7 +263,7 @@ class TestEmptySince:
                 AsyncMock(return_value={"nonsense": True}),
             ),
             _frozen(E1),
+            pytest.raises(UpdateFailed),
         ):
-            with pytest.raises(UpdateFailed):
-                await coordinator._async_update_data()
+            await coordinator._async_update_data()
         assert coordinator.empty_since is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,9 +1,11 @@
 """Tests for integration setup and coordinator."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.polleninformation import (
@@ -182,3 +184,86 @@ class TestOptionsReloadConsistency:
         assert coordinator.lon == 18.0
         assert coordinator.apikey == "new-key"
         assert coordinator.update_interval == timedelta(hours=4)
+
+
+EMPTY_PAYLOAD = {"contamination": []}
+FULL_PAYLOAD = {"contamination": [{"poll_title": "Birch (Betula)"}]}
+
+E1 = datetime(2026, 8, 18, 6, 0, tzinfo=timezone.utc)
+E2 = datetime(2026, 8, 18, 18, 0, tzinfo=timezone.utc)
+
+
+def _frozen(moment):
+    return patch("custom_components.polleninformation.dt_util.now", return_value=moment)
+
+
+class TestEmptySince:
+    """The coordinator owns response-level staleness.
+
+    data_stale describes the response, not a sensor: it means the fetch
+    succeeded and carried nothing usable. Tracking it here gives every entity
+    of a location the same timestamp for the same outage.
+    """
+
+    def _make_coordinator(self, hass):
+        entry = MockConfigEntry(domain=DOMAIN, title="Test", data={})
+        entry.add_to_hass(hass)
+        return PollenInformationDataUpdateCoordinator(
+            hass, entry, 53.5, 10.0, "DE", "en", "key", timedelta(hours=8)
+        )
+
+    async def _fetch(self, coordinator, payload, moment):
+        with (
+            patch(
+                "custom_components.polleninformation.async_get_pollenat_data",
+                AsyncMock(return_value=payload),
+            ),
+            _frozen(moment),
+        ):
+            await coordinator._async_update_data()
+
+    async def test_unset_before_any_fetch(self, hass):
+        assert self._make_coordinator(hass).empty_since is None
+
+    async def test_data_leaves_it_unset(self, hass):
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, FULL_PAYLOAD, E1)
+        assert coordinator.empty_since is None
+
+    async def test_an_empty_response_stamps_it(self, hass):
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, EMPTY_PAYLOAD, E1)
+        assert coordinator.empty_since == E1.isoformat()
+
+    async def test_it_holds_for_the_duration_of_one_outage(self, hass):
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, EMPTY_PAYLOAD, E1)
+        await self._fetch(coordinator, EMPTY_PAYLOAD, E2)
+        assert coordinator.empty_since == E1.isoformat()
+
+    async def test_recovery_clears_it(self, hass):
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, EMPTY_PAYLOAD, E1)
+        await self._fetch(coordinator, FULL_PAYLOAD, E2)
+        assert coordinator.empty_since is None
+
+    async def test_a_later_outage_is_stamped_afresh(self, hass):
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, EMPTY_PAYLOAD, E1)
+        await self._fetch(coordinator, FULL_PAYLOAD, E1)
+        await self._fetch(coordinator, EMPTY_PAYLOAD, E2)
+        assert coordinator.empty_since == E2.isoformat()
+
+    async def test_a_failed_fetch_does_not_stamp_it(self, hass):
+        """A fetch that never returned says nothing about the response."""
+        coordinator = self._make_coordinator(hass)
+        with (
+            patch(
+                "custom_components.polleninformation.async_get_pollenat_data",
+                AsyncMock(return_value={"nonsense": True}),
+            ),
+            _frozen(E1),
+        ):
+            with pytest.raises(UpdateFailed):
+                await coordinator._async_update_data()
+        assert coordinator.empty_since is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1691,49 +1691,51 @@ BINOMIAL_NAME_RESPONSE = {
 }
 
 
+async def _recreate_stale(hass, lang, unique_id, language_block=None):
+    """Run setup against an empty response so a registry entity is recreated."""
+    entry = _make_entry(lang)
+    entry.add_to_hass(hass)
+    ent_reg = er.async_get(hass)
+    ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        unique_id,
+        suggested_object_id=unique_id,
+        config_entry=entry,
+    )
+    entities = await _setup_entities(
+        hass,
+        lang,
+        entry=entry,
+        response=EMPTY_RESPONSE,
+        language_block=language_block or EMPTY_LANGUAGE_BLOCK,
+    )
+    return _by_type(entities, PolleninformationSensor)
+
+
 class TestStaleSensorRecovery:
     """A sensor recreated during an empty response must recover on any language."""
 
-    async def _recreate(self, hass, lang, unique_id):
-        entry = _make_entry(lang)
-        entry.add_to_hass(hass)
-        ent_reg = er.async_get(hass)
-        ent_reg.async_get_or_create(
-            "sensor",
-            DOMAIN,
-            unique_id,
-            suggested_object_id=unique_id,
-            config_entry=entry,
-        )
-        entities = await _setup_entities(
-            hass,
-            lang,
-            entry=entry,
-            response=EMPTY_RESPONSE,
-            language_block=EMPTY_LANGUAGE_BLOCK,
-        )
-        return _by_type(entities, PolleninformationSensor)
-
     async def test_german_sensor_recovers_on_localized_poll_title(self, hass):
-        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor = await _recreate_stale(hass, "de", "polleninformation_hamburg_birch")
         sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
         assert sensor.native_value == "hoch"
 
     async def test_german_forecast_recovers(self, hass):
-        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor = await _recreate_stale(hass, "de", "polleninformation_hamburg_birch")
         sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
         forecast = sensor.extra_state_attributes["forecast"]
         assert [day["level"] for day in forecast] == [3, 2, 1, 0]
 
     async def test_english_dock_sorrel_recovers(self, hass):
-        sensor = await self._recreate(
+        sensor = await _recreate_stale(
             hass, "en", "polleninformation_hamburg_dock_sorrel"
         )
         sensor.coordinator.data = ENGLISH_DOCK_SORREL_RESPONSE
         assert sensor.native_value == "moderate"
 
     async def test_latin_name_is_derived_from_the_slug(self, hass):
-        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor = await _recreate_stale(hass, "de", "polleninformation_hamburg_birch")
         sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
         assert sensor.extra_state_attributes["name_la"] == "Betula"
 
@@ -1744,7 +1746,7 @@ class TestStaleSensorRecovery:
         whole poll_title; its own name is "Mugwort", so only the map lookup on
         the display name itself can identify the entry.
         """
-        sensor = await self._recreate(hass, "es", "polleninformation_hamburg_mugwort")
+        sensor = await _recreate_stale(hass, "es", "polleninformation_hamburg_mugwort")
         sensor.coordinator.data = LATIN_GENUS_AS_NAME_RESPONSE
         assert sensor.native_value == "bajo"
 
@@ -1755,7 +1757,7 @@ class TestStaleSensorRecovery:
         again when the API recovers, so it has to be derived from whether the
         allergen was actually found.
         """
-        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor = await _recreate_stale(hass, "de", "polleninformation_hamburg_birch")
         sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
         attrs = sensor.extra_state_attributes
         assert "data_stale" not in attrs
@@ -1763,7 +1765,7 @@ class TestStaleSensorRecovery:
 
     async def test_stale_flag_stays_while_the_allergen_is_missing(self, hass):
         """Data for other allergens only is still no data for this one."""
-        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor = await _recreate_stale(hass, "de", "polleninformation_hamburg_birch")
         sensor.coordinator.data = LATIN_GENUS_AS_NAME_RESPONSE
         attrs = sensor.extra_state_attributes
         assert attrs["data_stale"] is True
@@ -1775,7 +1777,7 @@ class TestStaleSensorRecovery:
         Counting words would reject it, but it is a latin name the map knows,
         so a stale tree of heaven sensor must pick it up like any other.
         """
-        sensor = await self._recreate(
+        sensor = await _recreate_stale(
             hass, "de", "polleninformation_hamburg_tree_of_heaven"
         )
         sensor.coordinator.data = BINOMIAL_NAME_RESPONSE
@@ -1788,7 +1790,7 @@ class TestStaleSensorRecovery:
         matching it to the ragweed sensor would be a guess, not an
         identification.
         """
-        sensor = await self._recreate(hass, "es", "polleninformation_hamburg_ragweed")
+        sensor = await _recreate_stale(hass, "es", "polleninformation_hamburg_ragweed")
         sensor.coordinator.data = GENUS_PREFIXED_NAME_RESPONSE
         assert sensor.native_value is None
 
@@ -2056,3 +2058,4 @@ class TestPartialDataIsNotFreshData:
         assert attrs["forecast"]
         assert attrs["data_stale"] is True
         assert attrs["stale_since"] == T1.isoformat()
+

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1661,6 +1661,21 @@ ENGLISH_DOCK_SORREL_RESPONSE = {
 }
 
 
+GENUS_PREFIXED_NAME_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Ambrosia hojas",
+            "contamination_1": 2,
+            "contamination_2": 2,
+            "contamination_3": 1,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {},
+    "allergyrisk_hourly": {},
+}
+
+
 class TestStaleSensorRecovery:
     """A sensor recreated during an empty response must recover on any language."""
 
@@ -1739,3 +1754,13 @@ class TestStaleSensorRecovery:
         assert attrs["data_stale"] is True
         assert attrs["stale_since"] is not None
 
+    async def test_a_two_word_name_starting_with_a_genus_does_not_match(self, hass):
+        """The display-name lookup holds only for a name that IS the genus.
+
+        "Ambrosia hojas" is prose that happens to start with a latin genus, so
+        matching it to the ragweed sensor would be a guess, not an
+        identification.
+        """
+        sensor = await self._recreate(hass, "es", "polleninformation_hamburg_ragweed")
+        sensor.coordinator.data = GENUS_PREFIXED_NAME_RESPONSE
+        assert sensor.native_value is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1764,6 +1764,9 @@ class TestStaleSensorRecovery:
         sensor.coordinator.empty_since = None
         attrs = sensor.extra_state_attributes
         assert sensor.native_value is None
+        # No value means no value: nothing of an earlier reading is kept, so
+        # the empty forecast is what says the sensor has nothing to show.
+        assert attrs["forecast"] == []
         assert "data_stale" not in attrs
         assert "stale_since" not in attrs
 
@@ -1796,8 +1799,8 @@ class TestEveryEntityReportsTheSameOutage:
 
     The per-outage semantics themselves are the coordinator's, and are tested
     in test_init.py. What matters here is that an entity reports the
-    coordinator's value rather than one of its own: a card reading
-    stale_since off whichever entity it reaches first must get one answer.
+    coordinator's value rather than one of its own: anything reading
+    stale_since off an arbitrary entity of the location gets one answer.
     """
 
     async def _entities_during_an_outage(self, hass):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1764,3 +1764,104 @@ class TestStaleSensorRecovery:
         sensor = await self._recreate(hass, "es", "polleninformation_hamburg_ragweed")
         sensor.coordinator.data = GENUS_PREFIXED_NAME_RESPONSE
         assert sensor.native_value is None
+
+
+T1 = datetime(2026, 8, 18, 6, 0, tzinfo=timezone.utc)
+T2 = datetime(2026, 8, 18, 18, 0, tzinfo=timezone.utc)
+
+
+def _frozen(moment):
+    """Patch the sensor module's clock to a fixed moment."""
+    return patch(
+        "custom_components.polleninformation.sensor.dt_util.now",
+        return_value=moment,
+    )
+
+
+class TestStaleSinceFollowsTheCurrentOutage:
+    """stale_since must date the outage being reported, not the first one.
+
+    The timestamp is a constructor value, and setup does not run again when
+    the API recovers, so a second outage would otherwise republish the first
+    outage's timestamp and appear to have lasted for the whole gap.
+    """
+
+    async def _recreated_at(self, hass, moment):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_birch",
+            suggested_object_id="polleninformation_hamburg_birch",
+            config_entry=entry,
+        )
+        with _frozen(moment):
+            entities = await _setup_entities(
+                hass,
+                "de",
+                entry=entry,
+                response=EMPTY_RESPONSE,
+                language_block=EMPTY_LANGUAGE_BLOCK,
+            )
+        return _by_type(entities, PolleninformationSensor)
+
+    async def test_second_outage_gets_a_fresh_timestamp(self, hass):
+        sensor = await self._recreated_at(hass, T1)
+        with _frozen(T1):
+            assert sensor.extra_state_attributes["stale_since"] == T1.isoformat()
+
+        sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
+        with _frozen(T1):
+            assert "stale_since" not in sensor.extra_state_attributes
+
+        sensor.coordinator.data = EMPTY_RESPONSE
+        with _frozen(T2):
+            attrs = sensor.extra_state_attributes
+        assert attrs["data_stale"] is True
+        assert attrs["stale_since"] == T2.isoformat()
+
+    async def test_the_timestamp_does_not_drift_across_reads(self, hass):
+        """The property is read more than once per update."""
+        sensor = await self._recreated_at(hass, T1)
+        with _frozen(T1):
+            first = sensor.extra_state_attributes["stale_since"]
+        with _frozen(T2):
+            second = sensor.extra_state_attributes["stale_since"]
+        assert first == second == T1.isoformat()
+
+    @pytest.mark.parametrize(
+        ("cls", "key", "payload"),
+        [
+            (AllergyRiskSensor, "allergyrisk", {"allergyrisk_1": 5.0}),
+            (
+                AllergyRiskHourlySensor,
+                "allergyrisk_hourly",
+                {"allergyrisk_hourly_1": [5.0] * 24},
+            ),
+        ],
+    )
+    async def test_risk_sensors_date_the_current_outage(self, cls, key, payload):
+        """The risk sensors froze the same timestamp for the same reason."""
+        coordinator = _make_coordinator({key: {}})
+        sensor = cls(
+            coordinator=coordinator,
+            levels_current=["none", "low", "moderate", "high", "very high"],
+            location_slug="hamburg",
+            location_title="Hamburg",
+            is_stale=True,
+            stale_since=T1.isoformat(),
+        )
+        with _frozen(T1):
+            assert sensor.extra_state_attributes["stale_since"] == T1.isoformat()
+
+        coordinator.data = {key: payload}
+        with _frozen(T1):
+            assert "stale_since" not in sensor.extra_state_attributes
+
+        coordinator.data = {key: {}}
+        with _frozen(T2):
+            attrs = sensor.extra_state_attributes
+        assert attrs["data_stale"] is True
+        assert attrs["stale_since"] == T2.isoformat()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1638,3 +1638,14 @@ class TestStaleSensorRecovery:
         sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
         sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
         assert sensor.extra_state_attributes["name_la"] == "Betula"
+
+    async def test_recovers_when_the_latin_genus_is_the_display_name(self, hass):
+        """Issue #71 arrives without parentheses, so there is no latin to read.
+
+        A stale mugwort sensor on a Spanish install sees "Artemisia" as the
+        whole poll_title; its own name is "Mugwort", so only the map lookup on
+        the display name itself can identify the entry.
+        """
+        sensor = await self._recreate(hass, "es", "polleninformation_hamburg_mugwort")
+        sensor.coordinator.data = LATIN_GENUS_AS_NAME_RESPONSE
+        assert sensor.native_value is not None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1945,3 +1945,114 @@ class TestGenusPrefixedNameOnTheSetupPath:
             )
             is None
         )
+
+
+class TestPartialDataIsNotFreshData:
+    """A sensor with no readable value must not report itself fresh.
+
+    A risk block that is present but carries nothing usable for right now,
+    only a later day, a null, or an empty hourly list, left native_value
+    unknown while clearing the stale marker.
+    """
+
+    LEVELS = ["none", "low", "moderate", "high", "very high"]
+
+    def _risk(self, cls, data, is_stale=True):
+        return cls(
+            coordinator=_make_coordinator(data),
+            levels_current=self.LEVELS,
+            location_slug="hamburg",
+            location_title="Hamburg",
+            is_stale=is_stale,
+            stale_since=T1.isoformat(),
+        )
+
+    @pytest.mark.parametrize(
+        ("cls", "data"),
+        [
+            (AllergyRiskSensor, {"allergyrisk": {"allergyrisk_2": 5.0}}),
+            (AllergyRiskSensor, {"allergyrisk": {"allergyrisk_1": None}}),
+            (
+                AllergyRiskHourlySensor,
+                {"allergyrisk_hourly": {"allergyrisk_hourly_2": [5.0] * 24}},
+            ),
+            (AllergyRiskHourlySensor, {"allergyrisk_hourly": {}}),
+            (
+                AllergyRiskHourlySensor,
+                {"allergyrisk_hourly": {"allergyrisk_hourly_1": []}},
+            ),
+        ],
+    )
+    def test_partial_risk_data_stays_stale(self, cls, data):
+        sensor = self._risk(cls, data)
+        with _frozen(T2):
+            attrs = sensor.extra_state_attributes
+        assert sensor.native_value is None
+        assert attrs["data_stale"] is True
+        assert attrs["stale_since"] == T1.isoformat()
+
+    @pytest.mark.parametrize(
+        ("cls", "data"),
+        [
+            (AllergyRiskSensor, {"allergyrisk": {"allergyrisk_1": 0.0}}),
+            (
+                AllergyRiskHourlySensor,
+                {"allergyrisk_hourly": {"allergyrisk_hourly_1": [0.0] * 24}},
+            ),
+        ],
+    )
+    def test_a_zero_reading_is_a_reading(self, cls, data):
+        """No risk at all is a real value, not a missing one."""
+        sensor = self._risk(cls, data)
+        with _frozen(T2):
+            attrs = sensor.extra_state_attributes
+        assert sensor.native_value == "none"
+        assert "data_stale" not in attrs
+        assert "stale_since" not in attrs
+
+    def test_repeated_partial_responses_keep_the_first_timestamp(self):
+        """Flickering between partial shapes is one outage, not several."""
+        sensor = self._risk(
+            AllergyRiskSensor, {"allergyrisk": {"allergyrisk_2": 5.0}}, is_stale=False
+        )
+        with _frozen(T1):
+            first = sensor.extra_state_attributes["stale_since"]
+        sensor.coordinator.data = {"allergyrisk": {"allergyrisk_1": None}}
+        with _frozen(T2):
+            second = sensor.extra_state_attributes["stale_since"]
+        assert first == second == T1.isoformat()
+
+    def test_an_unusable_pollen_level_is_not_fresh(self):
+        """The pollen sensor answers the same question the same way.
+
+        A level outside the level names leaves native_value unknown while the
+        forecast is still built, so a forecast alone cannot stand for a
+        reading.
+        """
+        sensor = PolleninformationSensor(
+            coordinator=_make_coordinator(
+                {
+                    "contamination": [
+                        {"poll_title": "Birke (Betula)", "contamination_1": 9}
+                    ]
+                }
+            ),
+            sensor_type="pollen",
+            allergen_name="Birke",
+            allergen_en="birch",
+            allergen_slug="birch",
+            allergen_latin="Betula",
+            levels_current=self.LEVELS,
+            levels_en=self.LEVELS,
+            location_slug="hamburg",
+            location_title="Hamburg",
+            icon="mdi:tree-outline",
+            is_stale=True,
+            stale_since=T1.isoformat(),
+        )
+        with _frozen(T2):
+            attrs = sensor.extra_state_attributes
+        assert sensor.native_value is None
+        assert attrs["forecast"]
+        assert attrs["data_stale"] is True
+        assert attrs["stale_since"] == T1.isoformat()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1633,3 +1633,8 @@ class TestStaleSensorRecovery:
         )
         sensor.coordinator.data = ENGLISH_DOCK_SORREL_RESPONSE
         assert sensor.native_value == "moderate"
+
+    async def test_latin_name_is_derived_from_the_slug(self, hass):
+        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
+        assert sensor.extra_state_attributes["name_la"] == "Betula"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1558,3 +1558,78 @@ class TestStateMachineCollision:
             ent_reg.async_get_entity_id("sensor", DOMAIN, DAILY_UNIQUE_ID)
             == "sensor.polleninformation_hamburg_allergierisiko"
         )
+
+
+# --- Stale sensors recreated from the registry (issue #73) ---
+
+
+EMPTY_RESPONSE = {"contamination": [], "allergyrisk": {}, "allergyrisk_hourly": {}}
+
+GERMAN_BIRCH_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Birke (Betula)",
+            "contamination_1": 3,
+            "contamination_2": 2,
+            "contamination_3": 1,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {},
+    "allergyrisk_hourly": {},
+}
+
+ENGLISH_DOCK_SORREL_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Dock/Sorrel (Rumex)",
+            "contamination_1": 2,
+            "contamination_2": 2,
+            "contamination_3": 1,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {},
+    "allergyrisk_hourly": {},
+}
+
+
+class TestStaleSensorRecovery:
+    """A sensor recreated during an empty response must recover on any language."""
+
+    async def _recreate(self, hass, lang, unique_id):
+        entry = _make_entry(lang)
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            unique_id,
+            suggested_object_id=unique_id,
+            config_entry=entry,
+        )
+        entities = await _setup_entities(
+            hass,
+            lang,
+            entry=entry,
+            response=EMPTY_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        return _by_type(entities, PolleninformationSensor)
+
+    async def test_german_sensor_recovers_on_localized_poll_title(self, hass):
+        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
+        assert sensor.native_value == "hoch"
+
+    async def test_german_forecast_recovers(self, hass):
+        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
+        assert len(sensor.extra_state_attributes["forecast"]) == 4
+
+    async def test_english_dock_sorrel_recovers(self, hass):
+        sensor = await self._recreate(
+            hass, "en", "polleninformation_hamburg_dock_sorrel"
+        )
+        sensor.coordinator.data = ENGLISH_DOCK_SORREL_RESPONSE
+        assert sensor.native_value == "moderate"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -9,6 +9,9 @@ import pytest
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.polleninformation import (
+    PollenInformationDataUpdateCoordinator,
+)
 from custom_components.polleninformation.const import DOMAIN
 from custom_components.polleninformation.sensor import (
     ALLERGEN_ICON_MAP,
@@ -120,23 +123,33 @@ def _frozen(moment):
     )
 
 
+def _frozen_util(moment):
+    """Patch the coordinator module's clock to a fixed moment."""
+    return patch("custom_components.polleninformation.dt_util.now", return_value=moment)
+
+
 def _make_coordinator(
     data, last_updated=None, last_update_success=True, empty_since=_UNSET
 ):
     """Create a mock coordinator with the given data.
 
-    empty_since follows the rule the real coordinator applies in
-    _track_empty_response, so a response with no contamination looks stale
-    here too. A test that swaps .data afterwards sets it explicitly, which is
-    what the coordinator would do on the next refresh.
+    empty_since is set by the real coordinator method rather than by a copy
+    of its rule, so these tests cannot stay green against a production rule
+    that has changed. A test that swaps .data afterwards sets it explicitly,
+    which is what the next refresh would do.
     """
     coordinator = MagicMock()
     coordinator.data = data
     coordinator.last_updated = last_updated or datetime.now(timezone.utc)
     coordinator.last_update_success = last_update_success
+    coordinator.empty_since = None
     if empty_since is _UNSET:
-        empty_since = None if (data or {}).get("contamination") else T1.isoformat()
-    coordinator.empty_since = empty_since
+        with _frozen_util(T1):
+            PollenInformationDataUpdateCoordinator._track_empty_response(
+                coordinator, data or {}
+            )
+    else:
+        coordinator.empty_since = empty_since
     return coordinator
 
 
@@ -1920,6 +1933,29 @@ class TestAMissingReadingIsUnknownNotStale:
         assert sensor.native_value is None
         assert attrs["data_stale"] is True
         assert attrs["stale_since"] == T1.isoformat()
+
+    @pytest.mark.parametrize(
+        ("cls", "block"),
+        [
+            (AllergyRiskSensor, {"allergyrisk": {"allergyrisk_1": 7.5}}),
+            (
+                AllergyRiskHourlySensor,
+                {"allergyrisk_hourly": {"allergyrisk_hourly_1": [7.5] * 24}},
+            ),
+        ],
+    )
+    def test_a_risk_only_response_is_not_an_outage(self, cls, block):
+        """A reading and a stale marker must never appear together.
+
+        contamination can be empty while the risk blocks carry data, and a
+        sensor reporting a current level while advertising data_stale is the
+        contradiction the response-level definition exists to prevent.
+        """
+        sensor = self._risk(cls, block, contamination=[])
+        attrs = sensor.extra_state_attributes
+        assert sensor.native_value == "high"
+        assert "data_stale" not in attrs
+        assert "stale_since" not in attrs
 
     def test_an_unusable_pollen_level_is_unknown_without_a_marker(self):
         """A level the level names do not cover leaves no value either."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1893,3 +1893,55 @@ class TestStaleSinceFollowsTheCurrentOutage:
         assert attrs["data_stale"] is True
         assert attrs["stale_since"] == T2.isoformat()
 
+
+class TestGenusPrefixedNameOnTheSetupPath:
+    """Prose that begins with a latin genus must not be taken for that genus.
+
+    The setup path owns the entity_id and queues the rename, so resolving
+    "Ambrosia hojas" to ragweed there does more than mis-match a sensor.
+    """
+
+    async def _setup(self, hass, entry=None):
+        return await _setup_entities(
+            hass,
+            "es",
+            entry=entry,
+            response=GENUS_PREFIXED_NAME_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+
+    async def test_does_not_take_the_ragweed_slug(self, hass):
+        entities = await self._setup(hass)
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+        assert "polleninformation_hamburg_ragweed" not in unique_ids
+        assert "polleninformation_hamburg_ambrosia_hojas" in unique_ids
+
+    async def test_does_not_report_the_prose_as_a_latin_name(self, hass):
+        entities = await self._setup(hass)
+        sensor = _by_type(entities, PolleninformationSensor)
+        assert sensor.extra_state_attributes["name_la"] == ""
+
+    async def test_queues_no_rename_onto_ragweed(self, hass):
+        entry = _make_entry("es")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_ambrosia_hojas",
+            suggested_object_id="polleninformation_hamburg_ambrosia_hojas",
+            config_entry=entry,
+        )
+        await self._setup(hass, entry=entry)
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_ambrosia_hojas"
+            )
+            == "sensor.polleninformation_hamburg_ambrosia_hojas"
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_ragweed"
+            )
+            is None
+        )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -106,12 +106,37 @@ class TestExtractAllergenSlug:
 # --- Sensor class tests ---
 
 
-def _make_coordinator(data, last_updated=None, last_update_success=True):
-    """Create a mock coordinator with the given data."""
+T1 = datetime(2026, 8, 18, 6, 0, tzinfo=timezone.utc)
+T2 = datetime(2026, 8, 18, 18, 0, tzinfo=timezone.utc)
+
+_UNSET = object()
+
+
+def _frozen(moment):
+    """Patch the sensor module's clock to a fixed moment."""
+    return patch(
+        "custom_components.polleninformation.sensor.dt_util.now",
+        return_value=moment,
+    )
+
+
+def _make_coordinator(
+    data, last_updated=None, last_update_success=True, empty_since=_UNSET
+):
+    """Create a mock coordinator with the given data.
+
+    empty_since follows the rule the real coordinator applies in
+    _track_empty_response, so a response with no contamination looks stale
+    here too. A test that swaps .data afterwards sets it explicitly, which is
+    what the coordinator would do on the next refresh.
+    """
     coordinator = MagicMock()
     coordinator.data = data
     coordinator.last_updated = last_updated or datetime.now(timezone.utc)
     coordinator.last_update_success = last_update_success
+    if empty_since is _UNSET:
+        empty_since = None if (data or {}).get("contamination") else T1.isoformat()
+    coordinator.empty_since = empty_since
     return coordinator
 
 
@@ -165,12 +190,10 @@ class TestPolleninformationSensor:
             location_slug="hamburg",
             location_title="Hamburg",
             icon="mdi:tree-outline",
-            is_stale=True,
-            stale_since="2026-03-25T12:00:00",
         )
         attrs = sensor.extra_state_attributes
         assert attrs["data_stale"] is True
-        assert attrs["stale_since"] == "2026-03-25T12:00:00"
+        assert attrs["stale_since"] == T1.isoformat()
 
     def test_available_when_success(self, mock_api_response):
         sensor = self._make_sensor(
@@ -206,7 +229,6 @@ class TestAllergyRiskSensor:
             levels_current=["none", "low", "moderate", "high", "very high"],
             location_slug="hamburg",
             location_title="Hamburg",
-            is_stale=True,
         )
         assert sensor.native_value is None
 
@@ -217,9 +239,8 @@ class TestAllergyRiskSensor:
             levels_current=["none", "low", "moderate", "high", "very high"],
             location_slug="hamburg",
             location_title="Hamburg",
-            is_stale=True,
         )
-        # Even though created as stale, fresh coordinator data is used
+        # A sensor created during an outage still reads fresh data
         assert sensor.native_value == "moderate"
 
     def test_attributes_forecast(self, mock_api_response):
@@ -1723,26 +1744,28 @@ class TestStaleSensorRecovery:
         sensor.coordinator.data = LATIN_GENUS_AS_NAME_RESPONSE
         assert sensor.native_value == "bajo"
 
-    async def test_stale_flag_clears_once_the_allergen_is_found(self, hass):
-        """A recovered sensor must stop claiming its data is stale.
-
-        The flag is set in the constructor and async_setup_entry does not run
-        again when the API recovers, so it has to be derived from whether the
-        allergen was actually found.
-        """
+    async def test_the_marker_clears_when_the_response_carries_data(self, hass):
+        """The marker describes the response, so a response ends it."""
         sensor = await _recreate_stale(hass, "de", "polleninformation_hamburg_birch")
         sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
+        sensor.coordinator.empty_since = None
         attrs = sensor.extra_state_attributes
         assert "data_stale" not in attrs
         assert "stale_since" not in attrs
 
-    async def test_stale_flag_stays_while_the_allergen_is_missing(self, hass):
-        """Data for other allergens only is still no data for this one."""
+    async def test_an_allergen_missing_from_a_healthy_response_is_unknown(self, hass):
+        """One absent allergen is not an outage.
+
+        The response carried data, so nothing about it is stale. This sensor
+        simply has no reading, which Home Assistant expresses as unknown.
+        """
         sensor = await _recreate_stale(hass, "de", "polleninformation_hamburg_birch")
         sensor.coordinator.data = LATIN_GENUS_AS_NAME_RESPONSE
+        sensor.coordinator.empty_since = None
         attrs = sensor.extra_state_attributes
-        assert attrs["data_stale"] is True
-        assert attrs["stale_since"] is not None
+        assert sensor.native_value is None
+        assert "data_stale" not in attrs
+        assert "stale_since" not in attrs
 
     async def test_recovers_when_the_display_name_is_a_binomial_key(self, hass):
         """A binomial key in the latin map: "Ailanthus altissima".
@@ -1768,186 +1791,84 @@ class TestStaleSensorRecovery:
         assert sensor.native_value is None
 
 
-T1 = datetime(2026, 8, 18, 6, 0, tzinfo=timezone.utc)
-T2 = datetime(2026, 8, 18, 18, 0, tzinfo=timezone.utc)
+class TestEveryEntityReportsTheSameOutage:
+    """The timestamp belongs to the response, so siblings must agree on it.
 
-
-def _frozen(moment):
-    """Patch the sensor module's clock to a fixed moment."""
-    return patch(
-        "custom_components.polleninformation.sensor.dt_util.now",
-        return_value=moment,
-    )
-
-
-class TestStaleSinceFollowsTheCurrentOutage:
-    """stale_since must date the outage being reported, not the first one.
-
-    The timestamp is a constructor value, and setup does not run again when
-    the API recovers, so a second outage would otherwise republish the first
-    outage's timestamp and appear to have lasted for the whole gap.
+    The per-outage semantics themselves are the coordinator's, and are tested
+    in test_init.py. What matters here is that an entity reports the
+    coordinator's value rather than one of its own: a card reading
+    stale_since off whichever entity it reaches first must get one answer.
     """
 
-    async def _recreated_at(self, hass, moment):
+    async def _entities_during_an_outage(self, hass):
         entry = _make_entry("de")
         entry.add_to_hass(hass)
         ent_reg = er.async_get(hass)
-        ent_reg.async_get_or_create(
-            "sensor",
-            DOMAIN,
-            "polleninformation_hamburg_birch",
-            suggested_object_id="polleninformation_hamburg_birch",
-            config_entry=entry,
-        )
-        with _frozen(moment):
-            entities = await _setup_entities(
-                hass,
-                "de",
-                entry=entry,
-                response=EMPTY_RESPONSE,
-                language_block=EMPTY_LANGUAGE_BLOCK,
+        for slug in ("birch", "alder", "allergy_risk", "allergy_risk_hourly"):
+            ent_reg.async_get_or_create(
+                "sensor",
+                DOMAIN,
+                f"polleninformation_hamburg_{slug}",
+                suggested_object_id=f"polleninformation_hamburg_{slug}",
+                config_entry=entry,
             )
-        return _by_type(entities, PolleninformationSensor)
-
-    async def test_second_outage_gets_a_fresh_timestamp(self, hass):
-        sensor = await self._recreated_at(hass, T1)
-        with _frozen(T1):
-            assert sensor.extra_state_attributes["stale_since"] == T1.isoformat()
-
-        sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
-        with _frozen(T1):
-            assert "stale_since" not in sensor.extra_state_attributes
-
-        sensor.coordinator.data = EMPTY_RESPONSE
-        with _frozen(T2):
-            attrs = sensor.extra_state_attributes
-        assert attrs["data_stale"] is True
-        assert attrs["stale_since"] == T2.isoformat()
-
-    async def test_the_timestamp_does_not_drift_across_reads(self, hass):
-        """The property is read more than once per update."""
-        sensor = await self._recreated_at(hass, T1)
-        with _frozen(T1):
-            first = sensor.extra_state_attributes["stale_since"]
-        with _frozen(T2):
-            second = sensor.extra_state_attributes["stale_since"]
-        assert first == second == T1.isoformat()
-
-    @pytest.mark.parametrize(
-        ("cls", "key", "payload"),
-        [
-            (AllergyRiskSensor, "allergyrisk", {"allergyrisk_1": 5.0}),
-            (
-                AllergyRiskHourlySensor,
-                "allergyrisk_hourly",
-                {"allergyrisk_hourly_1": [5.0] * 24},
-            ),
-        ],
-    )
-    async def test_risk_sensors_date_the_current_outage(self, cls, key, payload):
-        """The risk sensors froze the same timestamp for the same reason."""
-        coordinator = _make_coordinator({key: {}})
-        sensor = cls(
-            coordinator=coordinator,
-            levels_current=["none", "low", "moderate", "high", "very high"],
-            location_slug="hamburg",
-            location_title="Hamburg",
-            is_stale=True,
-            stale_since=T1.isoformat(),
-        )
-        with _frozen(T1):
-            assert sensor.extra_state_attributes["stale_since"] == T1.isoformat()
-
-        coordinator.data = {key: payload}
-        with _frozen(T1):
-            assert "stale_since" not in sensor.extra_state_attributes
-
-        coordinator.data = {key: {}}
-        with _frozen(T2):
-            attrs = sensor.extra_state_attributes
-        assert attrs["data_stale"] is True
-        assert attrs["stale_since"] == T2.isoformat()
-
-
-class TestGenusPrefixedNameOnTheSetupPath:
-    """Prose that begins with a latin genus must not be taken for that genus.
-
-    The setup path owns the entity_id and queues the rename, so resolving
-    "Ambrosia hojas" to ragweed there does more than mis-match a sensor.
-    """
-
-    async def _setup(self, hass, entry=None):
         return await _setup_entities(
             hass,
-            "es",
+            "de",
             entry=entry,
-            response=GENUS_PREFIXED_NAME_RESPONSE,
+            response=EMPTY_RESPONSE,
             language_block=EMPTY_LANGUAGE_BLOCK,
         )
 
-    async def test_does_not_take_the_ragweed_slug(self, hass):
-        entities = await self._setup(hass)
-        unique_ids = {e.unique_id for e in entities if e.unique_id}
-        assert "polleninformation_hamburg_ragweed" not in unique_ids
-        assert "polleninformation_hamburg_ambrosia_hojas" in unique_ids
+    async def test_all_sensor_kinds_report_one_timestamp(self, hass):
+        entities = await self._entities_during_an_outage(hass)
+        assert len(entities) == 4
+        stamps = {e.extra_state_attributes["stale_since"] for e in entities}
+        assert stamps == {T1.isoformat()}
+        assert all(e.extra_state_attributes["data_stale"] is True for e in entities)
 
-    async def test_does_not_report_the_prose_as_a_latin_name(self, hass):
-        entities = await self._setup(hass)
-        sensor = _by_type(entities, PolleninformationSensor)
-        assert sensor.extra_state_attributes["name_la"] == ""
-
-    async def test_queues_no_rename_onto_ragweed(self, hass):
-        entry = _make_entry("es")
-        entry.add_to_hass(hass)
-        ent_reg = er.async_get(hass)
-        ent_reg.async_get_or_create(
-            "sensor",
-            DOMAIN,
-            "polleninformation_hamburg_ambrosia_hojas",
-            suggested_object_id="polleninformation_hamburg_ambrosia_hojas",
-            config_entry=entry,
-        )
-        await self._setup(hass, entry=entry)
-        assert (
-            ent_reg.async_get_entity_id(
-                "sensor", DOMAIN, "polleninformation_hamburg_ambrosia_hojas"
-            )
-            == "sensor.polleninformation_hamburg_ambrosia_hojas"
-        )
-        assert (
-            ent_reg.async_get_entity_id(
-                "sensor", DOMAIN, "polleninformation_hamburg_ragweed"
-            )
-            is None
-        )
+    async def test_the_marker_is_absent_once_the_coordinator_clears_it(self, hass):
+        entities = await self._entities_during_an_outage(hass)
+        for entity in entities:
+            entity.coordinator.data = RAGWEED_RESPONSE
+            entity.coordinator.empty_since = None
+        for entity in entities:
+            assert "data_stale" not in entity.extra_state_attributes
 
 
 EN_LEVELS = ["none", "low", "moderate", "high", "very high"]
 
+HEALTHY_CONTAMINATION = [{"poll_title": "Birch (Betula)", "contamination_1": 1}]
 
-class TestPartialDataIsNotFreshData:
-    """A sensor with no readable value must not report itself fresh.
 
-    A risk block that is present but carries nothing usable for right now,
-    only a later day, a null, or an empty hourly list, left native_value
-    unknown while clearing the stale marker.
+class TestAMissingReadingIsUnknownNotStale:
+    """A response that carried data is never stale, however thin it is.
+
+    A risk block with nothing usable for right now, only a later day, a null,
+    or an empty hourly list, leaves the sensor without a value. That is state
+    unknown, not an outage: the fetch succeeded and the response had data.
     """
 
-    def _risk(self, cls, data, is_stale=True):
+    def _risk(self, cls, block, contamination=None):
+        data = {
+            "contamination": HEALTHY_CONTAMINATION
+            if contamination is None
+            else contamination
+        }
+        data.update(block)
         return cls(
             coordinator=_make_coordinator(data),
             levels_current=EN_LEVELS,
             location_slug="hamburg",
             location_title="Hamburg",
-            is_stale=is_stale,
-            stale_since=T1.isoformat(),
         )
 
     @pytest.mark.parametrize(
-        ("cls", "data"),
+        ("cls", "block"),
         [
             (AllergyRiskSensor, {"allergyrisk": {"allergyrisk_2": 5.0}}),
             (AllergyRiskSensor, {"allergyrisk": {"allergyrisk_1": None}}),
+            (AllergyRiskSensor, {"allergyrisk": {}}),
             (
                 AllergyRiskHourlySensor,
                 {"allergyrisk_hourly": {"allergyrisk_hourly_2": [5.0] * 24}},
@@ -1959,16 +1880,15 @@ class TestPartialDataIsNotFreshData:
             ),
         ],
     )
-    def test_partial_risk_data_stays_stale(self, cls, data):
-        sensor = self._risk(cls, data)
-        with _frozen(T2):
-            attrs = sensor.extra_state_attributes
+    def test_a_thin_risk_block_is_unknown_without_a_marker(self, cls, block):
+        sensor = self._risk(cls, block)
+        attrs = sensor.extra_state_attributes
         assert sensor.native_value is None
-        assert attrs["data_stale"] is True
-        assert attrs["stale_since"] == T1.isoformat()
+        assert "data_stale" not in attrs
+        assert "stale_since" not in attrs
 
     @pytest.mark.parametrize(
-        ("cls", "data"),
+        ("cls", "block"),
         [
             (AllergyRiskSensor, {"allergyrisk": {"allergyrisk_1": 0.0}}),
             (
@@ -1977,34 +1897,29 @@ class TestPartialDataIsNotFreshData:
             ),
         ],
     )
-    def test_a_zero_reading_is_a_reading(self, cls, data):
+    def test_a_zero_reading_is_a_reading(self, cls, block):
         """No risk at all is a real value, not a missing one."""
-        sensor = self._risk(cls, data)
-        with _frozen(T2):
-            attrs = sensor.extra_state_attributes
+        sensor = self._risk(cls, block)
         assert sensor.native_value == "none"
-        assert "data_stale" not in attrs
-        assert "stale_since" not in attrs
+        assert "data_stale" not in sensor.extra_state_attributes
 
-    def test_repeated_partial_responses_keep_the_first_timestamp(self):
-        """Flickering between partial shapes is one outage, not several."""
-        sensor = self._risk(
-            AllergyRiskSensor, {"allergyrisk": {"allergyrisk_2": 5.0}}, is_stale=False
-        )
-        with _frozen(T1):
-            first = sensor.extra_state_attributes["stale_since"]
-        sensor.coordinator.data = {"allergyrisk": {"allergyrisk_1": None}}
-        with _frozen(T2):
-            second = sensor.extra_state_attributes["stale_since"]
-        assert first == second == T1.isoformat()
+    @pytest.mark.parametrize(
+        ("cls", "block"),
+        [
+            (AllergyRiskSensor, {"allergyrisk": {}}),
+            (AllergyRiskHourlySensor, {"allergyrisk_hourly": {}}),
+        ],
+    )
+    def test_an_empty_response_still_marks_the_risk_sensors(self, cls, block):
+        """The outage itself is response level, and does reach them."""
+        sensor = self._risk(cls, block, contamination=[])
+        attrs = sensor.extra_state_attributes
+        assert sensor.native_value is None
+        assert attrs["data_stale"] is True
+        assert attrs["stale_since"] == T1.isoformat()
 
-    def test_an_unusable_pollen_level_is_not_fresh(self):
-        """The pollen sensor answers the same question the same way.
-
-        A level outside the level names leaves native_value unknown while the
-        forecast is still built, so a forecast alone cannot stand for a
-        reading.
-        """
+    def test_an_unusable_pollen_level_is_unknown_without_a_marker(self):
+        """A level the level names do not cover leaves no value either."""
         sensor = PolleninformationSensor(
             coordinator=_make_coordinator(
                 {
@@ -2023,15 +1938,11 @@ class TestPartialDataIsNotFreshData:
             location_slug="hamburg",
             location_title="Hamburg",
             icon="mdi:tree-outline",
-            is_stale=True,
-            stale_since=T1.isoformat(),
         )
-        with _frozen(T2):
-            attrs = sensor.extra_state_attributes
+        attrs = sensor.extra_state_attributes
         assert sensor.native_value is None
         assert attrs["forecast"]
-        assert attrs["data_stale"] is True
-        assert attrs["stale_since"] == T1.isoformat()
+        assert "data_stale" not in attrs
 
 
 GERMAN_LANGUAGE_BLOCK = {"poll_titles": [{"name": "Birke", "latin": "Betula"}]}

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1286,6 +1286,73 @@ class TestEnglishBlockOutranksTheDisplayName:
         )
 
 
+class TestPresentLatinIsAuthoritative:
+    """A latin name the API sent wins even when nothing can resolve it.
+
+    The same response as above, but no language block knows the latin name
+    either. The display name must still not be read as a latin genus: the API
+    said this allergen is Asteraceae, so resolving it to mugwort would name the
+    entity after a different allergen and migrate an existing one onto it.
+    """
+
+    async def _setup(self, hass, entry=None):
+        return await _setup_entities(
+            hass,
+            "de",
+            entry=entry,
+            response=UNKNOWN_LATIN_WITH_GENUS_NAME_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+
+    async def test_falls_back_to_the_configured_language_name(self, hass):
+        entities = await self._setup(hass)
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+        assert "polleninformation_hamburg_artemisia" in unique_ids
+        assert "polleninformation_hamburg_mugwort" not in unique_ids
+
+    async def test_keeps_the_latin_name_the_api_sent(self, hass):
+        entities = await self._setup(hass)
+        sensor = next(
+            e
+            for e in entities
+            if isinstance(e, PolleninformationSensor)
+            and e.unique_id == "polleninformation_hamburg_artemisia"
+        )
+        assert sensor.extra_state_attributes["name_la"] == "Asteraceae"
+
+    async def test_warns_about_the_unknown_allergen(self, hass, caplog):
+        with caplog.at_level(logging.WARNING):
+            await self._setup(hass)
+        assert [r for r in caplog.records if "Unknown allergen" in r.getMessage()]
+
+    async def test_no_rename_is_queued(self, hass):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_artemisia",
+            suggested_object_id="polleninformation_hamburg_artemisia",
+            config_entry=entry,
+        )
+
+        await self._setup(hass, entry=entry)
+
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_artemisia"
+            )
+            == "sensor.polleninformation_hamburg_artemisia"
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_mugwort"
+            )
+            is None
+        )
+
+
 # The canonical slug for every allergen, pinned. These slugs are a public
 # contract: they are the entity_id suffix, they are in every unique_id, and
 # the pollen forecast card matches on them. A change to an API display name or

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2125,3 +2125,76 @@ class TestLocalizedTitleWithoutLatin:
         )
         sensor.coordinator.data = BINOMIAL_NAME_RESPONSE
         assert sensor.native_value == "mäßig"
+
+
+MUGWORT_ENTRY = {
+    "poll_title": "Artemisia",
+    "contamination_1": 1,
+    "contamination_2": 1,
+    "contamination_3": 0,
+    "contamination_4": 0,
+}
+
+COMPOSITE_ENTRY = {
+    "poll_title": "Artemisia (Asteraceae)",
+    "contamination_1": 3,
+    "contamination_2": 2,
+    "contamination_3": 2,
+    "contamination_4": 1,
+}
+
+ASTERACEAE_LANGUAGE_BLOCK = {
+    "poll_titles": [
+        {"name": "composite family", "latin": "Asteraceae"},
+        {"name": "mugwort", "latin": "Artemisia"},
+    ]
+}
+
+
+class TestTwoEntriesSharingOneName:
+    """Two allergens can share a match key, so the name alone cannot decide.
+
+    "Artemisia (Asteraceae)" and a bare "Artemisia" resolve to different
+    slugs, but poll_title_local strips the parenthesized latin, so both
+    sensors keep "Artemisia" as their name match key.
+    """
+
+    @pytest.mark.parametrize(
+        "contamination",
+        [
+            [MUGWORT_ENTRY, COMPOSITE_ENTRY],
+            [COMPOSITE_ENTRY, MUGWORT_ENTRY],
+        ],
+        ids=["mugwort_first", "composite_first"],
+    )
+    async def test_each_sensor_reads_its_own_entry(self, hass, contamination):
+        entities = await _setup_entities(
+            hass,
+            "en",
+            response={
+                "contamination": contamination,
+                "allergyrisk": {},
+                "allergyrisk_hourly": {},
+            },
+            language_block=ASTERACEAE_LANGUAGE_BLOCK,
+        )
+        by_slug = {
+            e.unique_id: e for e in entities if isinstance(e, PolleninformationSensor)
+        }
+        mugwort = by_slug["polleninformation_hamburg_mugwort"]
+        composite = by_slug["polleninformation_hamburg_composite_family"]
+
+        assert mugwort.native_value == "low"
+        assert composite.native_value == "high"
+        assert [d["level"] for d in mugwort.extra_state_attributes["forecast"]] == [
+            1,
+            1,
+            0,
+            0,
+        ]
+        assert [d["level"] for d in composite.extra_state_attributes["forecast"]] == [
+            3,
+            2,
+            2,
+            1,
+        ]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -29,7 +29,6 @@ from custom_components.polleninformation.sensor import (
 )
 from custom_components.polleninformation.utils import slugify
 
-
 # --- Helper function tests (pure, no HA dependency) ---
 
 
@@ -1191,6 +1190,81 @@ class TestLatinGenusAsDisplayName:
         assert (
             ent_reg.async_get_entity_id(
                 "sensor", DOMAIN, "polleninformation_hamburg_artemisia"
+            )
+            is None
+        )
+
+
+# An allergen whose latin name the static map does not know, but whose display
+# name happens to be the latin genus of a different allergen. The English
+# language block knows the latin name, so it must win: the display name is only
+# a last resort.
+UNKNOWN_LATIN_WITH_GENUS_NAME_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Artemisia (Asteraceae)",
+            "contamination_1": 1,
+            "contamination_2": 0,
+            "contamination_3": 0,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+COMPOSITE_FAMILY_LANGUAGE_BLOCK = {
+    "poll_titles": [{"name": "Composite family", "latin": "Asteraceae"}]
+}
+
+
+class TestEnglishBlockOutranksTheDisplayName:
+    """The English language block wins over a display name that is a genus.
+
+    The display-name lookup exists for allergens whose latin name is missing.
+    It must not outrank the English language block, because slugging the
+    allergen from the wrong source both names the entity after a different
+    allergen and makes the migration rename an existing entity onto it.
+    """
+
+    async def _setup(self, hass, entry=None):
+        return await _setup_entities(
+            hass,
+            "de",
+            entry=entry,
+            response=UNKNOWN_LATIN_WITH_GENUS_NAME_RESPONSE,
+            language_block=COMPOSITE_FAMILY_LANGUAGE_BLOCK,
+        )
+
+    async def test_slug_comes_from_the_english_block(self, hass):
+        entities = await self._setup(hass)
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+        assert "polleninformation_hamburg_composite_family" in unique_ids
+        assert "polleninformation_hamburg_mugwort" not in unique_ids
+
+    async def test_no_rename_onto_another_allergen(self, hass):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_composite_family",
+            suggested_object_id="polleninformation_hamburg_composite_family",
+            config_entry=entry,
+        )
+
+        await self._setup(hass, entry=entry)
+
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_composite_family"
+            )
+            == "sensor.polleninformation_hamburg_composite_family"
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_mugwort"
             )
             is None
         )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1718,3 +1718,24 @@ class TestStaleSensorRecovery:
         sensor.coordinator.data = LATIN_GENUS_AS_NAME_RESPONSE
         assert sensor.native_value == "bajo"
 
+    async def test_stale_flag_clears_once_the_allergen_is_found(self, hass):
+        """A recovered sensor must stop claiming its data is stale.
+
+        The flag is set in the constructor and async_setup_entry does not run
+        again when the API recovers, so it has to be derived from whether the
+        allergen was actually found.
+        """
+        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
+        attrs = sensor.extra_state_attributes
+        assert "data_stale" not in attrs
+        assert "stale_since" not in attrs
+
+    async def test_stale_flag_stays_while_the_allergen_is_missing(self, hass):
+        """Data for other allergens only is still no data for this one."""
+        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor.coordinator.data = LATIN_GENUS_AS_NAME_RESPONSE
+        attrs = sensor.extra_state_attributes
+        assert attrs["data_stale"] is True
+        assert attrs["stale_since"] is not None
+

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1676,6 +1676,21 @@ GENUS_PREFIXED_NAME_RESPONSE = {
 }
 
 
+BINOMIAL_NAME_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Ailanthus altissima",
+            "contamination_1": 2,
+            "contamination_2": 1,
+            "contamination_3": 0,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {},
+    "allergyrisk_hourly": {},
+}
+
+
 class TestStaleSensorRecovery:
     """A sensor recreated during an empty response must recover on any language."""
 
@@ -1753,6 +1768,18 @@ class TestStaleSensorRecovery:
         attrs = sensor.extra_state_attributes
         assert attrs["data_stale"] is True
         assert attrs["stale_since"] is not None
+
+    async def test_recovers_when_the_display_name_is_a_binomial_key(self, hass):
+        """A binomial key in the latin map: "Ailanthus altissima".
+
+        Counting words would reject it, but it is a latin name the map knows,
+        so a stale tree of heaven sensor must pick it up like any other.
+        """
+        sensor = await self._recreate(
+            hass, "de", "polleninformation_hamburg_tree_of_heaven"
+        )
+        sensor.coordinator.data = BINOMIAL_NAME_RESPONSE
+        assert sensor.native_value == "mäßig"
 
     async def test_a_two_word_name_starting_with_a_genus_does_not_match(self, hass):
         """The display-name lookup holds only for a name that IS the genus.
@@ -1865,3 +1892,4 @@ class TestStaleSinceFollowsTheCurrentOutage:
             attrs = sensor.extra_state_attributes
         assert attrs["data_stale"] is True
         assert attrs["stale_since"] == T2.isoformat()
+

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1922,6 +1922,9 @@ class TestGenusPrefixedNameOnTheSetupPath:
         )
 
 
+EN_LEVELS = ["none", "low", "moderate", "high", "very high"]
+
+
 class TestPartialDataIsNotFreshData:
     """A sensor with no readable value must not report itself fresh.
 
@@ -1930,12 +1933,10 @@ class TestPartialDataIsNotFreshData:
     unknown while clearing the stale marker.
     """
 
-    LEVELS = ["none", "low", "moderate", "high", "very high"]
-
     def _risk(self, cls, data, is_stale=True):
         return cls(
             coordinator=_make_coordinator(data),
-            levels_current=self.LEVELS,
+            levels_current=EN_LEVELS,
             location_slug="hamburg",
             location_title="Hamburg",
             is_stale=is_stale,
@@ -2017,8 +2018,8 @@ class TestPartialDataIsNotFreshData:
             allergen_en="birch",
             allergen_slug="birch",
             allergen_latin="Betula",
-            levels_current=self.LEVELS,
-            levels_en=self.LEVELS,
+            levels_current=EN_LEVELS,
+            levels_en=EN_LEVELS,
             location_slug="hamburg",
             location_title="Hamburg",
             icon="mdi:tree-outline",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1155,6 +1155,22 @@ class TestLatinGenusAsDisplayName:
             await self._setup(hass)
         assert not [r for r in caplog.records if "Unknown allergen" in r.getMessage()]
 
+    async def test_reports_the_genus_as_the_latin_name(self, hass):
+        """The display name is a proven latin genus, so it is the latin name.
+
+        The API left the latin field empty, but the map lookup that resolved
+        the slug proved the display name is a latin genus. Reporting an empty
+        name_la for exactly the allergens this resolves would waste that.
+        """
+        entities = await self._setup(hass)
+        sensor = next(
+            e
+            for e in entities
+            if isinstance(e, PolleninformationSensor)
+            and e.unique_id == "polleninformation_hamburg_mugwort"
+        )
+        assert sensor.extra_state_attributes["name_la"] == "Artemisia"
+
     async def test_existing_buggy_slug_entity_is_migrated(self, hass):
         """An entity from the pre-fix "artemisia" slug is carried to "mugwort".
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1692,7 +1692,8 @@ class TestStaleSensorRecovery:
     async def test_german_forecast_recovers(self, hass):
         sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
         sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
-        assert len(sensor.extra_state_attributes["forecast"]) == 4
+        forecast = sensor.extra_state_attributes["forecast"]
+        assert [day["level"] for day in forecast] == [3, 2, 1, 0]
 
     async def test_english_dock_sorrel_recovers(self, hass):
         sensor = await self._recreate(
@@ -1715,4 +1716,5 @@ class TestStaleSensorRecovery:
         """
         sensor = await self._recreate(hass, "es", "polleninformation_hamburg_mugwort")
         sensor.coordinator.data = LATIN_GENUS_AS_NAME_RESPONSE
-        assert sensor.native_value is not None
+        assert sensor.native_value == "bajo"
+

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2001,6 +2001,61 @@ LOCALIZED_TITLE_RESPONSE = {
 }
 
 
+class TestGenusPrefixedNameOnTheSetupPath:
+    """Prose that begins with a latin genus must not be taken for that genus.
+
+    The setup path owns the entity_id and queues the rename, so resolving
+    "Ambrosia hojas" to ragweed there does more than mis-match a sensor. The
+    stale-recovery direction is pinned in TestStaleSensorRecovery; this is
+    the setup direction of the same rule.
+    """
+
+    async def _setup(self, hass, entry=None):
+        return await _setup_entities(
+            hass,
+            "es",
+            entry=entry,
+            response=GENUS_PREFIXED_NAME_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+
+    async def test_does_not_take_the_ragweed_slug(self, hass):
+        entities = await self._setup(hass)
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+        assert "polleninformation_hamburg_ragweed" not in unique_ids
+        assert "polleninformation_hamburg_ambrosia_hojas" in unique_ids
+
+    async def test_does_not_report_the_prose_as_a_latin_name(self, hass):
+        entities = await self._setup(hass)
+        sensor = _by_type(entities, PolleninformationSensor)
+        assert sensor.extra_state_attributes["name_la"] == ""
+
+    async def test_queues_no_rename_onto_ragweed(self, hass):
+        entry = _make_entry("es")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_ambrosia_hojas",
+            suggested_object_id="polleninformation_hamburg_ambrosia_hojas",
+            config_entry=entry,
+        )
+        await self._setup(hass, entry=entry)
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_ambrosia_hojas"
+            )
+            == "sensor.polleninformation_hamburg_ambrosia_hojas"
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_ragweed"
+            )
+            is None
+        )
+
+
 class TestLocalizedTitleWithoutLatin:
     """The API also sends a localized title with no parenthesized latin name.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2059,3 +2059,69 @@ class TestPartialDataIsNotFreshData:
         assert attrs["data_stale"] is True
         assert attrs["stale_since"] == T1.isoformat()
 
+
+GERMAN_LANGUAGE_BLOCK = {"poll_titles": [{"name": "Birke", "latin": "Betula"}]}
+
+LOCALIZED_TITLE_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Birke",
+            "contamination_1": 3,
+            "contamination_2": 2,
+            "contamination_3": 1,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {},
+    "allergyrisk_hourly": {},
+}
+
+
+class TestLocalizedTitleWithoutLatin:
+    """The API also sends a localized title with no parenthesized latin name.
+
+    Setup resolves that shape through the language block. A recreated sensor
+    has no latin to read and the title is not a latin name either, so it has
+    to know the localized name the API will send.
+    """
+
+    async def _birch(self, hass):
+        return await _recreate_stale(
+            hass,
+            "de",
+            "polleninformation_hamburg_birch",
+            language_block=GERMAN_LANGUAGE_BLOCK,
+        )
+
+    async def test_recovers_from_a_localized_title(self, hass):
+        sensor = await self._birch(hass)
+        sensor.coordinator.data = LOCALIZED_TITLE_RESPONSE
+        assert sensor.native_value == "hoch"
+
+    async def test_forecast_recovers_from_a_localized_title(self, hass):
+        sensor = await self._birch(hass)
+        sensor.coordinator.data = LOCALIZED_TITLE_RESPONSE
+        forecast = sensor.extra_state_attributes["forecast"]
+        assert [day["level"] for day in forecast] == [3, 2, 1, 0]
+
+    async def test_the_recreated_sensor_is_named_in_the_configured_language(self, hass):
+        """The name the block carries is also the name the user should see."""
+        sensor = await self._birch(hass)
+        assert sensor.name == "Birke"
+
+    async def test_the_latin_shape_still_works(self, hass):
+        """The block must not displace the language independent match."""
+        sensor = await self._birch(hass)
+        sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
+        assert sensor.native_value == "hoch"
+
+    async def test_an_allergen_the_block_does_not_carry_still_recovers(self, hass):
+        """Falling back to the English name keeps the slug match reachable."""
+        sensor = await _recreate_stale(
+            hass,
+            "de",
+            "polleninformation_hamburg_tree_of_heaven",
+            language_block=GERMAN_LANGUAGE_BLOCK,
+        )
+        sensor.coordinator.data = BINOMIAL_NAME_RESPONSE
+        assert sensor.native_value == "mäßig"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -24,7 +24,6 @@ from custom_components.polleninformation.sensor import (
     entity_id_available,
     extract_allergen_slug_from_unique_id,
     localized_risk_object_id_suffixes,
-    pollen_forecast_for_allergen,
     scale_allergy_risk,
 )
 from custom_components.polleninformation.utils import slugify
@@ -102,32 +101,6 @@ class TestExtractAllergenSlug:
 
     def test_none(self):
         assert extract_allergen_slug_from_unique_id(None) is None
-
-
-class TestPollenForecast:
-    def test_match(self):
-        contamination = [
-            {
-                "poll_title": "Birke (Betula)",
-                "contamination_1": 0,
-                "contamination_2": 1,
-                "contamination_3": 2,
-                "contamination_4": 3,
-            }
-        ]
-        levels = ["none", "low", "moderate", "high", "very high"]
-        result = pollen_forecast_for_allergen(contamination, "Birke", levels)
-        assert len(result) == 4
-        assert result[0]["level"] == 0
-        assert result[0]["level_name"] == "none"
-        assert result[2]["level"] == 2
-        assert result[2]["level_name"] == "moderate"
-
-    def test_no_match(self):
-        contamination = [{"poll_title": "Birke (Betula)", "contamination_1": 1}]
-        levels = ["none", "low"]
-        result = pollen_forecast_for_allergen(contamination, "Unknown", levels)
-        assert result == []
 
 
 # --- Sensor class tests ---


### PR DESCRIPTION
## Summary

Two follow-ups to the allergen resolution fix that landed in #72, one separate bug
found while reviewing it, and the v0.5.5 release documentation.

## Follow-ups to #72 (issue #71)

**Gate the display-name lookup on the English block.** The fallback added in #72 fired
whenever the latin lookup failed, including when the API *did* send a latin name that
`LATIN_TO_ENGLISH_NAME` simply does not know. Since `allergen_en = mapped_en or
legacy_en`, the fallback then outranked the English language block and inverted the
resolution order documented in the comment above it. Failure scenario: the API adds
`"Ambrosia (Asteraceae)"` and the language block grows `Asteraceae -> "Composite
family"`. The fallback resolves `Ambrosia` to `ragweed`, `legacy_slug` and `slug_en`
differ, and `migrate_localized_allergen_ids()` silently renames the user's existing
`sensor.*_composite_family` onto a different allergen, history and automations
included. Gating on `allergen_en_obj is None` keeps the whole benefit of #72 and
restores the documented order. Not reachable with today's API data, so this is
hardening rather than a live bug.

**Record the genus the fallback proved.** When the fallback matches, the code has just
established that the display name is a latin genus, then discarded it four lines later,
so `name_la` stayed empty for exactly the allergens #72 repaired.

## Issue #73: a sensor recreated as stale never matched a localized title again

When the API returns empty data the integration recreates the existing entities as
stale. It rebuilt the allergen matching key from the English slug, but that key is
compared against the API's `poll_title`, which arrives in the configured language. On
any non-English installation the recreated sensor therefore kept returning `None` even
after the API recovered, until Home Assistant was restarted or the entry reloaded,
since the reconstruction only happens in `async_setup_entry`. English installations
were unaffected apart from `dock/sorrel`, which slugs to `dock_sorrel` and rebuilds as
`Dock Sorrel` rather than `Dock/Sorrel`.

The recreated sensor now also matches on its canonical slug, which is language
independent, via a new `allergen_slug_for_item()` and a shared `_find_item()` that
replaced the duplicated match loop in `native_value` and `extra_state_attributes`. The
slug helper also handles the no-parentheses case from #71, so a stale `mugwort` sensor
recovers from a `poll_title` of `"Artemisia"`. Recreated sensors also get their real
latin name and canonical English name instead of a blank `name_la` and a `.title()`
guess.

## Release

CHANGELOG section for v0.5.5, a note in `docs/entity_naming.md` about the fallback, and
the manifest version bump.

## Tests

215 passed, up from 207 on `dev`. Every new test was confirmed to fail against the code
it fixes before the fix was applied. The existing `artemisia` to `mugwort` migration
test stays green, which is the guard against the gating change accidentally collapsing
`legacy_slug` onto `slug_en`.

Ruff reports one finding fewer in the touched files than `dev` does; no new findings.
