### PR TITLE
Validate every latin name the language map generator records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,16 +56,27 @@
   latin name first, and a name is only used for an entry no other sensor
   claims.
 
-- **Two allergens keep their localized name during an outage** (issue #75) —
-  the integration ships a map of the allergen names the API answers with in
-  each language, and falls back to it when the API is unreachable. Two entries
-  in that map had been recorded with the wrong latin name, because the API had
-  put a Slovak word where the latin name goes and had sent no latin name at
-  all for mugwort in Spanish. A sensor kept through an API outage on a Slovak
-  or Spanish installation now keeps its own name instead of falling back to
-  English. The script that builds the map now checks every latin name it
-  records against the allergens the integration knows, and reports the ones it
-  cannot place instead of transcribing them silently.
+- **Ragweed is recognized on a Slovak installation** (issue #75) — the API
+  answers a Slovak request with the Slovak word for ragweed where the latin
+  name belongs, and the integration looks allergens up by their latin name, so
+  it did not recognize this one: an "Unknown allergen" warning asking for a
+  bug report was logged at every restart, and the sensor reported that word as
+  its latin name. The spelling is now known to be ragweed's, so the warning is
+  gone and the sensor reports `Ambrosia`. Only spellings the API has actually
+  been seen to send are treated this way, so a latin name the integration does
+  not know is still left exactly as the API sent it and still asks to be
+  reported.
+
+- **Two allergens keep their localized name during an outage** — the
+  integration ships a map of the allergen names the API answers with in each
+  language, and falls back to it when the API is unreachable. Two entries in
+  that map had been recorded with the wrong latin name: the Slovak word above,
+  and no latin name at all for mugwort in Spanish, where the API sends the
+  latin name as the display name instead. A sensor kept through an API outage
+  on a Slovak or Spanish installation now keeps its own name instead of
+  falling back to English. The script that builds the map now checks every
+  latin name it records against the allergens the integration knows, and
+  reports the ones it cannot place instead of transcribing them silently.
 
 - **A new outage is timed from when it started** — the `stale_since`
   timestamp was recorded once, when Home Assistant happened to start during an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,17 @@
   latin name first, and a name is only used for an entry no other sensor
   claims.
 
+- **Two allergens keep their localized name during an outage** (issue #75) —
+  the integration ships a map of the allergen names the API answers with in
+  each language, and falls back to it when the API is unreachable. Two entries
+  in that map had been recorded with the wrong latin name, because the API had
+  put a Slovak word where the latin name goes and had sent no latin name at
+  all for mugwort in Spanish. A sensor kept through an API outage on a Slovak
+  or Spanish installation now keeps its own name instead of falling back to
+  English. The script that builds the map now checks every latin name it
+  records against the allergens the integration knows, and reports the ones it
+  cannot place instead of transcribing them silently.
+
 - **A new outage is timed from when it started** — the `stale_since`
   timestamp was recorded once, when Home Assistant happened to start during an
   outage, and was reused for every later outage. An automation or template

--- a/custom_components/polleninformation/__init__.py
+++ b/custom_components/polleninformation/__init__.py
@@ -37,7 +37,7 @@ from .const import (
     DOMAIN,
     PLATFORMS,
 )
-from .utils import get_country_code_map
+from .utils import get_country_code_map, usable_contamination
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -185,9 +185,18 @@ class PollenInformationDataUpdateCoordinator(DataUpdateCoordinator):
         Every block counts, not just contamination: a response carrying only
         risk data still carried data, and marking it stale would tell the
         risk sensors they are stale while they report a current reading.
+
+        The contamination block counts by what is usable in it rather than by
+        its length, for the same reason the sensors do: entries that identify
+        no allergen build nothing and read nothing, so a block of only those
+        carried no more data than an empty one. The two tests are not the same
+        question and still do not always agree, which is intended: a response
+        whose pollen entries are all unusable but whose risk blocks are full
+        did carry data, so nothing is stale, while the pollen sensors are
+        recreated with no readings of their own and report unknown.
         """
         if (
-            result.get("contamination")
+            usable_contamination(result.get("contamination"))
             or result.get("allergyrisk")
             or result.get("allergyrisk_hourly")
         ):

--- a/custom_components/polleninformation/__init__.py
+++ b/custom_components/polleninformation/__init__.py
@@ -37,7 +37,7 @@ from .const import (
     DOMAIN,
     PLATFORMS,
 )
-from .utils import block_of, get_country_code_map, usable_contamination
+from .utils import get_country_code_map, usable_contamination, usable_risk_block
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -200,8 +200,8 @@ class PollenInformationDataUpdateCoordinator(DataUpdateCoordinator):
         """
         if (
             usable_contamination(result.get("contamination"))
-            or block_of(result, "allergyrisk")
-            or block_of(result, "allergyrisk_hourly")
+            or usable_risk_block(result, "allergyrisk")
+            or usable_risk_block(result, "allergyrisk_hourly")
         ):
             self.empty_since = None
         elif self.empty_since is None:

--- a/custom_components/polleninformation/__init__.py
+++ b/custom_components/polleninformation/__init__.py
@@ -37,7 +37,7 @@ from .const import (
     DOMAIN,
     PLATFORMS,
 )
-from .utils import get_country_code_map, usable_contamination
+from .utils import block_of, get_country_code_map, usable_contamination
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -186,10 +186,13 @@ class PollenInformationDataUpdateCoordinator(DataUpdateCoordinator):
         risk data still carried data, and marking it stale would tell the
         risk sensors they are stale while they report a current reading.
 
-        The contamination block counts by what is usable in it rather than by
-        its length, for the same reason the sensors do: entries that identify
-        no allergen build nothing and read nothing, so a block of only those
-        carried no more data than an empty one. The two tests are not the same
+        Every block counts by what is usable in it rather than by its length,
+        for the same reason the sensors do. Entries that identify no allergen
+        build nothing and read nothing; a risk block that is not an object is
+        read as absent and reports unknown. A response of nothing but those
+        carried no more data than an empty one, and saying otherwise would
+        leave the sensors recreated for want of any data while no outage was
+        ever stamped for them to point at. The two tests are not the same
         question and still do not always agree, which is intended: a response
         whose pollen entries are all unusable but whose risk blocks are full
         did carry data, so nothing is stale, while the pollen sensors are
@@ -197,8 +200,8 @@ class PollenInformationDataUpdateCoordinator(DataUpdateCoordinator):
         """
         if (
             usable_contamination(result.get("contamination"))
-            or result.get("allergyrisk")
-            or result.get("allergyrisk_hourly")
+            or block_of(result, "allergyrisk")
+            or block_of(result, "allergyrisk_hourly")
         ):
             self.empty_since = None
         elif self.empty_since is None:

--- a/custom_components/polleninformation/language_map.json
+++ b/custom_components/polleninformation/language_map.json
@@ -786,7 +786,7 @@
       },
       {
         "name": "Ragweed",
-        "latin": "ambrózia",
+        "latin": "Ambrosia",
         "poll_id": 6
       }
     ]
@@ -817,7 +817,7 @@
       },
       {
         "name": "Artemisia",
-        "latin": "",
+        "latin": "Artemisia",
         "poll_id": 7
       },
       {

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -173,15 +173,47 @@ def _latin_name_index() -> dict[str, str]:
     return index
 
 
-def canonical_latin(latin: str | None) -> str | None:
-    """Return the spelling of a latin name the maps use.
+def resolve_latin_alias(latin: str | None) -> str | None:
+    """Return the latin name a declared spelling stands for.
 
     Only a spelling declared in LATIN_NAME_ALIASES is rewritten, so a latin
-    name the API sent that no map knows is returned unchanged.
+    name the API sent that no map knows is returned unchanged, species and
+    all.
     """
     if not latin:
         return latin
     return LATIN_NAME_ALIASES.get(latin.strip().lower(), latin)
+
+
+@lru_cache(maxsize=1)
+def _canonical_latin_index() -> dict[str, str]:
+    """The key of LATIN_TO_ENGLISH_NAME per spelling that resolves to it."""
+    index = {latin.lower(): latin for latin in LATIN_TO_ENGLISH_NAME}
+    for latin in LATIN_TO_ENGLISH_NAME:
+        index.setdefault(latin.split()[0].lower(), latin)
+    for alias, latin in LATIN_NAME_ALIASES.items():
+        index.setdefault(alias, latin)
+    return index
+
+
+def canonical_latin(latin: str | None) -> str | None:
+    """Return the key of LATIN_TO_ENGLISH_NAME a latin name resolves to.
+
+    None when no map knows it. This is the spelling anything keyed by latin
+    name has to store, because the lookups against a language block match
+    exactly: an entry recorded as "poaceae" or "Ambrosia artemisiifolia" is
+    never found again by a consumer holding "Poaceae" or "Ambrosia".
+
+    A latin name that carries a species falls back to its genus, exactly as
+    english_name_for_latin does, so the two agree on what is recognized.
+    """
+    if not latin:
+        return None
+    index = _canonical_latin_index()
+    key = latin.strip().lower()
+    if canonical := index.get(key):
+        return canonical
+    return index.get(key.split()[0]) if key.split() else None
 
 
 def english_name_for_latin(latin: str | None) -> str | None:
@@ -501,7 +533,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         # A spelling the API is known to send in place of a latin name is
         # reported as the name it stands for, so the attribute carries a latin
         # name rather than a localized word.
-        allergen_la = canonical_latin(latin) if latin else ""
+        allergen_la = resolve_latin_alias(latin) if latin else ""
         if allergen_la != latin:
             _LOGGER.debug(
                 "Reporting %r as %r for allergen %r",

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -1051,6 +1051,20 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
         return attrs
 
 
+def hourly_readings(block, field):
+    """Return one day's hourly readings as a sequence.
+
+    Deliberately NOT in usable_risk_block. That predicate answers the question
+    every caller shares, whether there is anything here to read. What shape a
+    value must have to BE read belongs to the reader: the daily sensor wants a
+    number and scale_allergy_risk already swallows anything that is not one,
+    while this one wants a sequence of hours. A scalar has no length, and a
+    mapping is indexed by key rather than by hour, so neither is a day.
+    """
+    values = block.get(field)
+    return values if isinstance(values, (list, tuple)) else []
+
+
 class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
     """Hourly allergy risk sensor."""
 
@@ -1100,7 +1114,7 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
         if not allergyrisk_hourly:
             return None
         now_hour = dt_util.now().hour
-        values = allergyrisk_hourly.get("allergyrisk_hourly_1", [])
+        values = hourly_readings(allergyrisk_hourly, "allergyrisk_hourly_1")
         if 0 <= now_hour < len(values):
             raw = values[now_hour]
             scaled = scale_allergy_risk(raw)
@@ -1125,7 +1139,7 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
         base_time = dt_util.now().replace(hour=0, minute=0, second=0, microsecond=0)
         forecast = []
         for day in range(1, 5):
-            values = allergyrisk_hourly.get(f"allergyrisk_hourly_{day}", [])
+            values = hourly_readings(allergyrisk_hourly, f"allergyrisk_hourly_{day}")
             for hour, raw in enumerate(values):
                 dt = base_time + timedelta(days=day - 1, hours=hour)
                 scaled = scale_allergy_risk(raw)
@@ -1144,7 +1158,7 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
                 )
 
         now_hour = dt_util.now().hour
-        values_today = allergyrisk_hourly.get("allergyrisk_hourly_1", [])
+        values_today = hourly_readings(allergyrisk_hourly, "allergyrisk_hourly_1")
         raw_now = values_today[now_hour] if 0 <= now_hour < len(values_today) else None
         scaled_now = scale_allergy_risk(raw_now) if raw_now is not None else None
         named_now = (

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -40,6 +40,7 @@ from .const_levels import ALLERGEN_DISPLAY_OVERRIDES, LEVELS, RISK_SENSOR_NAMES
 from .utils import (
     allergen_names_from_item,
     async_get_language_block,
+    block_of,
     get_allergen_info_by_latin,
     normalize,
     slugify,
@@ -934,11 +935,7 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self) -> str | None:
-        allergyrisk = (
-            self.coordinator.data.get("allergyrisk", {})
-            if self.coordinator.data
-            else {}
-        )
+        allergyrisk = block_of(self.coordinator.data, "allergyrisk")
         if not allergyrisk:
             return None
         value = allergyrisk.get("allergyrisk_1", None)
@@ -949,11 +946,7 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        allergyrisk = (
-            self.coordinator.data.get("allergyrisk", {})
-            if self.coordinator.data
-            else {}
-        )
+        allergyrisk = block_of(self.coordinator.data, "allergyrisk")
         if not allergyrisk:
             attrs: dict[str, Any] = {
                 "location_title": self._location_title,
@@ -1048,11 +1041,7 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self) -> str | None:
-        allergyrisk_hourly = (
-            self.coordinator.data.get("allergyrisk_hourly", {})
-            if self.coordinator.data
-            else {}
-        )
+        allergyrisk_hourly = block_of(self.coordinator.data, "allergyrisk_hourly")
         if not allergyrisk_hourly:
             return None
         now_hour = dt_util.now().hour
@@ -1066,11 +1055,7 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        allergyrisk_hourly = (
-            self.coordinator.data.get("allergyrisk_hourly", {})
-            if self.coordinator.data
-            else {}
-        )
+        allergyrisk_hourly = block_of(self.coordinator.data, "allergyrisk_hourly")
         if not allergyrisk_hourly:
             attrs: dict[str, Any] = {
                 "location_title": self._location_title,

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -225,6 +225,23 @@ def canonical_latin(latin: str | None) -> str | None:
     return index.get(key.split()[0]) if key.split() else None
 
 
+def canonical_latin_for_display_name(name: str | None) -> str | None:
+    """Return the map key for a display name that IS a latin name, or None.
+
+    The display-name half of canonical_latin, and it does NOT fall back to
+    the genus, exactly as english_name_for_display_name does not: a display
+    name that merely begins with a genus is prose, and "Ambrosia hojas" is
+    not ragweed. The genus fallback belongs to the latin field, where a name
+    carrying a species really does resolve to its genus.
+
+    The pair mirrors english_name_for_latin and english_name_for_display_name
+    on purpose. Anything keyed by latin name has to agree with the sensors
+    about which allergen an entry is, and the two cannot agree if one of them
+    guesses from a first word where the other refuses to.
+    """
+    return _canonical_latin_index().get(name.strip().lower()) if name else None
+
+
 def english_name_for_latin(latin: str | None) -> str | None:
     """Return the English allergen name for a latin name, or None if unknown.
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -801,7 +801,14 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
         to different allergens. The name pass therefore skips any entry that
         identifies as a different allergen, and a name match only ever lands
         on an entry that nothing else claims.
+
+        Entries that identify no allergen are dropped first, by the same
+        predicate the setup path uses to decide which ones become sensors. A
+        non-object entry beside a good one used to raise here on every update,
+        which takes out every pollen sensor of the location rather than the
+        one bad entry.
         """
+        contamination = usable_contamination(contamination)
         for item in contamination:
             if allergen_slug_for_item(item) == self._allergen_slug:
                 return item

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -493,7 +493,16 @@ async def async_setup_entry(hass, entry, async_add_entities):
     allergen_renames: list[tuple[str, str]] = []
 
     for item in contamination:
-        poll_title_full = item.get("poll_title", "<unknown>")
+        poll_title_full = item.get("poll_title", "")
+        if not isinstance(poll_title_full, str) or not poll_title_full.strip():
+            # An entry with no readable title names nothing. Building a sensor
+            # from one gives an entity with no name, no latin name and an
+            # entity_id ending in nothing at all, which no later response and
+            # no restore can ever match back to an allergen. The same rule the
+            # language map generator applies: an allergen we can identify but
+            # not classify is kept, one that identifies nothing is not.
+            _LOGGER.warning("Skipping a pollen entry with no readable title: %r", item)
+            continue
         poll_title_local = capitalize_first(poll_title_full.split("(", 1)[0].strip())
         latin = None
         if "(" in poll_title_full and ")" in poll_title_full:

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -536,9 +536,14 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 latin or "",
             )
         allergen_en = mapped_en or legacy_en
-        # A spelling the API is known to send in place of a latin name is
-        # reported as the name it stands for, so the attribute carries a latin
-        # name rather than a localized word.
+        # name_la reports what the API said about this allergen, so a latin
+        # name that carries a species keeps it: "Ambrosia artemisiifolia" is
+        # more than the genus and the attribute is where that belongs. The one
+        # rewrite is a spelling the API is known to send in place of a latin
+        # name, so the attribute carries a latin name rather than a localized
+        # word. Deliberately not canonicalized: the restore path below can
+        # only report the genus, and matching it here would mean discarding a
+        # species the API did send. See the comment there.
         allergen_la = resolve_latin_alias(latin) if latin else ""
         if allergen_la != latin:
             _LOGGER.debug(
@@ -641,6 +646,16 @@ async def async_setup_entry(hass, entry, async_add_entities):
             else:
                 # The slug is all the registry keeps, so the names are
                 # derived back from it; the API is not answering right now.
+                # That makes name_la the key of LATIN_TO_ENGLISH_NAME here,
+                # which is the genus for every allergen the API spells with
+                # one, where the setup path reports the species alongside it
+                # when the API sends one. The slug does not carry a species,
+                # so this is the most this path can say. A sensor whose latin
+                # name has a species therefore reports the genus alone for as
+                # long as the outage lasts, and reports the species again on
+                # the first answer. Reporting the genus in both places would
+                # remove the difference by throwing away what the API told us,
+                # which is the wrong way to make two paths agree.
                 allergen_en, allergen_la = _slug_index().get(
                     allergen_slug, (allergen_slug.replace("_", " "), "")
                 )

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -494,26 +494,38 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     for item in contamination:
         poll_title_full = item.get("poll_title", "")
-        if not isinstance(poll_title_full, str) or not poll_title_full.strip():
-            # An entry with no readable title names nothing. Building a sensor
-            # from one gives an entity with no name, no latin name and an
-            # entity_id ending in nothing at all, which no later response and
-            # no restore can ever match back to an allergen. The same rule the
-            # language map generator applies: an allergen we can identify but
-            # not classify is kept, one that identifies nothing is not.
-            _LOGGER.warning("Skipping a pollen entry with no readable title: %r", item)
-            continue
+        if not isinstance(poll_title_full, str):
+            poll_title_full = ""
         poll_title_local = capitalize_first(poll_title_full.split("(", 1)[0].strip())
         latin = None
         if "(" in poll_title_full and ")" in poll_title_full:
             latin = poll_title_full.split("(", 1)[1].split(")", 1)[0].strip()
+        if not poll_title_local and not latin:
+            # The test is what the entry identifies, not whether its title is
+            # readable: "()" is a non-blank title with nothing in either half
+            # of it, and it names an allergen exactly as little as a missing
+            # title does. Building a sensor from one gives an entity with no
+            # name, no latin name and an entity_id ending in nothing at all,
+            # which no later response and no restore can match back to an
+            # allergen. The same rule the language map generator applies: an
+            # allergen we can identify but not classify is kept, one that
+            # identifies nothing is not.
+            _LOGGER.warning(
+                "Skipping a pollen entry that identifies no allergen: %r", item
+            )
+            continue
         if not latin and poll_title_local:
-            # A blank never matches a blank, in either direction. The API can
-            # send a title with no name part and no brackets, and the language
+            # A blank never matches a blank, in either direction: the language
             # map can hold an entry whose name is blank, for an allergen the
-            # API named by its latin name alone. Matching those two would hand
-            # the nameless entry the other one's latin name and make it that
-            # allergen.
+            # API named by its latin name alone, and matching that against a
+            # blank display name would hand the nameless entry the other one's
+            # latin name and make it that allergen.
+            #
+            # No accepted entry can reach here with a blank display name any
+            # more: reaching this line at all means no latin name was sent,
+            # and the guard above then refuses the entry unless it has a
+            # display name. Kept because it costs one comparison and it is
+            # what makes that reasoning safe to change.
             for allergen in language_block_current.get("poll_titles", []):
                 if allergen.get("name") and allergen["name"] == poll_title_local:
                     latin = allergen.get("latin")

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -40,11 +40,11 @@ from .const_levels import ALLERGEN_DISPLAY_OVERRIDES, LEVELS, RISK_SENSOR_NAMES
 from .utils import (
     allergen_names_from_item,
     async_get_language_block,
-    block_of,
     get_allergen_info_by_latin,
     normalize,
     slugify,
     usable_contamination,
+    usable_risk_block,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -647,7 +647,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         bool(raw_contamination) if isinstance(raw_contamination, list) else False
     )
     allergyrisk = (
-        block_of(coordinator.data, "allergyrisk")
+        usable_risk_block(coordinator.data, "allergyrisk")
         if has_data and api_sent_pollen
         else {}
     )
@@ -667,7 +667,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     # not an object is empty here exactly as it is for the sensor that reads
     # it and for the coordinator, rather than truthy in this one place.
     allergyrisk_hourly = (
-        block_of(coordinator.data, "allergyrisk_hourly")
+        usable_risk_block(coordinator.data, "allergyrisk_hourly")
         if has_data and api_sent_pollen
         else {}
     )
@@ -988,7 +988,7 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self) -> str | None:
-        allergyrisk = block_of(self.coordinator.data, "allergyrisk")
+        allergyrisk = usable_risk_block(self.coordinator.data, "allergyrisk")
         if not allergyrisk:
             return None
         value = allergyrisk.get("allergyrisk_1", None)
@@ -999,7 +999,7 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        allergyrisk = block_of(self.coordinator.data, "allergyrisk")
+        allergyrisk = usable_risk_block(self.coordinator.data, "allergyrisk")
         if not allergyrisk:
             attrs: dict[str, Any] = {
                 "location_title": self._location_title,
@@ -1094,7 +1094,9 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self) -> str | None:
-        allergyrisk_hourly = block_of(self.coordinator.data, "allergyrisk_hourly")
+        allergyrisk_hourly = usable_risk_block(
+            self.coordinator.data, "allergyrisk_hourly"
+        )
         if not allergyrisk_hourly:
             return None
         now_hour = dt_util.now().hour
@@ -1108,7 +1110,9 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        allergyrisk_hourly = block_of(self.coordinator.data, "allergyrisk_hourly")
+        allergyrisk_hourly = usable_risk_block(
+            self.coordinator.data, "allergyrisk_hourly"
+        )
         if not allergyrisk_hourly:
             attrs: dict[str, Any] = {
                 "location_title": self._location_title,

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -282,6 +282,7 @@ def allergen_slug_for_item(item: dict) -> str | None:
     The latin name in poll_title is the only part of the entry that does not
     vary with the configured language, so it is what identifies an allergen
     for a sensor that only knows its own slug.
+
     """
     poll_title = item.get("poll_title", "")
     if "(" in poll_title and ")" in poll_title:
@@ -620,10 +621,19 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     migrate_localized_allergen_ids(hass, location_slug, allergen_renames)
 
-    # Allergy risk daily sensor - only if contamination has data (otherwise allergyrisk is meaningless)
+    # The risk sensors are gated on the API having SENT pollen data, not on our
+    # having been able to read it. An empty contamination block means the API
+    # had nothing to say and a risk number beside it would be meaningless,
+    # which is what this gate was written for. A block we could not parse is
+    # the opposite case: the forecast was there, we failed at it, and the risk
+    # reading beside it is real and readable. Throwing it away would lose a
+    # number the API did send.
+    api_sent_pollen = (
+        bool(raw_contamination) if isinstance(raw_contamination, list) else False
+    )
     allergyrisk = (
-        coordinator.data.get("allergyrisk", {})
-        if has_data and not is_data_empty
+        block_of(coordinator.data, "allergyrisk")
+        if has_data and api_sent_pollen
         else {}
     )
     if allergyrisk:
@@ -638,10 +648,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
         if sensor.unique_id:
             new_unique_ids.add(sensor.unique_id)
 
-    # Allergy risk hourly sensor - only if contamination has data (otherwise allergyrisk is meaningless)
+    # Gated the same way, and read through the same helper: a block that is
+    # not an object is empty here exactly as it is for the sensor that reads
+    # it and for the coordinator, rather than truthy in this one place.
     allergyrisk_hourly = (
-        coordinator.data.get("allergyrisk_hourly", {})
-        if has_data and not is_data_empty
+        block_of(coordinator.data, "allergyrisk_hourly")
+        if has_data and api_sent_pollen
         else {}
     )
     if allergyrisk_hourly:

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -550,9 +550,16 @@ async def async_setup_entry(hass, entry, async_add_entities):
             # and the guard above then refuses the entry unless it has a
             # display name. Kept because it costs one comparison and it is
             # what makes that reasoning safe to change.
-            for allergen in language_block_current.get("poll_titles", []):
+            # Read defensively: this is the shipped language map, not the
+            # response, and it is the one input on this path nothing type
+            # checks. A latin name that is not a string would raise on the
+            # lookups below and take the whole config entry down.
+            for allergen in language_block_current.get("poll_titles") or []:
+                if not isinstance(allergen, dict):
+                    continue
                 if allergen.get("name") and allergen["name"] == poll_title_local:
-                    latin = allergen.get("latin")
+                    if isinstance(allergen.get("latin"), str):
+                        latin = allergen["latin"]
                     break
         # Resolution order: the static latin map, then the English language
         # block, then the name the API sent in the configured language. Only

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -855,9 +855,15 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
             if slug is not None and slug != self._allergen_slug:
                 continue
             # The display name through the shared parse, not a third reading
-            # of "the part before the bracket". Every entry here identifies an
-            # allergen, so the parse cannot answer None.
-            name, _ = allergen_names_from_item(item)
+            # of "the part before the bracket". The None cannot happen: the
+            # list was filtered by the same predicate at the top of this
+            # function, not by whoever called it. Handled anyway, so the line
+            # states the invariant instead of depending on a filter four lines
+            # up staying where it is.
+            parsed = allergen_names_from_item(item)
+            if parsed is None:
+                continue
+            name, _ = parsed
             if name.lower() == self._allergen_name.lower():
                 return item
         return None

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -498,9 +498,15 @@ async def async_setup_entry(hass, entry, async_add_entities):
         latin = None
         if "(" in poll_title_full and ")" in poll_title_full:
             latin = poll_title_full.split("(", 1)[1].split(")", 1)[0].strip()
-        if not latin:
+        if not latin and poll_title_local:
+            # A blank never matches a blank, in either direction. The API can
+            # send a title with no name part and no brackets, and the language
+            # map can hold an entry whose name is blank, for an allergen the
+            # API named by its latin name alone. Matching those two would hand
+            # the nameless entry the other one's latin name and make it that
+            # allergen.
             for allergen in language_block_current.get("poll_titles", []):
-                if allergen.get("name") == poll_title_local:
+                if allergen.get("name") and allergen["name"] == poll_title_local:
                     latin = allergen.get("latin")
                     break
         # Resolution order: the static latin map, then the English language

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -283,17 +283,25 @@ def allergen_slug_for_item(item: dict) -> str | None:
     vary with the configured language, so it is what identifies an allergen
     for a sensor that only knows its own slug.
 
+    The title is parsed by the shared helper rather than here. This used to
+    split the brackets itself and read poll_title without a guard, which was
+    safe only because both callers happen to filter the block first: safety by
+    call order, which lasts exactly until someone calls it from somewhere
+    else. An entry the helper cannot read identifies nothing, which is the
+    same answer this gave for a title it could not place.
     """
-    poll_title = item.get("poll_title", "")
-    if "(" in poll_title and ")" in poll_title:
-        latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
+    parsed = allergen_names_from_item(item)
+    if parsed is None:
+        return None
+    name, latin = parsed
+    if latin:
         name_en = english_name_for_latin(latin)
     else:
         # No latin at all: the API sometimes sends the latin name as the
         # display name instead (e.g. "Artemisia"), so the name itself is the
         # last chance to identify the entry. Only tried when no latin was
         # sent, so an entry that carries one is identified by that alone.
-        name_en = english_name_for_display_name(poll_title)
+        name_en = english_name_for_display_name(name)
     return slugify(name_en) if name_en else None
 
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -77,6 +77,19 @@ LATIN_TO_ENGLISH_NAME = {
     "Urticaceae": "nettle family",
 }
 
+# Spellings the API sends in the latin field that are not latin names, and the
+# name each one stands for. The Slovak response spells ragweed "ambrózia",
+# which is the Slovak word rather than a candidate scientific name, so nothing
+# above matches it and the allergen would be unknown.
+#
+# This is an allow-list on purpose: every entry is a fact about the API's data,
+# added after seeing it. A latin name the API sends that is simply not in the
+# map above is left alone, because it identifies its allergen whatever we can
+# resolve it to. Keys are lowercase; lookups normalize.
+LATIN_NAME_ALIASES = {
+    "ambrózia": "Ambrosia",
+}
+
 # Icons group the allergens by pollen source, which is what makes a list of
 # them scannable: the name next to the icon already says which species it is.
 # Material Design Icons has no species-specific plant icons, so a shared icon
@@ -155,7 +168,20 @@ def _latin_name_index() -> dict[str, str]:
     index = {latin.lower(): name for latin, name in LATIN_TO_ENGLISH_NAME.items()}
     for latin, name in LATIN_TO_ENGLISH_NAME.items():
         index.setdefault(latin.split()[0].lower(), name)
+    for alias, latin in LATIN_NAME_ALIASES.items():
+        index.setdefault(alias, LATIN_TO_ENGLISH_NAME[latin])
     return index
+
+
+def canonical_latin(latin: str | None) -> str | None:
+    """Return the spelling of a latin name the maps use.
+
+    Only a spelling declared in LATIN_NAME_ALIASES is rewritten, so a latin
+    name the API sent that no map knows is returned unchanged.
+    """
+    if not latin:
+        return latin
+    return LATIN_NAME_ALIASES.get(latin.strip().lower(), latin)
 
 
 def english_name_for_latin(latin: str | None) -> str | None:
@@ -472,7 +498,17 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 latin or "",
             )
         allergen_en = mapped_en or legacy_en
-        allergen_la = latin if latin else ""
+        # A spelling the API is known to send in place of a latin name is
+        # reported as the name it stands for, so the attribute carries a latin
+        # name rather than a localized word.
+        allergen_la = canonical_latin(latin) if latin else ""
+        if allergen_la != latin:
+            _LOGGER.debug(
+                "Reporting %r as %r for allergen %r",
+                latin,
+                allergen_la,
+                poll_title_local,
+            )
         slug_en = slugify(allergen_en) if allergen_en else slugify(poll_title_local)
         legacy_slug = slugify(legacy_en) if legacy_en else slug_en
         if legacy_slug and legacy_slug != slug_en:

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -854,8 +854,11 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
             slug = allergen_slug_for_item(item)
             if slug is not None and slug != self._allergen_slug:
                 continue
-            poll_title = item.get("poll_title", "").split("(", 1)[0].strip()
-            if poll_title.lower() == self._allergen_name.lower():
+            # The display name through the shared parse, not a third reading
+            # of "the part before the bracket". Every entry here identifies an
+            # allergen, so the parse cannot answer None.
+            name, _ = allergen_names_from_item(item)
+            if name.lower() == self._allergen_name.lower():
                 return item
         return None
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -86,6 +86,12 @@ LATIN_TO_ENGLISH_NAME = {
 # added after seeing it. A latin name the API sends that is simply not in the
 # map above is left alone, because it identifies its allergen whatever we can
 # resolve it to. Keys are lowercase; lookups normalize.
+#
+# A key here may not be a latin name the map above already knows, genus keys
+# included: the indexes let the real name win and resolve_latin_alias lets the
+# alias win, so such a key would make the two disagree about the same string
+# with nothing to warn about it. The value must be a key of the map above.
+# Both properties are pinned in tests/test_sensor.py.
 LATIN_NAME_ALIASES = {
     "ambrózia": "Ambrosia",
 }

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -38,10 +38,12 @@ from .const import (
 )
 from .const_levels import ALLERGEN_DISPLAY_OVERRIDES, LEVELS, RISK_SENSOR_NAMES
 from .utils import (
+    allergen_names_from_item,
     async_get_language_block,
     get_allergen_info_by_latin,
     normalize,
     slugify,
+    usable_contamination,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -443,8 +445,19 @@ async def async_setup_entry(hass, entry, async_add_entities):
     }
 
     has_data = coordinator.data is not None
-    contamination = coordinator.data.get("contamination", []) if has_data else []
+    raw_contamination = coordinator.data.get("contamination", []) if has_data else []
+    # Emptiness is a question about usable allergens, not about how many
+    # entries the API sent. An entry that identifies nothing builds no sensor,
+    # so a block of nothing but those is as empty as a block of none, and
+    # counting the raw list instead would leave the sensors this location
+    # already has absent rather than recreated and marked stale.
+    contamination = usable_contamination(raw_contamination)
     is_data_empty = len(contamination) == 0
+    for item in raw_contamination:
+        if allergen_names_from_item(item) is None:
+            _LOGGER.warning(
+                "Skipping a pollen entry that identifies no allergen: %r", item
+            )
 
     # Options override data (options flow writes to entry.options)
     def _opt(key, default=None):
@@ -493,27 +506,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
     allergen_renames: list[tuple[str, str]] = []
 
     for item in contamination:
-        poll_title_full = item.get("poll_title", "")
-        if not isinstance(poll_title_full, str):
-            poll_title_full = ""
-        poll_title_local = capitalize_first(poll_title_full.split("(", 1)[0].strip())
-        latin = None
-        if "(" in poll_title_full and ")" in poll_title_full:
-            latin = poll_title_full.split("(", 1)[1].split(")", 1)[0].strip()
-        if not poll_title_local and not latin:
-            # The test is what the entry identifies, not whether its title is
-            # readable: "()" is a non-blank title with nothing in either half
-            # of it, and it names an allergen exactly as little as a missing
-            # title does. Building a sensor from one gives an entity with no
-            # name, no latin name and an entity_id ending in nothing at all,
-            # which no later response and no restore can match back to an
-            # allergen. The same rule the language map generator applies: an
-            # allergen we can identify but not classify is kept, one that
-            # identifies nothing is not.
-            _LOGGER.warning(
-                "Skipping a pollen entry that identifies no allergen: %r", item
-            )
-            continue
+        # Every entry here identifies an allergen: usable_contamination has
+        # already dropped the ones that do not, warned about each, and counted
+        # what is left towards is_data_empty above.
+        name, latin = allergen_names_from_item(item)
+        poll_title_local = capitalize_first(name)
         if not latin and poll_title_local:
             # A blank never matches a blank, in either direction: the language
             # map can hold an entry whose name is blank, for an allergen the

--- a/custom_components/polleninformation/utils.py
+++ b/custom_components/polleninformation/utils.py
@@ -362,6 +362,33 @@ def block_of(data, key):
     return value if isinstance(value, dict) else {}
 
 
+def usable_risk_block(data, key):
+    """Return a risk block that holds a readable forecast, or an empty one.
+
+    block_of answers whether there IS a block; this answers whether there is
+    anything in it to read, which is the question every caller actually has.
+    A non-empty object with no forecast fields carries no more data than an
+    absent one: {"error": "upstream failure"} is what an API sends to say
+    something is wrong, and reading it as fresh data is the worst of the
+    available readings.
+
+    A field counts when it is one of this block's own numbered fields and
+    holds something. A risk of 0 is a real reading and counts; a null, an
+    empty list or an empty string does not.
+    """
+    block = block_of(data, key)
+    prefix = f"{key}_"
+    for field, value in block.items():
+        if not isinstance(field, str) or not field.startswith(prefix):
+            continue
+        if value is None:
+            continue
+        if isinstance(value, (list, dict, str, tuple, set)) and not value:
+            continue
+        return block
+    return {}
+
+
 def usable_contamination(contamination):
     """Return the contamination entries that identify an allergen."""
     if not isinstance(contamination, list):

--- a/custom_components/polleninformation/utils.py
+++ b/custom_components/polleninformation/utils.py
@@ -333,6 +333,20 @@ def allergen_names_from_item(item):
     return name, latin
 
 
+def block_of(data, key):
+    """Return data[key] when it is an object, and an empty one otherwise.
+
+    The API's blocks are read with .get, so a block that arrives as a list or
+    a string raises on the first read and takes the whole entity down with it.
+    A block that is not an object carries nothing this can use, which is what
+    an absent one means too.
+    """
+    if not isinstance(data, dict):
+        return {}
+    value = data.get(key)
+    return value if isinstance(value, dict) else {}
+
+
 def usable_contamination(contamination):
     """Return the contamination entries that identify an allergen."""
     if not isinstance(contamination, list):

--- a/custom_components/polleninformation/utils.py
+++ b/custom_components/polleninformation/utils.py
@@ -304,6 +304,42 @@ def split_location(locationtitle):
     return "", locationtitle
 
 
+def allergen_names_from_item(item):
+    """Return (display name, latin name) for a contamination entry, or None.
+
+    None means the entry identifies no allergen: it is not an object, or its
+    title has neither a display name nor a latin name in it. "(Poaceae)" has
+    one, "Trávy" has the other, "()" has neither and names an allergen exactly
+    as little as a missing title does.
+
+    Shared so that the sensors and the coordinator agree on what counts as an
+    allergen. They ask it for different reasons, one to build a sensor and one
+    to decide whether the response carried anything, and those two answers may
+    not drift apart: a block of entries that build no sensors has to read as
+    empty, or the sensors a location already has go absent instead of being
+    kept and marked stale.
+    """
+    if not isinstance(item, dict):
+        return None
+    poll_title = item.get("poll_title", "")
+    if not isinstance(poll_title, str):
+        poll_title = ""
+    name = poll_title.split("(", 1)[0].strip()
+    latin = None
+    if "(" in poll_title and ")" in poll_title:
+        latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
+    if not name and not latin:
+        return None
+    return name, latin
+
+
+def usable_contamination(contamination):
+    """Return the contamination entries that identify an allergen."""
+    if not isinstance(contamination, list):
+        return []
+    return [item for item in contamination if allergen_names_from_item(item)]
+
+
 def get_language_block_sync(lang_code):
     """
     Get language block for a given ISO code from language_map.json.

--- a/custom_components/polleninformation/utils.py
+++ b/custom_components/polleninformation/utils.py
@@ -392,10 +392,15 @@ async def async_get_language_block(hass, lang_code):
 
 
 def get_allergen_info_by_latin(latin, language_block):
+    """Return the language block's entry for a latin name, or None.
+
+    Reads defensively: the block comes from a file rather than from the
+    response, and it is one of the few inputs nothing type checks on the way
+    in. A row of the wrong shape is passed over rather than raising, because
+    raising here happens inside setup and costs the location every sensor it
+    has, not the one bad row.
     """
-    Get allergen info from a language block by latin name.
-    """
-    for allergen in language_block.get("poll_titles", []):
-        if allergen.get("latin") == latin:
+    for allergen in language_block.get("poll_titles") or []:
+        if isinstance(allergen, dict) and allergen.get("latin") == latin:
             return allergen
     return None

--- a/custom_components/polleninformation/utils.py
+++ b/custom_components/polleninformation/utils.py
@@ -304,13 +304,37 @@ def split_location(locationtitle):
     return "", locationtitle
 
 
+def parse_poll_title(poll_title):
+    """Return (display name, latin name) for a poll_title, or None.
+
+    None means the title identifies no allergen: it has neither a display name
+    nor a latin name in it. "(Poaceae)" has one, "Trávy" has the other, "()"
+    has neither and names an allergen exactly as little as a missing title
+    does. The latin name is None when the API sent no brackets, or only an
+    opening one, and a string otherwise.
+
+    THE one parse. The language map generator and the sensors both call it,
+    through this or through allergen_names_from_item, because two
+    implementations of "what does this title say" drift: they did, on the
+    unmatched bracket, where one read "Artemisia (" as mugwort and the other
+    as nothing.
+    """
+    if not isinstance(poll_title, str):
+        poll_title = ""
+    name = poll_title.split("(", 1)[0].strip()
+    latin = None
+    if "(" in poll_title and ")" in poll_title:
+        latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
+    if not name and not latin:
+        return None
+    return name, latin
+
+
 def allergen_names_from_item(item):
     """Return (display name, latin name) for a contamination entry, or None.
 
     None means the entry identifies no allergen: it is not an object, or its
-    title has neither a display name nor a latin name in it. "(Poaceae)" has
-    one, "Trávy" has the other, "()" has neither and names an allergen exactly
-    as little as a missing title does.
+    title does not name one.
 
     Shared so that the sensors and the coordinator agree on what counts as an
     allergen. They ask it for different reasons, one to build a sensor and one
@@ -321,16 +345,7 @@ def allergen_names_from_item(item):
     """
     if not isinstance(item, dict):
         return None
-    poll_title = item.get("poll_title", "")
-    if not isinstance(poll_title, str):
-        poll_title = ""
-    name = poll_title.split("(", 1)[0].strip()
-    latin = None
-    if "(" in poll_title and ")" in poll_title:
-        latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
-    if not name and not latin:
-        return None
-    return name, latin
+    return parse_poll_title(item.get("poll_title", ""))
 
 
 def block_of(data, key):

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -284,6 +284,13 @@ def poll_titles_from_contamination(contamination):
                 f"skipping a contamination entry that is not an object: {poll!r}"
             )
             continue
+        poll_id = poll.get("poll_id")
+        if poll_id is not None and not isinstance(poll_id, (str, int, float)):
+            warnings.append(
+                f"the API sent a poll_id that is not a scalar: {poll_id!r}; "
+                f"recording it as sent, and identifying this allergen by its "
+                f"latin name instead"
+            )
         name, latin = split_poll_title(poll.get("poll_title"))
         if not name and not latin:
             # The test is what the entry identifies, not whether its title is
@@ -347,13 +354,22 @@ def allergen_key(poll):
     would file the corrected spelling as a second allergen rather than as the
     same one. Then the latin name, then the display name, for an entry the API
     sent without an id.
+
+    Every field is type-checked before it is used, because this key goes into
+    a set: an id that arrives as a list or an object is unhashable and would
+    take down the whole run rather than the one entry, and a latin or a name
+    of the wrong type has no .strip(). A field this cannot use is passed over
+    for the next one, so the entry keeps its place in the merge instead of
+    losing its identity along with its id.
     """
     poll_id = poll.get("poll_id")
-    if poll_id is not None:
+    if isinstance(poll_id, (str, int, float)):
         return ("poll_id", poll_id)
-    if latin := poll.get("latin"):
+    latin = poll.get("latin")
+    if isinstance(latin, str) and latin.strip():
         return ("latin", latin.strip().lower())
-    if name := poll.get("name"):
+    name = poll.get("name")
+    if isinstance(name, str) and name.strip():
         return ("name", name.strip().lower())
     return None
 
@@ -530,6 +546,12 @@ def repair_db(db):
                     f"{lang_code}: name or latin is not a string, skipping: {poll!r}"
                 )
                 continue
+            poll_id = poll.get("poll_id")
+            if poll_id is not None and not isinstance(poll_id, (str, int, float)):
+                warnings.append(
+                    f"{lang_code}: poll_id is not a scalar: {poll_id!r}; the "
+                    f"entry is kept and identified by its latin name"
+                )
             resolved, entry_warnings = resolve_latin(name, latin)
             warnings.extend(f"{lang_code}: {w}" for w in entry_warnings)
             if resolved != latin:

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -298,6 +298,24 @@ def needs_fetch(db, lang_code):
     return not isinstance(entry, dict) or "error" in entry
 
 
+def unreadable_entry_warning(db, lang_code):
+    """Warn about a language entry that will be refetched and overwritten.
+
+    needs_fetch treats an entry it cannot read as one to fetch again, which
+    is right: an entry that is not an object holds nothing worth keeping. But
+    it is the one place in this script that destroys something, so it says
+    so first rather than doing it quietly. An entry that is simply absent, or
+    one that records an error, is the ordinary case and says nothing.
+    """
+    entry = db.get(lang_code)
+    if entry is None or isinstance(entry, dict):
+        return None
+    return (
+        f"the file holds {entry!r} for this language, which is not an entry "
+        f"this can read; refetching and overwriting it"
+    )
+
+
 def language_entry_from_response(lang_code, data):
     """Return the db entry for one language's response, plus warnings.
 
@@ -441,6 +459,9 @@ def run_fetch():
         if not needs_fetch(db, lang_code):
             print(f"{lang_code}: Already in db, skipping.")
             continue
+
+        if warning := unreadable_entry_warning(db, lang_code):
+            print(f"{lang_code}: WARNING: {warning}")
 
         params = {
             "country": COUNTRY,

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -419,10 +419,19 @@ def repair_db(db):
 
 
 def run_repair():
-    """Revalidate the whole db offline and save it if anything changed."""
+    """Revalidate the whole db offline and save it if anything changed.
+
+    The only thing decided here is the message for a database that is empty
+    or absent. Everything else goes to repair_db unexamined, because an entry
+    point that judges the data before the validator sees it can silently
+    exclude the very shapes the validator exists to report: `if not db` sent
+    every falsy root, a file holding [] or "" or 0 or false or null, down the
+    "nothing to repair" path, which is the one answer that was certainly
+    wrong.
+    """
     db = load_db()
-    if not db:
-        print(f"No {DB_FILE} to repair.")
+    if isinstance(db, dict) and not db:
+        print(f"No languages in {DB_FILE} to repair.")
         return
 
     changes, warnings = repair_db(db)

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -159,6 +159,10 @@ def resolve_latin(name, latin):
        which is the shape reported in issue #71;
     4. anything else is warned about and recorded exactly as the API sent it.
 
+    An entry whose display name is blank is warned about too, and kept: a
+    title like "(Poaceae)" identifies its allergen, so dropping it would be
+    the mistake, but it leaves the file holding half a pairing.
+
     Rungs 1 to 3 all record a key of LATIN_TO_ENGLISH_NAME, never the string
     the API happened to send, because every consumer of this file matches a
     latin name exactly: an entry recorded as "Ambrosia artemisiifolia" is not
@@ -175,8 +179,17 @@ def resolve_latin(name, latin):
     something to tell us.
     """
     if latin and (canonical := canonical_latin(latin)):
+        # A title like "(Poaceae)" names the allergen but not in this
+        # language, so the entry is kept and the missing half is reported: the
+        # file's whole job is the pairing, and half of one is worth knowing
+        # about even though it identifies its allergen perfectly well.
+        blank_name_warning = (
+            f"the API sent {canonical!r} with no display name; recording the "
+            f"entry, but this language has no name for that allergen"
+        )
+        blank_name = [] if name else [blank_name_warning]
         if canonical == latin:
-            return latin, []
+            return latin, blank_name
         if latin.strip().lower() in LATIN_NAME_ALIASES:
             warning = (
                 f"{name!r}: the API sent {latin!r} where the latin name goes, "
@@ -187,7 +200,7 @@ def resolve_latin(name, latin):
                 f"{name!r}: the API spells the latin name {latin!r}; recording "
                 f"it as {canonical!r}, the spelling every lookup matches on"
             )
-        return canonical, [warning]
+        return canonical, blank_name + [warning]
 
     sent = f"latin name {latin!r}" if latin else "no latin name"
 

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -78,9 +78,16 @@ HEADERS = {
 def load_db():
     """Load the existing language_map.json, or return empty dict.
 
-    A file that is not JSON at all stops the run. Treating it as an empty db
-    would be the destructive reading: the fetch would refetch every language
-    and write over whatever was in there.
+    A file that is not JSON at all stops the run. The rule this follows is
+    not "unreadable stops, readable continues", it is narrower: a run that
+    would REWRITE the file stops, a run that cannot damage it continues. The
+    fetch writes, so it exits on JSON it cannot parse and on a root that is
+    not an object. The repair only ever writes what it has read, so it
+    reports those same roots and leaves the file byte for byte as it was.
+
+    Treating an unreadable file as an empty db would be the destructive
+    reading: the fetch would refetch every language and write over whatever
+    was in there.
     """
     if not os.path.exists(DB_FILE):
         return {}

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -353,7 +353,16 @@ def repair_db(db):
         if not isinstance(entry, dict):
             warnings.append(f"{lang_code}: not an object, skipping: {entry!r}")
             continue
-        poll_titles = entry.get("poll_titles") or []
+        # Every field below is read raw and type-checked before anything is
+        # defaulted. Defaulting first, with `or`, would convert a falsy value
+        # of the wrong type into a valid-looking one and walk it past the
+        # check: a latin of 0 would read as absent, the display name would
+        # then be resolved in its place, and the malformed entry would be
+        # rewritten instead of reported. Only a missing key or an explicit
+        # null is defaulted, and that is a decision rather than a side effect.
+        poll_titles = entry.get("poll_titles")
+        if poll_titles is None:
+            poll_titles = []
         if not isinstance(poll_titles, list):
             warnings.append(
                 f"{lang_code}: poll_titles is not a list, skipping: {poll_titles!r}"
@@ -365,8 +374,12 @@ def repair_db(db):
                     f"{lang_code}: entry is not an object, skipping: {poll!r}"
                 )
                 continue
-            name = poll.get("name") or ""
-            latin = poll.get("latin") or ""
+            name = poll.get("name")
+            latin = poll.get("latin")
+            if name is None:
+                name = ""
+            if latin is None:
+                latin = ""
             if not isinstance(name, str) or not isinstance(latin, str):
                 warnings.append(
                     f"{lang_code}: name or latin is not a string, skipping: {poll!r}"

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -60,7 +60,14 @@ LANG_CODES = [
     "uk",
     "hu",
 ]
-DB_FILE = "custom_components/polleninformation/language_map.json"
+# Anchored to the script rather than to the working directory. Relative, it
+# resolved against wherever the shell happened to be, so a run from any other
+# directory found no file, read no languages, fetched all sixteen and wrote a
+# new map there. A file that is merely absent is indistinguishable from an
+# empty database, so no guard downstream can catch that.
+DB_FILE = str(
+    REPO_ROOT / "custom_components" / "polleninformation" / "language_map.json"
+)
 DELAY_SEC = 2  # Polite delay between requests (adjust if needed)
 HEADERS = {
     "Accept": "application/json, text/plain, */*",

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -117,9 +117,10 @@ def split_poll_title(poll_title):
     brackets comes back as the latin name, and a title without brackets comes
     back with none. resolve_latin decides what that is worth.
 
-    Total over whatever the API sends. A title that is not a string at all
-    reads as an empty one, which resolve_latin then warns about, because one
-    malformed entry may not cost the language its other allergens.
+    Total over whatever it is handed: a title that is not a string reads as an
+    empty one. The caller rejects such an entry before it gets here, since a
+    title that cannot be read names no allergen, but the split itself does not
+    raise on one.
     """
     poll_title = poll_title if isinstance(poll_title, str) else ""
     if "(" in poll_title and ")" in poll_title:
@@ -208,10 +209,18 @@ def resolve_latin(name, latin):
 def poll_titles_from_contamination(contamination):
     """Return the poll_titles entries for a contamination block, plus warnings.
 
-    Every entry in the block produces exactly one entry here, whether or not
-    its allergen is recognized. The one thing that is dropped is an entry that
-    is not an object at all, since there is nothing in it to record, and that
-    is warned about rather than passed over.
+    Every entry the API sends produces exactly one entry here, whether or not
+    its allergen is recognized: an unknown latin name still names a real
+    allergen, and dropping it would hide a new one.
+
+    Two shapes are the exception, and they are the opposite case. An entry
+    that is not an object, and an entry with no readable title, name nothing
+    at all. Recording those would not preserve information, it would
+    manufacture a well-formed record out of nothing, and a block of them would
+    then look like a language that has allergens. Both are warned about rather
+    than passed over, and a block left empty by them is a response with no
+    allergens, which language_entry_from_response records as an error so the
+    language is fetched again.
     """
     poll_titles = []
     warnings = []
@@ -225,7 +234,13 @@ def poll_titles_from_contamination(contamination):
                 f"skipping a contamination entry that is not an object: {poll!r}"
             )
             continue
-        name, latin = split_poll_title(poll.get("poll_title", ""))
+        poll_title = poll.get("poll_title")
+        if not isinstance(poll_title, str) or not poll_title.strip():
+            warnings.append(
+                f"skipping a contamination entry with no readable title: {poll!r}"
+            )
+            continue
+        name, latin = split_poll_title(poll_title)
         latin, entry_warnings = resolve_latin(name, latin)
         warnings.extend(entry_warnings)
         poll_titles.append(

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -116,8 +116,12 @@ def split_poll_title(poll_title):
     This is the transcription step only: whatever the API put between the
     brackets comes back as the latin name, and a title without brackets comes
     back with none. resolve_latin decides what that is worth.
+
+    Total over whatever the API sends. A title that is not a string at all
+    reads as an empty one, which resolve_latin then warns about, because one
+    malformed entry may not cost the language its other allergens.
     """
-    poll_title = poll_title or ""
+    poll_title = poll_title if isinstance(poll_title, str) else ""
     if "(" in poll_title and ")" in poll_title:
         name = poll_title.split("(", 1)[0].strip()
         latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
@@ -205,11 +209,22 @@ def poll_titles_from_contamination(contamination):
     """Return the poll_titles entries for a contamination block, plus warnings.
 
     Every entry in the block produces exactly one entry here, whether or not
-    its allergen is recognized.
+    its allergen is recognized. The one thing that is dropped is an entry that
+    is not an object at all, since there is nothing in it to record, and that
+    is warned about rather than passed over.
     """
     poll_titles = []
     warnings = []
+    if not isinstance(contamination, list):
+        return poll_titles, [
+            f"the API sent a contamination block that is not a list: {contamination!r}"
+        ]
     for poll in contamination:
+        if not isinstance(poll, dict):
+            warnings.append(
+                f"skipping a contamination entry that is not an object: {poll!r}"
+            )
+            continue
         name, latin = split_poll_title(poll.get("poll_title", ""))
         latin, entry_warnings = resolve_latin(name, latin)
         warnings.extend(entry_warnings)
@@ -225,13 +240,31 @@ def repair_db(db):
     Returns (changes, warnings), where a change is one corrected latin name.
     Entries are only ever rewritten, never removed: an allergen no map knows
     keeps what the API sent and is warned about again.
+
+    Total over whatever the file holds. This is the tool you reach for when
+    the file is wrong, so a shape it did not expect is reported with the
+    language it sits in rather than raised as a traceback that names neither.
     """
     changes = []
     warnings = []
     for lang_code, entry in db.items():
-        for poll in entry.get("poll_titles", []):
-            name = poll.get("name", "")
-            latin = poll.get("latin", "")
+        if not isinstance(entry, dict):
+            warnings.append(f"{lang_code}: not an object, skipping: {entry!r}")
+            continue
+        poll_titles = entry.get("poll_titles") or []
+        if not isinstance(poll_titles, list):
+            warnings.append(
+                f"{lang_code}: poll_titles is not a list, skipping: {poll_titles!r}"
+            )
+            continue
+        for poll in poll_titles:
+            if not isinstance(poll, dict):
+                warnings.append(
+                    f"{lang_code}: entry is not an object, skipping: {poll!r}"
+                )
+                continue
+            name = poll.get("name") or ""
+            latin = poll.get("latin") or ""
             resolved, entry_warnings = resolve_latin(name, latin)
             warnings.extend(f"{lang_code}: {w}" for w in entry_warnings)
             if resolved != latin:
@@ -272,7 +305,7 @@ def run_fetch():
     base_url = "https://www.polleninformation.at/api/forecast/public"
 
     for lang_code in LANG_CODES:
-        if lang_code in db:
+        if lang_code in db and "error" not in db[lang_code]:
             print(f"{lang_code}: Already in db, skipping.")
             continue
 
@@ -294,17 +327,13 @@ def run_fetch():
             time.sleep(DELAY_SEC)
             continue
 
-        # Parse forecast block for title/allergens
-        try:
-            poll_titles, warnings = poll_titles_from_contamination(
-                data.get("contamination", [])
-            )
-        except Exception as e:
-            print(f"{lang_code}: [parse error: {e}]")
-            db[lang_code] = {"error": f"parse error: {e}", "lang_code": lang_code}
-            save_db(db)
-            time.sleep(DELAY_SEC)
-            continue
+        # Parse forecast block for title/allergens. Total over anything the
+        # API can send, so there is no parse error to catch: an entry that
+        # cannot be read costs its own line and not the whole language, and a
+        # bug here surfaces as a traceback rather than as an error entry
+        # persisted in a file that is never refetched.
+        contamination = data.get("contamination", []) if isinstance(data, dict) else []
+        poll_titles, warnings = poll_titles_from_contamination(contamination)
 
         for warning in warnings:
             print(f"{lang_code}: WARNING: {warning}")

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -1,10 +1,40 @@
+"""Generate custom_components/polleninformation/language_map.json.
+
+Two modes, both run from the repository root:
+
+    python scripts/generate_language_codes.py           # fetch missing languages
+    python scripts/generate_language_codes.py --repair  # revalidate, offline
+
+The fetch mode asks the API for one forecast per interface language and
+records the localized allergen names it answers with. It needs API_KEY (from
+the environment or from .env) and network access, and it only fetches
+languages the file does not already have.
+
+The repair mode needs neither. It revalidates every latin name already in the
+file with the same rules the fetch mode applies to a fresh response, which is
+what lets an entry recorded before those rules existed correct itself. Run it
+after changing the validation, and review the diff.
+
+Both modes take their authority from LATIN_TO_ENGLISH_NAME in sensor.py, so
+this script imports the integration and therefore needs Home Assistant
+installed (the test venv has it).
+"""
+
+import argparse
 import json
 import os
+import sys
 import time
-import requests
-from dotenv import load_dotenv
+from pathlib import Path
 
-load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), "../.env"))
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from custom_components.polleninformation.sensor import (
+    LATIN_TO_ENGLISH_NAME,
+    english_name_for_display_name,
+    english_name_for_latin,
+)
 
 # ================================
 # CONFIGURATION
@@ -13,7 +43,6 @@ load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), "../.env"))
 LAT = 48.2081743
 LON = 16.3738189
 COUNTRY = "AT"
-API_KEY = os.environ["API_KEY"]
 LANG_CODES = [
     "de",
     "en",
@@ -39,6 +68,14 @@ HEADERS = {
     "User-Agent": "Mozilla/5.0 (compatible; polleninfo-script/1.0)",
 }
 
+# The reverse of LATIN_TO_ENGLISH_NAME. The English names are unique, so this
+# is lossless. It is the last resort for an entry whose display name is the
+# English allergen name rather than a localized one, which is what the API
+# sends for ragweed in some languages.
+ENGLISH_NAME_TO_LATIN = {
+    name.lower(): latin for latin, name in LATIN_TO_ENGLISH_NAME.items()
+}
+
 
 def load_db():
     """Load the existing language_map.json, or return empty dict."""
@@ -52,6 +89,10 @@ def save_db(db):
     """Save the language_map.json file (pretty-printed, UTF-8)."""
     with open(DB_FILE, "w", encoding="utf-8") as f:
         json.dump(db, f, indent=2, ensure_ascii=False)
+        # The file is checked in, so it ends with a newline like every other
+        # source file. Without this every save shows up as a diff on the last
+        # line.
+        f.write("\n")
 
 
 def get_language_name(lang_code):
@@ -78,7 +119,132 @@ def get_language_name(lang_code):
     return names.get(lang_code, lang_code)
 
 
-def main():
+def split_poll_title(poll_title):
+    """Split a poll_title into its display name and its bracketed latin name.
+
+    This is the transcription step only: whatever the API put between the
+    brackets comes back as the latin name, and a title without brackets comes
+    back with none. resolve_latin decides what that is worth.
+    """
+    poll_title = poll_title or ""
+    if "(" in poll_title and ")" in poll_title:
+        name = poll_title.split("(", 1)[0].strip()
+        latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
+    else:
+        name = poll_title.strip()
+        latin = ""
+    return name, latin
+
+
+def resolve_latin(name, latin):
+    """Return the latin name to record for an entry, plus any warnings.
+
+    The API does not always put a latin name between the brackets, and does
+    not always use brackets at all, so a transcribed latin name is checked
+    against LATIN_TO_ENGLISH_NAME before it is trusted. When it fails, the
+    display name is the second chance: it is either a latin name itself, the
+    shape reported in issue #71, or the English allergen name, which is what
+    the API sends for ragweed in some languages.
+
+    An entry no lookup recognizes is warned about and recorded exactly as the
+    API sent it. Dropping it would hide a genuinely new allergen, which is the
+    one case where this file has something to tell us.
+    """
+    if latin and english_name_for_latin(latin):
+        return latin, []
+
+    sent = f"latin name {latin!r}" if latin else "no latin name"
+
+    if english := english_name_for_display_name(name):
+        canonical = ENGLISH_NAME_TO_LATIN[english]
+        warning = (
+            f"{name!r}: the API sent {sent} and a display name that is one; "
+            f"recording {canonical!r}"
+        )
+        return canonical, [warning]
+
+    if canonical := ENGLISH_NAME_TO_LATIN.get(name.strip().lower()):
+        warning = (
+            f"{name!r}: the API sent {sent} and an untranslated English "
+            f"display name; recording {canonical!r}"
+        )
+        return canonical, [warning]
+
+    warning = (
+        f"{name!r}: the API sent {sent} and a display name no map knows. "
+        f"Recording it as sent. If this is a new allergen it needs adding to "
+        f"LATIN_TO_ENGLISH_NAME in sensor.py; please open an issue."
+    )
+    return latin, [warning]
+
+
+def poll_titles_from_contamination(contamination):
+    """Return the poll_titles entries for a contamination block, plus warnings.
+
+    Every entry in the block produces exactly one entry here, whether or not
+    its allergen is recognized.
+    """
+    poll_titles = []
+    warnings = []
+    for poll in contamination:
+        name, latin = split_poll_title(poll.get("poll_title", ""))
+        latin, entry_warnings = resolve_latin(name, latin)
+        warnings.extend(entry_warnings)
+        poll_titles.append(
+            {"name": name, "latin": latin, "poll_id": poll.get("poll_id")}
+        )
+    return poll_titles, warnings
+
+
+def repair_db(db):
+    """Revalidate every latin name already in the db, in place.
+
+    Returns (changes, warnings), where a change is one corrected latin name.
+    Entries are only ever rewritten, never removed: an allergen no map knows
+    keeps what the API sent and is warned about again.
+    """
+    changes = []
+    warnings = []
+    for lang_code, entry in db.items():
+        for poll in entry.get("poll_titles", []):
+            name = poll.get("name", "")
+            latin = poll.get("latin", "")
+            resolved, entry_warnings = resolve_latin(name, latin)
+            warnings.extend(f"{lang_code}: {w}" for w in entry_warnings)
+            if resolved != latin:
+                poll["latin"] = resolved
+                changes.append(f"{lang_code}: {name!r}: {latin!r} -> {resolved!r}")
+    return changes, warnings
+
+
+def run_repair():
+    """Revalidate the whole db offline and save it if anything changed."""
+    db = load_db()
+    if not db:
+        print(f"No {DB_FILE} to repair.")
+        return
+
+    changes, warnings = repair_db(db)
+    for warning in warnings:
+        print(f"WARNING: {warning}")
+    for change in changes:
+        print(f"Repaired {change}")
+
+    if changes:
+        save_db(db)
+        print(f"Done. {len(changes)} latin name(s) repaired in {DB_FILE}")
+    else:
+        print(f"Done. Nothing to repair in {DB_FILE}")
+
+
+def run_fetch():
+    """Fetch every language missing from the db and record its allergen names."""
+    import requests
+    from dotenv import load_dotenv
+
+    load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), "../.env"))
+    api_key = os.environ["API_KEY"]
+
     db = load_db()
     base_url = "https://www.polleninformation.at/api/forecast/public"
 
@@ -92,7 +258,7 @@ def main():
             "lang": lang_code,
             "latitude": LAT,
             "longitude": LON,
-            "apikey": API_KEY,
+            "apikey": api_key,
         }
         try:
             resp = requests.get(base_url, params=params, headers=HEADERS, timeout=20)
@@ -107,26 +273,19 @@ def main():
 
         # Parse forecast block for title/allergens
         try:
-            contamination = data.get("contamination", [])
-            poll_titles = []
-            for poll in contamination:
-                poll_title = poll.get("poll_title", "")
-                # Split "name (Latin)" pattern
-                if "(" in poll_title and ")" in poll_title:
-                    name = poll_title.split("(", 1)[0].strip()
-                    latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
-                else:
-                    name = poll_title.strip()
-                    latin = ""
-                poll_titles.append(
-                    {"name": name, "latin": latin, "poll_id": poll.get("poll_id")}
-                )
+            poll_titles, warnings = poll_titles_from_contamination(
+                data.get("contamination", [])
+            )
         except Exception as e:
             print(f"{lang_code}: [parse error: {e}]")
             db[lang_code] = {"error": f"parse error: {e}", "lang_code": lang_code}
             save_db(db)
             time.sleep(DELAY_SEC)
             continue
+
+        for warning in warnings:
+            print(f"{lang_code}: WARNING: {warning}")
+
         entry = {
             "lang_code": lang_code,
             "lang": get_language_name(lang_code),
@@ -138,6 +297,24 @@ def main():
         time.sleep(DELAY_SEC)
 
     print(f"Done. See {DB_FILE}")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--repair",
+        action="store_true",
+        help=(
+            "revalidate the latin names already in the file instead of "
+            "fetching; needs no API key and no network"
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.repair:
+        run_repair()
+    else:
+        run_fetch()
 
 
 if __name__ == "__main__":

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -335,6 +335,35 @@ def unreadable_entry_warning(db, lang_code):
     )
 
 
+def entry_after_retry(previous, entry):
+    """Return the entry to store, given what the file already held.
+
+    A retry may improve an entry and may not impoverish it. An entry marked
+    incomplete is fetched again, and that retry can fail or come back
+    malformed; storing the error entry it produces would drop allergen names
+    the file already had, which is the trade the incomplete marker exists to
+    refuse. Eleven localized names beside a failure are worth more to a sensor
+    than none, exactly as they were worth more than an error entry.
+
+    So a failure keeps what was there, records that the retry failed, and
+    leaves the language retryable. The stored message says the names are from
+    an earlier fetch, because an entry carrying both names and a failure
+    should not read as a clean partial.
+    """
+    if "error" not in entry:
+        return entry
+    if not isinstance(previous, dict) or not previous.get("poll_titles"):
+        return entry
+
+    kept = dict(previous)
+    kept["incomplete"] = True
+    kept["retry_error"] = (
+        f"the last retry failed ({entry['error']}); the allergen names in this "
+        f"entry are from an earlier fetch"
+    )
+    return kept
+
+
 def language_entry_from_response(lang_code, data):
     """Return the db entry for one language's response, plus warnings.
 
@@ -517,13 +546,16 @@ def run_fetch():
             "longitude": LON,
             "apikey": api_key,
         }
+        previous = db.get(lang_code)
         try:
             resp = requests.get(base_url, params=params, headers=HEADERS, timeout=20)
             resp.raise_for_status()
             data = resp.json()
         except Exception as e:
             print(f"{lang_code}: [request error: {e}]")
-            db[lang_code] = {"error": str(e), "lang_code": lang_code}
+            db[lang_code] = entry_after_retry(
+                previous, {"error": str(e), "lang_code": lang_code}
+            )
             save_db(db)
             time.sleep(DELAY_SEC)
             continue
@@ -538,9 +570,12 @@ def run_fetch():
         for warning in warnings:
             print(f"{lang_code}: WARNING: {warning}")
 
+        entry = entry_after_retry(previous, entry)
         db[lang_code] = entry
         if "error" in entry:
             print(f"{lang_code}: [{entry['error']}]")
+        elif "retry_error" in entry:
+            print(f"{lang_code}: [{entry['retry_error']}]")
         else:
             print(f"{lang_code}: OK, {len(entry['poll_titles'])} allergens")
         save_db(db)

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -69,11 +69,22 @@ HEADERS = {
 
 
 def load_db():
-    """Load the existing language_map.json, or return empty dict."""
+    """Load the existing language_map.json, or return empty dict.
+
+    A file that is not JSON at all stops the run. Treating it as an empty db
+    would be the destructive reading: the fetch would refetch every language
+    and write over whatever was in there.
+    """
     if not os.path.exists(DB_FILE):
         return {}
     with open(DB_FILE, "r", encoding="utf-8") as f:
-        return json.load(f)
+        try:
+            return json.load(f)
+        except json.JSONDecodeError as e:
+            raise SystemExit(
+                f"{DB_FILE} is not valid JSON ({e}). Fix or remove it; this "
+                f"script will not overwrite a file it cannot read."
+            ) from e
 
 
 def save_db(db):
@@ -378,6 +389,12 @@ def run_fetch():
     api_key = os.environ["API_KEY"]
 
     db = load_db()
+    if not isinstance(db, dict):
+        raise SystemExit(
+            f"{DB_FILE} does not hold an object at its root, but a "
+            f"{type(db).__name__}. Fix or remove it; this script will not "
+            f"overwrite a file it cannot read."
+        )
     base_url = "https://www.polleninformation.at/api/forecast/public"
 
     for lang_code in LANG_CODES:

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -234,6 +234,54 @@ def poll_titles_from_contamination(contamination):
     return poll_titles, warnings
 
 
+def needs_fetch(db, lang_code):
+    """Whether a language still has to be fetched.
+
+    An entry that records an error is retried, which is the only reason the
+    error is written to the file at all: a language whose response could not
+    be read has to come back on the next run rather than sit there forever.
+    """
+    entry = db.get(lang_code)
+    return not isinstance(entry, dict) or "error" in entry
+
+
+def language_entry_from_response(lang_code, data):
+    """Return the db entry for one language's response, plus warnings.
+
+    A response this cannot take a single allergen from is recorded as an
+    error, whatever shape caused it: a top level that is not an object, no
+    contamination block, a block that is not a list, an empty block, or a
+    block of entries none of which could be read.
+
+    An empty response and a malformed one are not distinguishable here, and
+    for this file they do not need to be. Both leave a language with no
+    allergen names, which is the one thing the file exists to hold, so both
+    have to be fetched again rather than saved as a language that legitimately
+    has none. Recording either as a success would be permanent: needs_fetch
+    only retries an entry that carries an error.
+    """
+    warnings = []
+    poll_titles = []
+    if not isinstance(data, dict):
+        error = (
+            f"malformed response: the top level is {type(data).__name__}, not an object"
+        )
+    elif "contamination" not in data:
+        error = "malformed response: no contamination block"
+    else:
+        poll_titles, warnings = poll_titles_from_contamination(data["contamination"])
+        error = "the response carries no allergens" if not poll_titles else None
+
+    if error:
+        return {"error": error, "lang_code": lang_code}, warnings
+
+    return {
+        "lang_code": lang_code,
+        "lang": get_language_name(lang_code),
+        "poll_titles": poll_titles,
+    }, warnings
+
+
 def repair_db(db):
     """Revalidate every latin name already in the db, in place.
 
@@ -310,7 +358,7 @@ def run_fetch():
     base_url = "https://www.polleninformation.at/api/forecast/public"
 
     for lang_code in LANG_CODES:
-        if lang_code in db and "error" not in db[lang_code]:
+        if not needs_fetch(db, lang_code):
             print(f"{lang_code}: Already in db, skipping.")
             continue
 
@@ -337,19 +385,16 @@ def run_fetch():
         # cannot be read costs its own line and not the whole language, and a
         # bug here surfaces as a traceback rather than as an error entry
         # persisted in a file that is never refetched.
-        contamination = data.get("contamination", []) if isinstance(data, dict) else []
-        poll_titles, warnings = poll_titles_from_contamination(contamination)
+        entry, warnings = language_entry_from_response(lang_code, data)
 
         for warning in warnings:
             print(f"{lang_code}: WARNING: {warning}")
 
-        entry = {
-            "lang_code": lang_code,
-            "lang": get_language_name(lang_code),
-            "poll_titles": poll_titles,
-        }
         db[lang_code] = entry
-        print(f"{lang_code}: OK, {len(poll_titles)} allergens")
+        if "error" in entry:
+            print(f"{lang_code}: [{entry['error']}]")
+        else:
+            print(f"{lang_code}: OK, {len(entry['poll_titles'])} allergens")
         save_db(db)
         time.sleep(DELAY_SEC)
 

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -335,33 +335,82 @@ def unreadable_entry_warning(db, lang_code):
     )
 
 
+def allergen_key(poll):
+    """Return what identifies an allergen ACROSS two fetches of one language.
+
+    poll_id first, because it is the API's own identifier and the one thing
+    that survives a latin name being corrected: keying on the latin instead
+    would file the corrected spelling as a second allergen rather than as the
+    same one. Then the latin name, then the display name, for an entry the API
+    sent without an id.
+    """
+    poll_id = poll.get("poll_id")
+    if poll_id is not None:
+        return ("poll_id", poll_id)
+    if latin := poll.get("latin"):
+        return ("latin", latin.strip().lower())
+    if name := poll.get("name"):
+        return ("name", name.strip().lower())
+    return None
+
+
 def entry_after_retry(previous, entry):
     """Return the entry to store, given what the file already held.
 
     A retry may improve an entry and may not impoverish it. An entry marked
-    incomplete is fetched again, and that retry can fail or come back
-    malformed; storing the error entry it produces would drop allergen names
-    the file already had, which is the trade the incomplete marker exists to
-    refuse. Eleven localized names beside a failure are worth more to a sensor
-    than none, exactly as they were worth more than an error entry.
+    incomplete is fetched again, and that retry can come back failed, poorer,
+    or clean. Only the last of those may replace what is there.
 
-    So a failure keeps what was there, records that the retry failed, and
-    leaves the language retryable. The stored message says the names are from
-    an earlier fetch, because an entry carrying both names and a failure
-    should not read as a clean partial.
+    A FAILED retry keeps everything and records that it failed. The stored
+    message says the names are from an earlier fetch, because an entry
+    carrying both names and a failure should not read as a clean partial.
+
+    A POORER retry, one that is itself incomplete, is merged per allergen:
+    every name it did read wins, since it is the newer one, and every allergen
+    it did not read keeps the name the file already had. Neither half of a
+    wholesale comparison is right on its own. Keeping the old entry because it
+    has more names would throw away a name the API has just corrected;
+    replacing it because the response is newer would drop ten names to gain
+    one, which is the trade the incomplete marker exists to refuse.
+
+    A CLEAN retry replaces the entry outright, which is what bounds the merge.
+    An allergen that has genuinely left the API for this language disappears
+    from the file on the first response that reads cleanly. Until then the
+    response is one we have admitted we cannot fully read, and in it a missing
+    allergen and an unreadable one are the same observation: the entry we
+    could not read may BE the allergen that looks missing. Dropping it would
+    infer a disappearance from the one response that cannot support the
+    inference.
     """
-    if "error" not in entry:
-        return entry
-    if not isinstance(previous, dict) or not previous.get("poll_titles"):
+    if "error" in entry:
+        if not isinstance(previous, dict) or not previous.get("poll_titles"):
+            return entry
+        kept = dict(previous)
+        kept["incomplete"] = True
+        kept["retry_error"] = (
+            f"the last retry failed ({entry['error']}); the allergen names in "
+            f"this entry are from an earlier fetch"
+        )
+        return kept
+
+    if not entry.get("incomplete") or not isinstance(previous, dict):
         return entry
 
-    kept = dict(previous)
-    kept["incomplete"] = True
-    kept["retry_error"] = (
-        f"the last retry failed ({entry['error']}); the allergen names in this "
-        f"entry are from an earlier fetch"
-    )
-    return kept
+    previous_titles = previous.get("poll_titles")
+    if not isinstance(previous_titles, list):
+        return entry
+
+    fresh_keys = {allergen_key(poll) for poll in entry["poll_titles"]}
+    kept = [
+        poll
+        for poll in previous_titles
+        if isinstance(poll, dict)
+        and (key := allergen_key(poll)) is not None
+        and key not in fresh_keys
+    ]
+    if not kept:
+        return entry
+    return {**entry, "poll_titles": [*entry["poll_titles"], *kept]}
 
 
 def language_entry_from_response(lang_code, data):

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -265,6 +265,11 @@ def repair_db(db):
                 continue
             name = poll.get("name") or ""
             latin = poll.get("latin") or ""
+            if not isinstance(name, str) or not isinstance(latin, str):
+                warnings.append(
+                    f"{lang_code}: name or latin is not a string, skipping: {poll!r}"
+                )
+                continue
             resolved, entry_warnings = resolve_latin(name, latin)
             warnings.extend(f"{lang_code}: {w}" for w in entry_warnings)
             if resolved != latin:

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -31,9 +31,8 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from custom_components.polleninformation.sensor import (
+    LATIN_NAME_ALIASES,
     canonical_latin,
-    english_name_for_display_name,
-    english_name_for_latin,
 )
 
 # ================================
@@ -135,12 +134,20 @@ def resolve_latin(name, latin):
     not always use brackets at all, so a transcribed latin name is checked
     against the integration's own maps before it is trusted:
 
-    1. a latin name LATIN_TO_ENGLISH_NAME knows is recorded as sent;
+    1. a latin name LATIN_TO_ENGLISH_NAME knows is recorded under that map's
+       own key, so "poaceae" and "Ambrosia artemisiifolia" are recorded as
+       "Poaceae" and "Ambrosia";
     2. a spelling LATIN_NAME_ALIASES declares, such as the Slovak "ambrózia",
        is recorded as the latin name it stands for;
     3. the display name is read as a latin name only when the API sent none,
        which is the shape reported in issue #71;
     4. anything else is warned about and recorded exactly as the API sent it.
+
+    Rungs 1 to 3 all record a key of LATIN_TO_ENGLISH_NAME, never the string
+    the API happened to send, because every consumer of this file matches a
+    latin name exactly: an entry recorded as "Ambrosia artemisiifolia" is not
+    found again by the restore path, which holds "Ambrosia". The name field
+    already preserves the API's own wording.
 
     A latin name the API did send is otherwise authoritative even when nothing
     resolves it, exactly as it is for the sensors: "Artemisia (Asteraceae)" is
@@ -151,25 +158,30 @@ def resolve_latin(name, latin):
     hide a genuinely new allergen, which is the one case where this file has
     something to tell us.
     """
-    if latin and english_name_for_latin(latin):
-        canonical = canonical_latin(latin)
-        if canonical != latin:
+    if latin and (canonical := canonical_latin(latin)):
+        if canonical == latin:
+            return latin, []
+        if latin.strip().lower() in LATIN_NAME_ALIASES:
             warning = (
                 f"{name!r}: the API sent {latin!r} where the latin name goes, "
                 f"which is a known spelling of {canonical!r}; recording that"
             )
-            return canonical, [warning]
-        return latin, []
+        else:
+            warning = (
+                f"{name!r}: the API spells the latin name {latin!r}; recording "
+                f"it as {canonical!r}, the spelling every lookup matches on"
+            )
+        return canonical, [warning]
 
     sent = f"latin name {latin!r}" if latin else "no latin name"
 
-    if not latin and english_name_for_display_name(name):
+    if not latin and (canonical := canonical_latin(name)):
         # The display name is itself a latin name, so record it as one.
         warning = (
             f"{name!r}: the API sent {sent} and a display name that is one; "
-            f"recording {name!r}"
+            f"recording {canonical!r}"
         )
-        return name, [warning]
+        return canonical, [warning]
 
     if latin:
         warning = (

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -136,6 +136,27 @@ def split_poll_title(poll_title):
     return name, latin
 
 
+# Everything a scientific name is allowed to be made of. The nomenclature
+# codes require a name to be written in Latin letters, so a name never carries
+# a diacritic or a non-Latin script; the multiplication sign is the one
+# exception, since it marks a hybrid ("Ambrosia x helenae" is also written
+# with it).
+SCIENTIFIC_NAME_CHARACTERS = set(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ .-'×"
+)
+
+
+def could_be_a_scientific_name(latin):
+    """Return whether a string could be a scientific name at all.
+
+    This does not say the name exists, only that nothing rules it out. A
+    string carrying a diacritic or a non-Latin script cannot be one, which is
+    how a localized word the API put between the brackets is told apart from
+    a genuine latin name the static map happens not to know.
+    """
+    return bool(latin) and set(latin) <= SCIENTIFIC_NAME_CHARACTERS
+
+
 def resolve_latin(name, latin):
     """Return the latin name to record for an entry, plus any warnings.
 
@@ -146,6 +167,14 @@ def resolve_latin(name, latin):
     shape reported in issue #71, or the English allergen name, which is what
     the API sends for ragweed in some languages.
 
+    A latin name the API did send is authoritative even when nothing resolves
+    it, exactly as it is for the sensors: "Artemisia (Asteraceae)" is the
+    composite family, not mugwort, and reading its display name as a latin
+    name would record it as a different allergen. So the display name is only
+    read as a latin name when the API sent none, and it is only read as an
+    English allergen name when the API sent none or sent something that could
+    not be a scientific name whatever it names.
+
     An entry no lookup recognizes is warned about and recorded exactly as the
     API sent it. Dropping it would hide a genuinely new allergen, which is the
     one case where this file has something to tell us.
@@ -155,7 +184,7 @@ def resolve_latin(name, latin):
 
     sent = f"latin name {latin!r}" if latin else "no latin name"
 
-    if english := english_name_for_display_name(name):
+    if not latin and (english := english_name_for_display_name(name)):
         canonical = ENGLISH_NAME_TO_LATIN[english]
         warning = (
             f"{name!r}: the API sent {sent} and a display name that is one; "
@@ -163,18 +192,28 @@ def resolve_latin(name, latin):
         )
         return canonical, [warning]
 
-    if canonical := ENGLISH_NAME_TO_LATIN.get(name.strip().lower()):
+    if not could_be_a_scientific_name(latin) and (
+        canonical := ENGLISH_NAME_TO_LATIN.get(name.strip().lower())
+    ):
         warning = (
             f"{name!r}: the API sent {sent} and an untranslated English "
             f"display name; recording {canonical!r}"
         )
         return canonical, [warning]
 
-    warning = (
-        f"{name!r}: the API sent {sent} and a display name no map knows. "
-        f"Recording it as sent. If this is a new allergen it needs adding to "
-        f"LATIN_TO_ENGLISH_NAME in sensor.py; please open an issue."
-    )
+    if latin:
+        warning = (
+            f"{name!r}: the API sent {sent}, which no map knows. Keeping it: "
+            f"a latin name the API sent identifies the allergen even when "
+            f"nothing resolves it. If this is a new allergen it needs adding "
+            f"to LATIN_TO_ENGLISH_NAME in sensor.py; please open an issue."
+        )
+    else:
+        warning = (
+            f"{name!r}: the API sent {sent} and a display name no map knows. "
+            f"Recording it as sent. If this is a new allergen it needs adding "
+            f"to LATIN_TO_ENGLISH_NAME in sensor.py; please open an issue."
+        )
     return latin, [warning]
 
 

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -35,6 +35,7 @@ from custom_components.polleninformation.sensor import (
     canonical_latin,
     canonical_latin_for_display_name,
 )
+from custom_components.polleninformation.utils import parse_poll_title
 
 # ================================
 # CONFIGURATION
@@ -143,19 +144,22 @@ def split_poll_title(poll_title):
     brackets comes back as the latin name, and a title without brackets comes
     back with none. resolve_latin decides what that is worth.
 
-    Total over whatever it is handed: a title that is not a string reads as an
-    empty one. The caller rejects such an entry before it gets here, since a
-    title that cannot be read names no allergen, but the split itself does not
-    raise on one.
+    Delegates to the integration's own parse, so that the file and the sensors
+    read a title the same way rather than nearly the same way. They differed
+    on the unmatched bracket: this kept "Artemisia (" whole and recorded
+    nothing, while the sensors split at the bracket and read mugwort.
+
+    The seam is the return shape. The shared parse answers None for a title
+    that identifies nothing and None for an absent latin name; this answers a
+    pair either way, with "" where there is no latin name, because resolve_latin
+    is written against strings and the caller decides what to do with a title
+    that names nothing.
     """
-    poll_title = poll_title if isinstance(poll_title, str) else ""
-    if "(" in poll_title and ")" in poll_title:
-        name = poll_title.split("(", 1)[0].strip()
-        latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
-    else:
-        name = poll_title.strip()
-        latin = ""
-    return name, latin
+    parsed = parse_poll_title(poll_title)
+    if parsed is None:
+        return "", ""
+    name, latin = parsed
+    return name, latin or ""
 
 
 def resolve_latin(name, latin):

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -304,12 +304,20 @@ def repair_db(db):
     Entries are only ever rewritten, never removed: an allergen no map knows
     keeps what the API sent and is warned about again.
 
-    Total over whatever the file holds. This is the tool you reach for when
-    the file is wrong, so a shape it did not expect is reported with the
-    language it sits in rather than raised as a traceback that names neither.
+    Total over whatever the file holds, from the root down. This is the tool
+    you reach for when the file is wrong, so a shape it did not expect is
+    reported, with the language it sits in where there is one, rather than
+    raised as a traceback that names neither. Nothing is rewritten on the way:
+    a file this cannot read is left exactly as it is.
     """
     changes = []
     warnings = []
+    if not isinstance(db, dict):
+        warning = (
+            f"the file does not hold an object at its root, but a "
+            f"{type(db).__name__}; nothing to repair"
+        )
+        return changes, [warning]
     for lang_code, entry in db.items():
         if not isinstance(entry, dict):
             warnings.append(f"{lang_code}: not an object, skipping: {entry!r}")

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -15,7 +15,7 @@ file with the same rules the fetch mode applies to a fresh response, which is
 what lets an entry recorded before those rules existed correct itself. Run it
 after changing the validation, and review the diff.
 
-Both modes take their authority from LATIN_TO_ENGLISH_NAME in sensor.py, so
+Both modes take their authority from the allergen maps in sensor.py, so
 this script imports the integration and therefore needs Home Assistant
 installed (the test venv has it).
 """
@@ -31,7 +31,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from custom_components.polleninformation.sensor import (
-    LATIN_TO_ENGLISH_NAME,
+    canonical_latin,
     english_name_for_display_name,
     english_name_for_latin,
 )
@@ -66,14 +66,6 @@ DELAY_SEC = 2  # Polite delay between requests (adjust if needed)
 HEADERS = {
     "Accept": "application/json, text/plain, */*",
     "User-Agent": "Mozilla/5.0 (compatible; polleninfo-script/1.0)",
-}
-
-# The reverse of LATIN_TO_ENGLISH_NAME. The English names are unique, so this
-# is lossless. It is the last resort for an entry whose display name is the
-# English allergen name rather than a localized one, which is what the API
-# sends for ragweed in some languages.
-ENGLISH_NAME_TO_LATIN = {
-    name.lower(): latin for latin, name in LATIN_TO_ENGLISH_NAME.items()
 }
 
 
@@ -136,77 +128,57 @@ def split_poll_title(poll_title):
     return name, latin
 
 
-# Everything a scientific name is allowed to be made of. The nomenclature
-# codes require a name to be written in Latin letters, so a name never carries
-# a diacritic or a non-Latin script; the multiplication sign is the one
-# exception, since it marks a hybrid ("Ambrosia x helenae" is also written
-# with it).
-SCIENTIFIC_NAME_CHARACTERS = set(
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ .-'×"
-)
-
-
-def could_be_a_scientific_name(latin):
-    """Return whether a string could be a scientific name at all.
-
-    This does not say the name exists, only that nothing rules it out. A
-    string carrying a diacritic or a non-Latin script cannot be one, which is
-    how a localized word the API put between the brackets is told apart from
-    a genuine latin name the static map happens not to know.
-    """
-    return bool(latin) and set(latin) <= SCIENTIFIC_NAME_CHARACTERS
-
-
 def resolve_latin(name, latin):
     """Return the latin name to record for an entry, plus any warnings.
 
     The API does not always put a latin name between the brackets, and does
     not always use brackets at all, so a transcribed latin name is checked
-    against LATIN_TO_ENGLISH_NAME before it is trusted. When it fails, the
-    display name is the second chance: it is either a latin name itself, the
-    shape reported in issue #71, or the English allergen name, which is what
-    the API sends for ragweed in some languages.
+    against the integration's own maps before it is trusted:
 
-    A latin name the API did send is authoritative even when nothing resolves
-    it, exactly as it is for the sensors: "Artemisia (Asteraceae)" is the
-    composite family, not mugwort, and reading its display name as a latin
-    name would record it as a different allergen. So the display name is only
-    read as a latin name when the API sent none, and it is only read as an
-    English allergen name when the API sent none or sent something that could
-    not be a scientific name whatever it names.
+    1. a latin name LATIN_TO_ENGLISH_NAME knows is recorded as sent;
+    2. a spelling LATIN_NAME_ALIASES declares, such as the Slovak "ambrózia",
+       is recorded as the latin name it stands for;
+    3. the display name is read as a latin name only when the API sent none,
+       which is the shape reported in issue #71;
+    4. anything else is warned about and recorded exactly as the API sent it.
 
-    An entry no lookup recognizes is warned about and recorded exactly as the
-    API sent it. Dropping it would hide a genuinely new allergen, which is the
-    one case where this file has something to tell us.
+    A latin name the API did send is otherwise authoritative even when nothing
+    resolves it, exactly as it is for the sensors: "Artemisia (Asteraceae)" is
+    the composite family, not mugwort, and reading its display name as a latin
+    name would record it as a different allergen. Only a spelling declared in
+    the alias table overrides what the API sent, so an unknown latin name is
+    never guessed at, and dropping it is never an option either: that would
+    hide a genuinely new allergen, which is the one case where this file has
+    something to tell us.
     """
     if latin and english_name_for_latin(latin):
+        canonical = canonical_latin(latin)
+        if canonical != latin:
+            warning = (
+                f"{name!r}: the API sent {latin!r} where the latin name goes, "
+                f"which is a known spelling of {canonical!r}; recording that"
+            )
+            return canonical, [warning]
         return latin, []
 
     sent = f"latin name {latin!r}" if latin else "no latin name"
 
-    if not latin and (english := english_name_for_display_name(name)):
-        canonical = ENGLISH_NAME_TO_LATIN[english]
+    if not latin and english_name_for_display_name(name):
+        # The display name is itself a latin name, so record it as one.
         warning = (
             f"{name!r}: the API sent {sent} and a display name that is one; "
-            f"recording {canonical!r}"
+            f"recording {name!r}"
         )
-        return canonical, [warning]
-
-    if not could_be_a_scientific_name(latin) and (
-        canonical := ENGLISH_NAME_TO_LATIN.get(name.strip().lower())
-    ):
-        warning = (
-            f"{name!r}: the API sent {sent} and an untranslated English "
-            f"display name; recording {canonical!r}"
-        )
-        return canonical, [warning]
+        return name, [warning]
 
     if latin:
         warning = (
             f"{name!r}: the API sent {sent}, which no map knows. Keeping it: "
             f"a latin name the API sent identifies the allergen even when "
             f"nothing resolves it. If this is a new allergen it needs adding "
-            f"to LATIN_TO_ENGLISH_NAME in sensor.py; please open an issue."
+            f"to LATIN_TO_ENGLISH_NAME in sensor.py, and a spelling that is "
+            f"not a latin name at all to LATIN_NAME_ALIASES; please open an "
+            f"issue."
         )
     else:
         warning = (

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -299,9 +299,17 @@ def needs_fetch(db, lang_code):
     An entry that records an error is retried, which is the only reason the
     error is written to the file at all: a language whose response could not
     be read has to come back on the next run rather than sit there forever.
+
+    So is an entry that is incomplete. A response can be readable and still
+    have lost an allergen to a malformed entry, and nothing else would ever
+    revisit it: this skips a saved language, and --repair cannot invent an
+    entry that was never recorded. Left alone it would be permanently missing
+    one allergen with nothing to say so.
     """
     entry = db.get(lang_code)
-    return not isinstance(entry, dict) or "error" in entry
+    if not isinstance(entry, dict):
+        return True
+    return "error" in entry or bool(entry.get("incomplete"))
 
 
 def unreadable_entry_warning(db, lang_code):
@@ -335,10 +343,18 @@ def language_entry_from_response(lang_code, data):
     allergen names, which is the one thing the file exists to hold, so both
     have to be fetched again rather than saved as a language that legitimately
     has none. Recording either as a success would be permanent: needs_fetch
-    only retries an entry that carries an error.
+    only retries an entry that carries an error or is marked incomplete.
+
+    A response that lost SOME of its entries is marked incomplete and keeps
+    the ones it had. The entry is worth keeping, because eleven names are
+    worth more to a sensor than none, and it may not be treated as finished,
+    because nothing else would ever come back for the twelfth: this file is
+    only fetched for languages it lacks, and --repair cannot invent an entry
+    that was never recorded.
     """
     warnings = []
     poll_titles = []
+    dropped = 0
     if not isinstance(data, dict):
         error = (
             f"malformed response: the top level is {type(data).__name__}, not an object"
@@ -346,17 +362,28 @@ def language_entry_from_response(lang_code, data):
     elif "contamination" not in data:
         error = "malformed response: no contamination block"
     else:
-        poll_titles, warnings = poll_titles_from_contamination(data["contamination"])
+        contamination = data["contamination"]
+        poll_titles, warnings = poll_titles_from_contamination(contamination)
         error = "the response carries no allergens" if not poll_titles else None
+        if isinstance(contamination, list):
+            dropped = len(contamination) - len(poll_titles)
 
     if error:
         return {"error": error, "lang_code": lang_code}, warnings
 
-    return {
+    entry = {
         "lang_code": lang_code,
         "lang": get_language_name(lang_code),
         "poll_titles": poll_titles,
-    }, warnings
+    }
+    if dropped:
+        entry["incomplete"] = True
+        incomplete_warning = (
+            f"{dropped} entry(ies) could not be read, so this language is "
+            f"recorded as incomplete and will be fetched again"
+        )
+        warnings = [*warnings, incomplete_warning]
+    return entry, warnings
 
 
 def repair_db(db):

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -33,6 +33,7 @@ sys.path.insert(0, str(REPO_ROOT))
 from custom_components.polleninformation.sensor import (
     LATIN_NAME_ALIASES,
     canonical_latin,
+    canonical_latin_for_display_name,
 )
 
 # ================================
@@ -170,7 +171,8 @@ def resolve_latin(name, latin):
     2. a spelling LATIN_NAME_ALIASES declares, such as the Slovak "ambrózia",
        is recorded as the latin name it stands for;
     3. the display name is read as a latin name only when the API sent none,
-       which is the shape reported in issue #71;
+       which is the shape reported in issue #71, and only on an exact match,
+       because prose that begins with a genus is not an identity;
     4. anything else is warned about and recorded exactly as the API sent it.
 
     An entry whose display name is blank is warned about too, and kept: a
@@ -218,8 +220,11 @@ def resolve_latin(name, latin):
 
     sent = f"latin name {latin!r}" if latin else "no latin name"
 
-    if not latin and (canonical := canonical_latin(name)):
-        # The display name is itself a latin name, so record it as one.
+    if not latin and (canonical := canonical_latin_for_display_name(name)):
+        # The display name is itself a latin name, so record it as one. The
+        # lookup is exact, with no genus fallback: "Ambrosia hojas" is prose
+        # that begins with a genus, and recording it as Ambrosia would file
+        # the entry under an allergen the sensors refuse to read it as.
         warning = (
             f"{name!r}: the API sent {sent} and a display name that is one; "
             f"recording {canonical!r}"

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -252,13 +252,16 @@ def poll_titles_from_contamination(contamination):
     allergen, and dropping it would hide a new one.
 
     Two shapes are the exception, and they are the opposite case. An entry
-    that is not an object, and an entry with no readable title, name nothing
-    at all. Recording those would not preserve information, it would
-    manufacture a well-formed record out of nothing, and a block of them would
-    then look like a language that has allergens. Both are warned about rather
-    than passed over, and a block left empty by them is a response with no
-    allergens, which language_entry_from_response records as an error so the
-    language is fetched again.
+    that is not an object, and an entry that identifies no allergen, name
+    nothing at all. The second is the parsed test rather than a test on the
+    raw title: a title is kept when it has a display name or a latin name,
+    so "(Poaceae)" is kept for its latin name and "()" is not, any more than
+    a missing title is. Recording those would not preserve information, it
+    would manufacture a well-formed record out of nothing, and a block of
+    them would then look like a language that has allergens. Both are warned
+    about rather than passed over, and a block left empty by them is a
+    response with no allergens, which language_entry_from_response records as
+    an error so the language is fetched again.
     """
     poll_titles = []
     warnings = []
@@ -272,13 +275,16 @@ def poll_titles_from_contamination(contamination):
                 f"skipping a contamination entry that is not an object: {poll!r}"
             )
             continue
-        poll_title = poll.get("poll_title")
-        if not isinstance(poll_title, str) or not poll_title.strip():
+        name, latin = split_poll_title(poll.get("poll_title"))
+        if not name and not latin:
+            # The test is what the entry identifies, not whether its title is
+            # readable. "()" and "( )" are non-blank titles with nothing in
+            # either half, and they name an allergen exactly as little as a
+            # missing title does.
             warnings.append(
-                f"skipping a contamination entry with no readable title: {poll!r}"
+                f"skipping a contamination entry that identifies no allergen: {poll!r}"
             )
             continue
-        name, latin = split_poll_title(poll_title)
         latin, entry_warnings = resolve_latin(name, latin)
         warnings.extend(entry_warnings)
         poll_titles.append(

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -68,13 +68,17 @@ class TestResolveLatin:
         assert latin == "Ambrosia artemisiifolia"
         assert warnings == []
 
-    def test_localized_word_in_brackets_is_replaced_from_the_display_name(self, script):
-        # The sk shape: the API put a Slovak word where the latin name goes,
-        # and left the display name in English.
+    def test_a_declared_alias_is_recorded_as_the_name_it_stands_for(self, script):
+        # The sk shape: the API put the Slovak word for ragweed where the
+        # latin name goes. That spelling is declared in LATIN_NAME_ALIASES,
+        # which is the only thing that may override what the API sent.
         latin, warnings = script.resolve_latin("Ragweed", "ambrózia")
         assert latin == "Ambrosia"
         assert len(warnings) == 1
         assert "ambrózia" in warnings[0]
+
+    def test_an_alias_is_matched_case_insensitively(self, script):
+        assert script.resolve_latin("Ragweed", "Ambrózia")[0] == "Ambrosia"
 
     def test_display_name_that_is_a_latin_name_supplies_the_missing_latin(self, script):
         # The es shape, and the shape reported in issue #71.
@@ -92,18 +96,14 @@ class TestResolveLatin:
         assert len(warnings) == 1
         assert "Keeping it" in warnings[0]
 
-    def test_a_latin_the_api_sent_outranks_an_english_display_name(self, script):
-        # The same rule for the English-name lookup: "Asteraceae" could be a
-        # scientific name, so it identifies the allergen whatever the display
-        # name says.
+    def test_an_english_display_name_never_overrides_a_latin_one(self, script):
+        # "Ragweed (Asteraceae)" is the case that ruled out inferring a latin
+        # name from the display name. Asteraceae is not a declared alias, so
+        # nothing touches it.
         latin, warnings = script.resolve_latin("Ragweed", "Asteraceae")
         assert latin == "Asteraceae"
         assert len(warnings) == 1
         assert "Keeping it" in warnings[0]
-
-    def test_a_hybrid_name_the_map_does_not_know_is_kept(self, script):
-        latin, _ = script.resolve_latin("Ragweed", "Asteraceae × nova")
-        assert latin == "Asteraceae × nova"
 
     def test_unknown_latin_is_kept_as_sent_and_warned_about(self, script):
         latin, warnings = script.resolve_latin("Nässlor", "Nonexistentia")
@@ -116,26 +116,6 @@ class TestResolveLatin:
         assert latin == ""
         assert len(warnings) == 1
         assert "no latin name" in warnings[0]
-
-
-class TestCouldBeAScientificName:
-    """What tells a latin name the map does not know from a localized word.
-
-    This is the whole safety argument for the English-name lookup: it may
-    only override what the API put between the brackets when that string
-    cannot be a scientific name whatever it names.
-    """
-
-    @pytest.mark.parametrize(
-        "latin",
-        ["Asteraceae", "Ambrosia artemisiifolia", "Ambrosia × helenae", "Poaceae"],
-    )
-    def test_latin_names_could_be_one(self, script, latin):
-        assert script.could_be_a_scientific_name(latin)
-
-    @pytest.mark.parametrize("latin", ["ambrózia", "Амброзия", "パセリ", "", "räven"])
-    def test_a_localized_word_could_not(self, script, latin):
-        assert not script.could_be_a_scientific_name(latin)
 
 
 class TestPollTitlesFromContamination:

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -310,7 +310,30 @@ class TestRepairDb:
 
 
 class TestShippedLanguageMap:
-    """The file itself, as shipped."""
+    """The file itself, as shipped.
+
+    The map may not carry an allergen the integration does not know. That is
+    deliberate, and it is why these two fail rather than pass when the API
+    adds one: the generator writes an unknown allergen through on purpose, so
+    that it reaches a human. The fix when they go red is to add the allergen
+    to LATIN_TO_ENGLISH_NAME in sensor.py, or its spelling to
+    LATIN_NAME_ALIASES if that is what it turns out to be. It is never to
+    relax the assertion, and never to delete the entry from the file.
+    """
+
+    def test_no_recorded_latin_name_is_a_known_bad_spelling(self, script):
+        # The narrow half of the tripwire: whatever else the file holds, it
+        # may not hold a spelling we have already established is not a latin
+        # name, nor an entry with no latin name at all. This one stays true
+        # even for an allergen the integration does not know yet.
+        db = json.loads(LANGUAGE_MAP.read_text(encoding="utf-8"))
+        bad = [
+            (lang_code, entry["name"], entry["latin"])
+            for lang_code, block in db.items()
+            for entry in block.get("poll_titles", [])
+            if not entry["latin"] or entry["latin"].lower() in script.LATIN_NAME_ALIASES
+        ]
+        assert bad == []
 
     def test_every_recorded_latin_name_is_recognized(self, script):
         db = json.loads(LANGUAGE_MAP.read_text(encoding="utf-8"))

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -185,6 +185,94 @@ class TestPollTitlesFromContamination:
         assert poll_titles[0]["name"] == "Ragweed"
 
 
+class TestLanguageEntryFromResponse:
+    """What one language's response is worth, before it reaches the file.
+
+    A response no allergen can be read from is recorded as an error rather
+    than as a language that has none, because only an error entry is fetched
+    again. An empty response and a malformed one are not told apart here: for
+    this file they are the same defect, a language with no allergen names.
+    """
+
+    def test_a_good_response_records_its_allergens(self, script):
+        entry, warnings = script.language_entry_from_response(
+            "sk",
+            {"contamination": [{"poll_title": "Trávy (Poaceae)", "poll_id": 5}]},
+        )
+
+        assert entry["lang_code"] == "sk"
+        assert entry["lang"] == "Slovak"
+        assert entry["poll_titles"] == [
+            {"name": "Trávy", "latin": "Poaceae", "poll_id": 5}
+        ]
+        assert warnings == []
+
+    def test_a_top_level_that_is_not_an_object_is_an_error_entry(self, script):
+        # An array is what an upstream error looks like, and recording it as a
+        # language with no allergens would be permanent.
+        entry, _ = script.language_entry_from_response("sk", [])
+        assert "error" in entry
+        assert "top level" in entry["error"]
+
+    @pytest.mark.parametrize("data", [[], "oops", None, 42])
+    def test_no_malformed_top_level_is_recorded_as_a_success(self, script, data):
+        entry, _ = script.language_entry_from_response("sk", data)
+        assert "error" in entry
+        assert "poll_titles" not in entry
+
+    def test_a_missing_contamination_block_is_an_error_entry(self, script):
+        entry, _ = script.language_entry_from_response("sk", {"allergyrisk": {}})
+        assert "error" in entry
+
+    def test_an_empty_contamination_block_is_an_error_entry(self, script):
+        entry, _ = script.language_entry_from_response("sk", {"contamination": []})
+        assert "error" in entry
+
+    def test_a_block_of_unreadable_entries_is_an_error_entry(self, script):
+        entry, warnings = script.language_entry_from_response(
+            "sk", {"contamination": ["oops", "also oops"]}
+        )
+        assert "error" in entry
+        assert len(warnings) == 2
+
+    def test_a_readable_entry_beside_an_unreadable_one_is_kept(self, script):
+        entry, warnings = script.language_entry_from_response(
+            "sk",
+            {
+                "contamination": [
+                    "oops",
+                    {"poll_title": "Trávy (Poaceae)", "poll_id": 5},
+                ]
+            },
+        )
+        assert [poll["latin"] for poll in entry["poll_titles"]] == ["Poaceae"]
+        assert len(warnings) == 1
+
+
+class TestNeedsFetch:
+    """Which languages the next run goes back for."""
+
+    def test_a_language_that_is_not_there_is_fetched(self, script):
+        assert script.needs_fetch({}, "sk")
+
+    def test_a_recorded_language_is_not_refetched(self, script):
+        db = {"sk": {"lang_code": "sk", "poll_titles": []}}
+        assert not script.needs_fetch(db, "sk")
+
+    def test_an_error_entry_is_retried(self, script):
+        db = {"sk": {"lang_code": "sk", "error": "request error: timeout"}}
+        assert script.needs_fetch(db, "sk")
+
+    def test_a_malformed_response_is_retried_on_the_next_run(self, script):
+        # The two halves together: a response that cannot be read is recorded
+        # as an error, and an error is what the next run comes back for.
+        entry, _ = script.language_entry_from_response("sk", [])
+        assert script.needs_fetch({"sk": entry}, "sk")
+
+    def test_a_language_that_is_not_an_object_is_refetched(self, script):
+        assert script.needs_fetch({"sk": "oops"}, "sk")
+
+
 class TestRepairDb:
     """The offline pass that lets an already recorded entry correct itself."""
 

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -119,6 +119,22 @@ class TestResolveLatin:
         assert len(warnings) == 1
         assert "Keeping it" in warnings[0]
 
+    def test_a_blank_display_name_is_kept_and_warned_about(self, script):
+        # "(Poaceae)" names its allergen, so dropping it would be the mistake,
+        # but the file holds half a pairing and that is worth reporting.
+        latin, warnings = script.resolve_latin("", "Poaceae")
+
+        assert latin == "Poaceae"
+        assert len(warnings) == 1
+        assert "no display name" in warnings[0]
+        assert "Poaceae" in warnings[0]
+
+    def test_a_blank_name_beside_a_spelling_fix_warns_about_both(self, script):
+        latin, warnings = script.resolve_latin("", "poaceae")
+
+        assert latin == "Poaceae"
+        assert len(warnings) == 2
+
     def test_unknown_latin_is_kept_as_sent_and_warned_about(self, script):
         latin, warnings = script.resolve_latin("Nässlor", "Nonexistentia")
         assert latin == "Nonexistentia"
@@ -193,6 +209,15 @@ class TestPollTitlesFromContamination:
         )
         assert len(poll_titles) == 1
         assert len(warnings) == 1
+
+    def test_a_title_that_is_only_a_latin_name_is_kept(self, script):
+        poll_titles, warnings = script.poll_titles_from_contamination(
+            [{"poll_title": "(Poaceae)", "poll_id": 5}]
+        )
+
+        assert poll_titles == [{"name": "", "latin": "Poaceae", "poll_id": 5}]
+        assert len(warnings) == 1
+        assert "no display name" in warnings[0]
 
     def test_display_names_are_kept_as_the_api_sent_them(self, script):
         poll_titles, _ = script.poll_titles_from_contamination(

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -228,6 +228,13 @@ class TestLanguageEntryFromResponse:
         entry, _ = script.language_entry_from_response("sk", {"contamination": []})
         assert "error" in entry
 
+    def test_a_contamination_block_that_is_not_a_list_is_an_error_entry(self, script):
+        entry, warnings = script.language_entry_from_response(
+            "sk", {"contamination": "oops"}
+        )
+        assert "error" in entry
+        assert len(warnings) == 1
+
     def test_a_block_of_unreadable_entries_is_an_error_entry(self, script):
         entry, warnings = script.language_entry_from_response(
             "sk", {"contamination": ["oops", "also oops"]}

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -1090,6 +1090,11 @@ class TestTheFileAndTheRuntimeAgree:
             # read the empty brackets as a latin name it could not place and
             # resolve to nothing, while the file recorded Artemisia.
             "Artemisia ()",
+            # An opening bracket and no closing one. The two parses differed
+            # on exactly this: the runtime split at the bracket and read
+            # mugwort, the generator kept the title whole and read nothing.
+            "Artemisia (",
+            "Artemisia (   )",
         ],
     )
     def test_both_sides_resolve_the_same_input_the_same_way(self, script, poll_title):
@@ -1118,6 +1123,12 @@ class TestTheFileAndTheRuntimeAgree:
     def test_empty_brackets_resolve_to_the_display_name_on_both_sides(self, script):
         assert self._runtime_allergen("Artemisia ()") == "mugwort"
         assert self._recorded_allergen(script, "Artemisia ()") == "mugwort"
+
+    def test_an_unmatched_bracket_resolves_to_the_display_name_on_both_sides(
+        self, script
+    ):
+        assert self._runtime_allergen("Artemisia (") == "mugwort"
+        assert self._recorded_allergen(script, "Artemisia (") == "mugwort"
 
 
 class TestShippedLanguageMap:

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -226,6 +226,30 @@ class TestPollTitlesFromContamination:
         assert poll_titles[0]["name"] == "Ragweed"
 
 
+class TestUnreadableEntryWarning:
+    """The one path in this script that destroys something says so first."""
+
+    @pytest.mark.parametrize("entry", ["oops", 42, ["sk"], True])
+    def test_an_entry_that_cannot_be_read_is_announced(self, script, entry):
+        warning = script.unreadable_entry_warning({"sk": entry}, "sk")
+
+        assert warning is not None
+        assert "overwriting" in warning
+        # It is refetched, which is the behaviour being announced.
+        assert script.needs_fetch({"sk": entry}, "sk")
+
+    def test_a_language_that_is_absent_says_nothing(self, script):
+        assert script.unreadable_entry_warning({}, "sk") is None
+
+    def test_an_error_entry_says_nothing(self, script):
+        db = {"sk": {"lang_code": "sk", "error": "request error: timeout"}}
+        assert script.unreadable_entry_warning(db, "sk") is None
+
+    def test_a_good_entry_says_nothing(self, script):
+        db = {"sk": {"lang_code": "sk", "poll_titles": []}}
+        assert script.unreadable_entry_warning(db, "sk") is None
+
+
 class TestLanguageEntryFromResponse:
     """What one language's response is worth, before it reaches the file.
 

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -581,6 +581,30 @@ class TestRunFetchWritesThroughTheRetryRule:
         assert "retry_error" not in db["sk"]
         assert not script.needs_fetch(db, "sk")
 
+    def test_a_poorer_retry_keeps_the_names_it_did_not_read(
+        self, script, monkeypatch, tmp_path
+    ):
+        # Codex's case, driven through the write: three allergens on disk, a
+        # retry that reads one and loses another to a malformed entry.
+        payload = {
+            "contamination": [
+                {"poll_title": "Traviny (Poaceae)", "poll_id": 5},
+                {"poll_title": "()", "poll_id": 2},
+            ]
+        }
+        db = self._run(
+            script,
+            monkeypatch,
+            tmp_path,
+            {"sk": RICHER_PREVIOUS},
+            self._answer(payload),
+        )
+        by_id = {poll["poll_id"]: poll["name"] for poll in db["sk"]["poll_titles"]}
+
+        assert by_id == {5: "Traviny", 2: "Breza", 1: "Jelša"}
+        assert db["sk"]["incomplete"] is True
+        assert script.needs_fetch(db, "sk")
+
     def test_a_language_with_nothing_to_lose_records_the_error(
         self, script, monkeypatch, tmp_path
     ):
@@ -591,6 +615,111 @@ class TestRunFetchWritesThroughTheRetryRule:
 
         assert "error" in db["sk"]
         assert "poll_titles" not in db["sk"]
+
+
+# The same language after a retry that read one allergen and lost another.
+RICHER_PREVIOUS = {
+    "lang_code": "sk",
+    "lang": "Slovak",
+    "poll_titles": [
+        {"name": "Trávy", "latin": "Poaceae", "poll_id": 5},
+        {"name": "Breza", "latin": "Betula", "poll_id": 2},
+        {"name": "Jelša", "latin": "Alnus", "poll_id": 1},
+    ],
+    "incomplete": True,
+}
+
+
+POORER_RETRY = {
+    "lang_code": "sk",
+    "lang": "Slovak",
+    "poll_titles": [{"name": "Traviny", "latin": "Poaceae", "poll_id": 5}],
+    "incomplete": True,
+}
+
+
+class TestAPoorerRetryIsMergedPerAllergen:
+    """The success-but-poorer path, which is the same invariant as the failure.
+
+    A retry that is itself incomplete has read some allergens and lost
+    others. Every name it read is the newer one and wins; every allergen it
+    did not read keeps the name the file already had. Wholesale comparison is
+    wrong in both directions: keeping the old entry for having more names
+    throws away a name the API has just corrected, and taking the new one for
+    being newer drops ten names to gain one.
+    """
+
+    def test_the_names_the_retry_lost_are_kept(self, script):
+        got = script.entry_after_retry(RICHER_PREVIOUS, POORER_RETRY)
+
+        assert {poll["poll_id"] for poll in got["poll_titles"]} == {5, 2, 1}
+
+    def test_the_name_the_retry_read_is_the_new_one(self, script):
+        got = script.entry_after_retry(RICHER_PREVIOUS, POORER_RETRY)
+        by_id = {poll["poll_id"]: poll["name"] for poll in got["poll_titles"]}
+
+        # Fresher for the allergen it read, kept for the two it did not.
+        assert by_id[5] == "Traviny"
+        assert by_id[2] == "Breza"
+        assert by_id[1] == "Jelša"
+
+    def test_no_allergen_is_recorded_twice(self, script):
+        got = script.entry_after_retry(RICHER_PREVIOUS, POORER_RETRY)
+        keys = [poll["poll_id"] for poll in got["poll_titles"]]
+
+        assert len(keys) == len(set(keys))
+
+    def test_a_corrected_latin_name_replaces_rather_than_duplicates(self, script):
+        # Keyed on poll_id, so the same allergen under a corrected spelling is
+        # the same allergen. Keying on the latin name would file it twice.
+        poorer = {
+            "lang_code": "sk",
+            "lang": "Slovak",
+            "poll_titles": [{"name": "Trávy", "latin": "Poaceae", "poll_id": 5}],
+            "incomplete": True,
+        }
+        previous = {
+            "lang_code": "sk",
+            "poll_titles": [{"name": "Trávy", "latin": "poaceae", "poll_id": 5}],
+            "incomplete": True,
+        }
+        got = script.entry_after_retry(previous, poorer)
+
+        assert got["poll_titles"] == poorer["poll_titles"]
+
+    def test_the_merged_entry_stays_retryable(self, script):
+        got = script.entry_after_retry(RICHER_PREVIOUS, POORER_RETRY)
+
+        assert got["incomplete"] is True
+        assert script.needs_fetch({"sk": got}, "sk")
+
+    def test_a_clean_retry_replaces_the_entry_outright(self, script):
+        # What bounds the merge: an allergen that has genuinely left the API
+        # for this language is gone from the file on the first response that
+        # reads cleanly, and only then.
+        clean = {
+            "lang_code": "sk",
+            "lang": "Slovak",
+            "poll_titles": [{"name": "Traviny", "latin": "Poaceae", "poll_id": 5}],
+        }
+        got = script.entry_after_retry(RICHER_PREVIOUS, clean)
+
+        assert got == clean
+        assert not script.needs_fetch({"sk": got}, "sk")
+
+    def test_an_entry_without_a_poll_id_is_kept_by_its_latin_name(self, script):
+        previous = {
+            "lang_code": "sk",
+            "poll_titles": [{"name": "Breza", "latin": "Betula", "poll_id": None}],
+            "incomplete": True,
+        }
+        got = script.entry_after_retry(previous, POORER_RETRY)
+
+        assert {poll["latin"] for poll in got["poll_titles"]} == {"Poaceae", "Betula"}
+
+    def test_a_first_fetch_has_nothing_to_merge(self, script):
+        assert script.entry_after_retry(None, POORER_RETRY) == POORER_RETRY
+        assert script.entry_after_retry({"error": "x"}, POORER_RETRY) == POORER_RETRY
 
 
 class TestNeedsFetch:

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -56,6 +56,11 @@ class TestSplitPollTitle:
     def test_empty_title(self, script):
         assert script.split_poll_title("") == ("", "")
 
+    @pytest.mark.parametrize("poll_title", [None, 123, ["Ragweed"], {"a": 1}])
+    def test_a_title_that_is_not_a_string_reads_as_empty(self, script, poll_title):
+        # Raising here would cost the language its other allergens.
+        assert script.split_poll_title(poll_title) == ("", "")
+
 
 class TestResolveLatin:
     """The validation step, over the shapes the API actually sends."""
@@ -147,6 +152,31 @@ class TestPollTitlesFromContamination:
         ]
         # One warning each for the two repairs and the unknown allergen.
         assert len(warnings) == 3
+
+    def test_one_malformed_entry_does_not_cost_the_others(self, script):
+        contamination = [
+            {"poll_title": "Trávy (Poaceae)", "poll_id": 5},
+            {"poll_title": 123, "poll_id": 6},
+            {"poll_title": "Breza (Betula)", "poll_id": 2},
+        ]
+        poll_titles, warnings = script.poll_titles_from_contamination(contamination)
+
+        assert [entry["poll_id"] for entry in poll_titles] == [5, 6, 2]
+        assert [entry["latin"] for entry in poll_titles] == ["Poaceae", "", "Betula"]
+        assert len(warnings) == 1
+
+    @pytest.mark.parametrize("contamination", ["oops", None, {"poll_title": "x"}])
+    def test_a_block_that_is_not_a_list_is_reported(self, script, contamination):
+        poll_titles, warnings = script.poll_titles_from_contamination(contamination)
+        assert poll_titles == []
+        assert len(warnings) == 1
+
+    def test_an_entry_that_is_not_an_object_is_reported(self, script):
+        poll_titles, warnings = script.poll_titles_from_contamination(
+            [{"poll_title": "Trávy (Poaceae)", "poll_id": 5}, "oops"]
+        )
+        assert len(poll_titles) == 1
+        assert len(warnings) == 1
 
     def test_display_names_are_kept_as_the_api_sent_them(self, script):
         poll_titles, _ = script.poll_titles_from_contamination(
@@ -258,6 +288,25 @@ class TestRepairDb:
     def test_tolerates_an_error_entry(self, script):
         db = {"tr": {"lang_code": "tr", "error": "request error: timeout"}}
         assert script.repair_db(db) == ([], [])
+
+    @pytest.mark.parametrize(
+        "db",
+        [
+            {"x": {"poll_titles": [{"name": None, "latin": "Nonexistentia"}]}},
+            {"x": {"poll_titles": [{"name": "Trávy", "latin": None}]}},
+            {"x": {"poll_titles": ["oops"]}},
+            {"x": {"poll_titles": "oops"}},
+            {"x": "oops"},
+        ],
+    )
+    def test_reports_a_shape_it_did_not_expect_instead_of_raising(self, script, db):
+        # --repair is the tool you reach for when the file is wrong, so a
+        # wrong file has to come back as a warning naming the language.
+        changes, warnings = script.repair_db(db)
+
+        assert changes == []
+        assert len(warnings) == 1
+        assert warnings[0].startswith("x: ")
 
 
 class TestShippedLanguageMap:

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -361,7 +361,48 @@ class TestLanguageEntryFromResponse:
             },
         )
         assert [poll["latin"] for poll in entry["poll_titles"]] == ["Poaceae"]
-        assert len(warnings) == 1
+        # One for the entry that was dropped, one for the language being left
+        # incomplete because of it.
+        assert len(warnings) == 2
+
+    def test_a_response_that_lost_an_entry_is_marked_incomplete(self, script):
+        entry, warnings = script.language_entry_from_response(
+            "sk",
+            {
+                "contamination": [
+                    {"poll_title": "Trávy (Poaceae)", "poll_id": 5},
+                    {"poll_title": "()", "poll_id": 6},
+                ]
+            },
+        )
+
+        assert entry["incomplete"] is True
+        assert [poll["latin"] for poll in entry["poll_titles"]] == ["Poaceae"]
+        assert any("incomplete" in w for w in warnings)
+
+    def test_an_incomplete_language_is_fetched_again(self, script):
+        # The property that matters: nothing else would ever come back for the
+        # entry that was lost, since a saved language is skipped and --repair
+        # cannot invent an entry that was never recorded.
+        entry, _ = script.language_entry_from_response(
+            "sk",
+            {
+                "contamination": [
+                    {"poll_title": "Trávy (Poaceae)", "poll_id": 5},
+                    {"poll_title": "()", "poll_id": 6},
+                ]
+            },
+        )
+
+        assert script.needs_fetch({"sk": entry}, "sk")
+
+    def test_a_complete_response_is_not_marked(self, script):
+        entry, _ = script.language_entry_from_response(
+            "sk", {"contamination": [{"poll_title": "Trávy (Poaceae)", "poll_id": 5}]}
+        )
+
+        assert "incomplete" not in entry
+        assert not script.needs_fetch({"sk": entry}, "sk")
 
 
 class TestNeedsFetch:
@@ -373,6 +414,10 @@ class TestNeedsFetch:
     def test_a_recorded_language_is_not_refetched(self, script):
         db = {"sk": {"lang_code": "sk", "poll_titles": []}}
         assert not script.needs_fetch(db, "sk")
+
+    def test_an_incomplete_entry_is_retried(self, script):
+        db = {"sk": {"lang_code": "sk", "poll_titles": [], "incomplete": True}}
+        assert script.needs_fetch(db, "sk")
 
     def test_an_error_entry_is_retried(self, script):
         db = {"sk": {"lang_code": "sk", "error": "request error: timeout"}}

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -1,0 +1,213 @@
+"""Tests for scripts/generate_language_codes.py.
+
+The script is not importable as a module (scripts/ is not a package and the
+file name is not an identifier we import anywhere), so it is loaded from its
+path. Loading it must stay free of side effects: it may not read API_KEY or
+import requests at import time, which is why those live inside run_fetch.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "generate_language_codes.py"
+LANGUAGE_MAP = (
+    REPO_ROOT / "custom_components" / "polleninformation" / "language_map.json"
+)
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location(
+        "generate_language_codes", SCRIPT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def script():
+    """The generator, loaded from its path."""
+    return _load_script()
+
+
+class TestSplitPollTitle:
+    """The transcription step: what the API sent, split in two."""
+
+    def test_name_with_latin_in_brackets(self, script):
+        assert script.split_poll_title("Ragweed (Ambrosia)") == (
+            "Ragweed",
+            "Ambrosia",
+        )
+
+    def test_localized_word_in_brackets_is_transcribed_as_sent(self, script):
+        # The split does not judge; resolve_latin does.
+        assert script.split_poll_title("Ragweed (ambrózia)") == (
+            "Ragweed",
+            "ambrózia",
+        )
+
+    def test_bare_name_has_no_latin(self, script):
+        assert script.split_poll_title("Artemisia") == ("Artemisia", "")
+
+    def test_empty_title(self, script):
+        assert script.split_poll_title("") == ("", "")
+
+
+class TestResolveLatin:
+    """The validation step, over the shapes the API actually sends."""
+
+    def test_known_latin_is_kept_without_a_warning(self, script):
+        assert script.resolve_latin("Trávy", "Poaceae") == ("Poaceae", [])
+
+    def test_genus_and_species_is_kept(self, script):
+        latin, warnings = script.resolve_latin("Ambrosia", "Ambrosia artemisiifolia")
+        assert latin == "Ambrosia artemisiifolia"
+        assert warnings == []
+
+    def test_localized_word_in_brackets_is_replaced_from_the_display_name(self, script):
+        # The sk shape: the API put a Slovak word where the latin name goes,
+        # and left the display name in English.
+        latin, warnings = script.resolve_latin("Ragweed", "ambrózia")
+        assert latin == "Ambrosia"
+        assert len(warnings) == 1
+        assert "ambrózia" in warnings[0]
+
+    def test_display_name_that_is_a_latin_name_supplies_the_missing_latin(self, script):
+        # The es shape, and the shape reported in issue #71.
+        latin, warnings = script.resolve_latin("Artemisia", "")
+        assert latin == "Artemisia"
+        assert len(warnings) == 1
+        assert "Artemisia" in warnings[0]
+
+    def test_unknown_latin_is_kept_as_sent_and_warned_about(self, script):
+        latin, warnings = script.resolve_latin("Nässlor", "Nonexistentia")
+        assert latin == "Nonexistentia"
+        assert len(warnings) == 1
+        assert "please open an issue" in warnings[0]
+
+    def test_unknown_allergen_without_a_latin_is_warned_about(self, script):
+        latin, warnings = script.resolve_latin("Något nytt", "")
+        assert latin == ""
+        assert len(warnings) == 1
+        assert "no latin name" in warnings[0]
+
+
+class TestPollTitlesFromContamination:
+    """Nothing the API sends is ever dropped."""
+
+    def test_every_entry_is_recorded(self, script):
+        contamination = [
+            {"poll_title": "Trávy (Poaceae)", "poll_id": 5},
+            {"poll_title": "Ragweed (ambrózia)", "poll_id": 6},
+            {"poll_title": "Artemisia", "poll_id": 7},
+            {"poll_title": "Något nytt (Nonexistentia)", "poll_id": 999},
+        ]
+        poll_titles, warnings = script.poll_titles_from_contamination(contamination)
+
+        assert [entry["poll_id"] for entry in poll_titles] == [5, 6, 7, 999]
+        assert [entry["latin"] for entry in poll_titles] == [
+            "Poaceae",
+            "Ambrosia",
+            "Artemisia",
+            "Nonexistentia",
+        ]
+        # One warning each for the two repairs and the unknown allergen.
+        assert len(warnings) == 3
+
+    def test_display_names_are_kept_as_the_api_sent_them(self, script):
+        poll_titles, _ = script.poll_titles_from_contamination(
+            [{"poll_title": "Ragweed (ambrózia)", "poll_id": 6}]
+        )
+        assert poll_titles[0]["name"] == "Ragweed"
+
+
+class TestRepairDb:
+    """The offline pass that lets an already recorded entry correct itself."""
+
+    def test_repairs_the_two_shipped_shapes(self, script):
+        db = {
+            "sk": {
+                "lang_code": "sk",
+                "poll_titles": [
+                    {"name": "Trávy", "latin": "Poaceae", "poll_id": 5},
+                    {"name": "Ragweed", "latin": "ambrózia", "poll_id": 6},
+                ],
+            },
+            "es": {
+                "lang_code": "es",
+                "poll_titles": [
+                    {"name": "Artemisia", "latin": "", "poll_id": 7},
+                ],
+            },
+        }
+        changes, warnings = script.repair_db(db)
+
+        assert db["sk"]["poll_titles"][1]["latin"] == "Ambrosia"
+        assert db["es"]["poll_titles"][0]["latin"] == "Artemisia"
+        assert len(changes) == 2
+        assert len(warnings) == 2
+
+    def test_leaves_a_clean_db_untouched(self, script):
+        db = {
+            "en": {
+                "lang_code": "en",
+                "poll_titles": [{"name": "grasses", "latin": "Poaceae", "poll_id": 5}],
+            }
+        }
+        changes, warnings = script.repair_db(db)
+
+        assert changes == []
+        assert warnings == []
+        assert db["en"]["poll_titles"][0]["latin"] == "Poaceae"
+
+    def test_is_idempotent(self, script):
+        db = {
+            "sk": {
+                "lang_code": "sk",
+                "poll_titles": [{"name": "Ragweed", "latin": "ambrózia"}],
+            }
+        }
+        script.repair_db(db)
+        changes, _ = script.repair_db(db)
+
+        assert changes == []
+
+    def test_keeps_an_unknown_allergen_and_warns_again(self, script):
+        db = {
+            "sv": {
+                "lang_code": "sv",
+                "poll_titles": [{"name": "Något nytt", "latin": "Nonexistentia"}],
+            }
+        }
+        changes, warnings = script.repair_db(db)
+
+        assert changes == []
+        assert len(warnings) == 1
+        assert db["sv"]["poll_titles"][0]["latin"] == "Nonexistentia"
+
+    def test_tolerates_an_error_entry(self, script):
+        db = {"tr": {"lang_code": "tr", "error": "request error: timeout"}}
+        assert script.repair_db(db) == ([], [])
+
+
+class TestShippedLanguageMap:
+    """The file itself, as shipped."""
+
+    def test_every_recorded_latin_name_is_recognized(self, script):
+        db = json.loads(LANGUAGE_MAP.read_text(encoding="utf-8"))
+        unrecognized = [
+            (lang_code, entry["name"], entry["latin"])
+            for lang_code, block in db.items()
+            for entry in block.get("poll_titles", [])
+            if not script.english_name_for_latin(entry["latin"])
+        ]
+        assert unrecognized == []
+
+    def test_needs_no_repair(self, script):
+        db = json.loads(LANGUAGE_MAP.read_text(encoding="utf-8"))
+        changes, warnings = script.repair_db(db)
+        assert (changes, warnings) == ([], [])

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -83,6 +83,28 @@ class TestResolveLatin:
         assert len(warnings) == 1
         assert "Artemisia" in warnings[0]
 
+    def test_a_latin_the_api_sent_outranks_a_latin_display_name(self, script):
+        # "Artemisia (Asteraceae)" is the composite family, not mugwort. The
+        # display name may only be read as a latin name when the API sent
+        # none, exactly as the setup path in sensor.py has it.
+        latin, warnings = script.resolve_latin("Artemisia", "Asteraceae")
+        assert latin == "Asteraceae"
+        assert len(warnings) == 1
+        assert "Keeping it" in warnings[0]
+
+    def test_a_latin_the_api_sent_outranks_an_english_display_name(self, script):
+        # The same rule for the English-name lookup: "Asteraceae" could be a
+        # scientific name, so it identifies the allergen whatever the display
+        # name says.
+        latin, warnings = script.resolve_latin("Ragweed", "Asteraceae")
+        assert latin == "Asteraceae"
+        assert len(warnings) == 1
+        assert "Keeping it" in warnings[0]
+
+    def test_a_hybrid_name_the_map_does_not_know_is_kept(self, script):
+        latin, _ = script.resolve_latin("Ragweed", "Asteraceae × nova")
+        assert latin == "Asteraceae × nova"
+
     def test_unknown_latin_is_kept_as_sent_and_warned_about(self, script):
         latin, warnings = script.resolve_latin("Nässlor", "Nonexistentia")
         assert latin == "Nonexistentia"
@@ -94,6 +116,26 @@ class TestResolveLatin:
         assert latin == ""
         assert len(warnings) == 1
         assert "no latin name" in warnings[0]
+
+
+class TestCouldBeAScientificName:
+    """What tells a latin name the map does not know from a localized word.
+
+    This is the whole safety argument for the English-name lookup: it may
+    only override what the API put between the brackets when that string
+    cannot be a scientific name whatever it names.
+    """
+
+    @pytest.mark.parametrize(
+        "latin",
+        ["Asteraceae", "Ambrosia artemisiifolia", "Ambrosia × helenae", "Poaceae"],
+    )
+    def test_latin_names_could_be_one(self, script, latin):
+        assert script.could_be_a_scientific_name(latin)
+
+    @pytest.mark.parametrize("latin", ["ambrózia", "Амброзия", "パセリ", "", "räven"])
+    def test_a_localized_word_could_not(self, script, latin):
+        assert not script.could_be_a_scientific_name(latin)
 
 
 class TestPollTitlesFromContamination:
@@ -188,6 +230,42 @@ class TestRepairDb:
         assert changes == []
         assert len(warnings) == 1
         assert db["sv"]["poll_titles"][0]["latin"] == "Nonexistentia"
+
+    def test_keeps_a_latin_the_api_sent_that_no_map_knows(self, script):
+        # The repair rewrites a file we ship, so an entry the API recorded
+        # correctly must survive it. Reading "Artemisia" as the latin name
+        # here would record the composite family as mugwort, and the next
+        # repair run would then confirm that as correct.
+        db = {
+            "de": {
+                "lang_code": "de",
+                "poll_titles": [
+                    {"name": "Artemisia", "latin": "Asteraceae", "poll_id": 300}
+                ],
+            }
+        }
+        changes, warnings = script.repair_db(db)
+
+        assert changes == []
+        assert db["de"]["poll_titles"][0]["latin"] == "Asteraceae"
+        assert len(warnings) == 1
+
+    def test_a_correctly_recorded_entry_survives_a_round_trip(self, script):
+        db = {
+            "de": {
+                "lang_code": "de",
+                "poll_titles": [
+                    {"name": "Gräser", "latin": "Poaceae", "poll_id": 5},
+                    {"name": "Artemisia", "latin": "Asteraceae", "poll_id": 300},
+                ],
+            }
+        }
+        before = json.dumps(db, sort_keys=True)
+
+        script.repair_db(db)
+        script.repair_db(db)
+
+        assert json.dumps(db, sort_keys=True) == before
 
     def test_tolerates_an_error_entry(self, script):
         db = {"tr": {"lang_code": "tr", "error": "request error: timeout"}}

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -184,18 +184,49 @@ class TestPollTitlesFromContamination:
 
     @pytest.mark.parametrize(
         "poll",
-        [{"poll_id": 6}, {"poll_title": 123}, {"poll_title": ""}, {"poll_title": "  "}],
+        [
+            # Nothing to read at all.
+            {"poll_id": 6},
+            {"poll_title": 123},
+            {"poll_title": ""},
+            {"poll_title": "  "},
+            # A non-blank title with nothing in either half of it, which
+            # identifies an allergen exactly as little as the four above.
+            {"poll_title": "()"},
+            {"poll_title": "( )"},
+            {"poll_title": "  (  )  "},
+            {"poll_title": "()extra"},
+        ],
     )
-    def test_an_entry_with_no_readable_title_is_skipped(self, script, poll):
-        # An unknown latin name still names a real allergen and is kept. A
-        # title that cannot be read names nothing, so recording it would
-        # manufacture a blank allergen and make an unreadable block look like
-        # a language that has some.
+    def test_an_entry_that_identifies_nothing_is_skipped(self, script, poll):
+        # An unknown latin name still names a real allergen and is kept. An
+        # entry with neither a display name nor a latin name names nothing, so
+        # recording it would manufacture a blank allergen and make a block of
+        # them look like a language that has some.
         poll_titles, warnings = script.poll_titles_from_contamination([poll])
 
         assert poll_titles == []
         assert len(warnings) == 1
-        assert "no readable title" in warnings[0]
+        assert "identifies no allergen" in warnings[0]
+
+    @pytest.mark.parametrize(
+        ("poll_title", "expected"),
+        [
+            ("(Poaceae)", {"name": "", "latin": "Poaceae"}),
+            ("Trávy", {"name": "Trávy", "latin": ""}),
+            ("Trávy (Poaceae)", {"name": "Trávy", "latin": "Poaceae"}),
+        ],
+    )
+    def test_either_half_alone_is_enough_to_be_kept(self, script, poll_title, expected):
+        # The rule is what the entry identifies, so one half is enough: a
+        # latin name with no display name is an allergen this language has no
+        # word for, and a display name with no latin name is one we may not be
+        # able to classify. Both are kept.
+        poll_titles, _ = script.poll_titles_from_contamination(
+            [{"poll_title": poll_title, "poll_id": 5}]
+        )
+
+        assert poll_titles == [{**expected, "poll_id": 5}]
 
     @pytest.mark.parametrize("contamination", ["oops", None, {"poll_title": "x"}])
     def test_a_block_that_is_not_a_list_is_reported(self, script, contamination):
@@ -308,7 +339,7 @@ class TestLanguageEntryFromResponse:
         assert len(warnings) == 2
 
     def test_a_block_of_title_less_entries_is_an_error_entry(self, script):
-        # The chain end to end: every entry is skipped for want of a title,
+        # The chain end to end: every entry is skipped for naming nothing,
         # which leaves no allergens, which is an error entry, which
         # needs_fetch comes back for.
         entry, warnings = script.language_entry_from_response(

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -307,6 +307,21 @@ class TestNeedsFetch:
         assert script.needs_fetch({"sk": "oops"}, "sk")
 
 
+class TestRepairDbRoot:
+    """The level above the per-language checks: the file's own root."""
+
+    @pytest.mark.parametrize("db", [["sk"], "oops", 42, True])
+    def test_a_root_that_is_not_an_object_is_reported(self, script, db):
+        changes, warnings = script.repair_db(db)
+
+        assert changes == []
+        assert len(warnings) == 1
+        assert "root" in warnings[0]
+
+    def test_an_empty_root_is_not_a_complaint(self, script):
+        assert script.repair_db({}) == ([], [])
+
+
 class TestRepairDb:
     """The offline pass that lets an already recorded entry correct itself."""
 

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -290,6 +290,27 @@ class TestRepairDb:
         assert script.repair_db(db) == ([], [])
 
     @pytest.mark.parametrize(
+        "poll",
+        [
+            {"name": "Trávy", "latin": 5},
+            {"name": 5, "latin": ""},
+            {"name": ["Trávy"], "latin": "Poaceae"},
+        ],
+    )
+    def test_a_scalar_that_is_not_a_string_does_not_abort_the_run(self, script, poll):
+        # canonical_latin strips, so a truthy non-string used to raise and
+        # take every remaining language with it.
+        db = {"x": {"poll_titles": [poll, {"name": "Breza", "latin": "Betula"}]}}
+        changes, warnings = script.repair_db(db)
+
+        assert changes == []
+        assert len(warnings) == 1
+        assert warnings[0].startswith("x: ")
+        # The entry is left exactly as it was: a defect is reported, never
+        # quietly rewritten into a well-formed record.
+        assert db["x"]["poll_titles"][0] == poll
+
+    @pytest.mark.parametrize(
         "db",
         [
             {"x": {"poll_titles": [{"name": None, "latin": "Nonexistentia"}]}},

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -161,9 +161,24 @@ class TestPollTitlesFromContamination:
         ]
         poll_titles, warnings = script.poll_titles_from_contamination(contamination)
 
-        assert [entry["poll_id"] for entry in poll_titles] == [5, 6, 2]
-        assert [entry["latin"] for entry in poll_titles] == ["Poaceae", "", "Betula"]
+        assert [entry["poll_id"] for entry in poll_titles] == [5, 2]
+        assert [entry["latin"] for entry in poll_titles] == ["Poaceae", "Betula"]
         assert len(warnings) == 1
+
+    @pytest.mark.parametrize(
+        "poll",
+        [{"poll_id": 6}, {"poll_title": 123}, {"poll_title": ""}, {"poll_title": "  "}],
+    )
+    def test_an_entry_with_no_readable_title_is_skipped(self, script, poll):
+        # An unknown latin name still names a real allergen and is kept. A
+        # title that cannot be read names nothing, so recording it would
+        # manufacture a blank allergen and make an unreadable block look like
+        # a language that has some.
+        poll_titles, warnings = script.poll_titles_from_contamination([poll])
+
+        assert poll_titles == []
+        assert len(warnings) == 1
+        assert "no readable title" in warnings[0]
 
     @pytest.mark.parametrize("contamination", ["oops", None, {"poll_title": "x"}])
     def test_a_block_that_is_not_a_list_is_reported(self, script, contamination):
@@ -241,6 +256,18 @@ class TestLanguageEntryFromResponse:
         )
         assert "error" in entry
         assert len(warnings) == 2
+
+    def test_a_block_of_title_less_entries_is_an_error_entry(self, script):
+        # The chain end to end: every entry is skipped for want of a title,
+        # which leaves no allergens, which is an error entry, which
+        # needs_fetch comes back for.
+        entry, warnings = script.language_entry_from_response(
+            "sk", {"contamination": [{"poll_id": 5}, {"poll_id": 6}]}
+        )
+
+        assert "error" in entry
+        assert len(warnings) == 2
+        assert script.needs_fetch({"sk": entry}, "sk")
 
     def test_a_readable_entry_beside_an_unreadable_one_is_kept(self, script):
         entry, warnings = script.language_entry_from_response(

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -63,10 +63,18 @@ class TestResolveLatin:
     def test_known_latin_is_kept_without_a_warning(self, script):
         assert script.resolve_latin("Trávy", "Poaceae") == ("Poaceae", [])
 
-    def test_genus_and_species_is_kept(self, script):
+    def test_genus_and_species_is_recorded_as_the_genus(self, script):
+        # Every consumer of this file matches a latin name exactly, and the
+        # one the restore path holds is the map's own key.
         latin, warnings = script.resolve_latin("Ambrosia", "Ambrosia artemisiifolia")
-        assert latin == "Ambrosia artemisiifolia"
-        assert warnings == []
+        assert latin == "Ambrosia"
+        assert len(warnings) == 1
+
+    @pytest.mark.parametrize("sent", ["poaceae", " Poaceae ", "POACEAE"])
+    def test_a_recognized_latin_is_recorded_under_the_map_key(self, script, sent):
+        latin, warnings = script.resolve_latin("Trávy", sent)
+        assert latin == "Poaceae"
+        assert len(warnings) == 1
 
     def test_a_declared_alias_is_recorded_as_the_name_it_stands_for(self, script):
         # The sk shape: the API put the Slovak word for ragweed where the
@@ -261,7 +269,7 @@ class TestShippedLanguageMap:
             (lang_code, entry["name"], entry["latin"])
             for lang_code, block in db.items()
             for entry in block.get("poll_titles", [])
-            if not script.english_name_for_latin(entry["latin"])
+            if not script.canonical_latin(entry["latin"])
         ]
         assert unrecognized == []
 

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -8,6 +8,8 @@ import requests at import time, which is why those live inside run_fetch.
 
 import importlib.util
 import json
+import sys
+import types
 from pathlib import Path
 from unittest.mock import patch
 
@@ -409,6 +411,186 @@ class TestLanguageEntryFromResponse:
 
         assert "incomplete" not in entry
         assert not script.needs_fetch({"sk": entry}, "sk")
+
+
+# A language the file already holds names for, marked for another try. What a
+# failed retry must not be allowed to take away.
+PARTIAL_ENTRY = {
+    "lang_code": "sk",
+    "lang": "Slovak",
+    "poll_titles": [{"name": "Trávy", "latin": "Poaceae", "poll_id": 5}],
+    "incomplete": True,
+}
+
+PARTIAL_DB = {"sk": PARTIAL_ENTRY}
+
+
+class TestARetryNeverImpoverishesAnEntry:
+    """A retry may improve what the file holds and may not take from it.
+
+    The incomplete marker exists because eleven localized names are worth
+    more to a sensor than none. The retry it schedules must not then do the
+    thing the marker refused: a failed or malformed retry that replaced the
+    entry with an error object would drop those names and send every allergen
+    in that language back to its English name.
+    """
+
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            {"error": "request error: timeout", "lang_code": "sk"},
+            {"error": "malformed response: no contamination block", "lang_code": "sk"},
+            {"error": "the response carries no allergens", "lang_code": "sk"},
+        ],
+    )
+    def test_a_failed_retry_keeps_the_names(self, script, failure):
+        kept = script.entry_after_retry(PARTIAL_ENTRY, failure)
+
+        assert kept["poll_titles"] == PARTIAL_ENTRY["poll_titles"]
+
+    def test_a_failed_retry_says_the_names_are_old(self, script):
+        # The record may not read as a clean partial when it is a partial
+        # plus a failure.
+        kept = script.entry_after_retry(
+            PARTIAL_ENTRY, {"error": "request error: timeout", "lang_code": "sk"}
+        )
+
+        assert "earlier fetch" in kept["retry_error"]
+        assert "request error: timeout" in kept["retry_error"]
+
+    def test_a_failed_retry_stays_retryable(self, script):
+        kept = script.entry_after_retry(
+            PARTIAL_ENTRY, {"error": "request error: timeout", "lang_code": "sk"}
+        )
+
+        assert script.needs_fetch({"sk": kept}, "sk")
+
+    def test_a_clean_retry_replaces_the_entry(self, script):
+        fresh = {
+            "lang_code": "sk",
+            "lang": "Slovak",
+            "poll_titles": [
+                {"name": "Trávy", "latin": "Poaceae", "poll_id": 5},
+                {"name": "Breza", "latin": "Betula", "poll_id": 2},
+            ],
+        }
+        got = script.entry_after_retry(PARTIAL_ENTRY, fresh)
+
+        assert got == fresh
+        assert "incomplete" not in got
+        assert "retry_error" not in got
+        assert not script.needs_fetch({"sk": got}, "sk")
+
+    @pytest.mark.parametrize(
+        "previous",
+        [
+            None,
+            "oops",
+            {"lang_code": "sk", "error": "request error: timeout"},
+            {"lang_code": "sk", "poll_titles": []},
+        ],
+    )
+    def test_nothing_to_keep_records_the_error_as_before(self, script, previous):
+        failure = {"error": "request error: timeout", "lang_code": "sk"}
+        assert script.entry_after_retry(previous, failure) == failure
+
+    def test_a_complete_entry_is_never_retried_and_so_never_clobbered(self, script):
+        # The answer to whether a transient failure can cost a COMPLETE
+        # language its names: it is not reachable, because such an entry is
+        # never fetched again. Pinned both ways, so neither half can drift.
+        complete = {
+            "lang_code": "sk",
+            "lang": "Slovak",
+            "poll_titles": [{"name": "Trávy", "latin": "Poaceae", "poll_id": 5}],
+        }
+        assert not script.needs_fetch({"sk": complete}, "sk")
+        kept = script.entry_after_retry(
+            complete, {"error": "request error: timeout", "lang_code": "sk"}
+        )
+        assert kept["poll_titles"] == complete["poll_titles"]
+
+
+class TestRunFetchWritesThroughTheRetryRule:
+    """The rule where it actually lands: the two lines that write the file.
+
+    Both failure paths in run_fetch assign to db[lang_code], and either one
+    could drop an entry's allergen names. Exercised end to end, with the
+    network and the environment stubbed, because a helper that gets this
+    right is worth nothing if the caller writes past it.
+    """
+
+    @staticmethod
+    def _run(script, monkeypatch, tmp_path, existing, responder):
+        db_file = tmp_path / "language_map.json"
+        db_file.write_text(json.dumps(existing), encoding="utf-8")
+        monkeypatch.setattr(script, "DB_FILE", str(db_file))
+        monkeypatch.setattr(script, "LANG_CODES", ["sk"])
+        monkeypatch.setattr(script, "DELAY_SEC", 0)
+        monkeypatch.setenv("API_KEY", "test-key")
+        monkeypatch.setitem(
+            sys.modules, "requests", types.SimpleNamespace(get=responder)
+        )
+        monkeypatch.setitem(
+            sys.modules, "dotenv", types.SimpleNamespace(load_dotenv=lambda **kw: None)
+        )
+        script.run_fetch()
+        return json.loads(db_file.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _answer(payload):
+        def responder(*args, **kwargs):
+            return types.SimpleNamespace(
+                raise_for_status=lambda: None, json=lambda: payload
+            )
+
+        return responder
+
+    def test_a_request_failure_keeps_the_names_on_disk(
+        self, script, monkeypatch, tmp_path
+    ):
+        def boom(*args, **kwargs):
+            raise RuntimeError("timeout")
+
+        db = self._run(script, monkeypatch, tmp_path, PARTIAL_DB, boom)
+
+        assert db["sk"]["poll_titles"] == PARTIAL_ENTRY["poll_titles"]
+        assert "earlier fetch" in db["sk"]["retry_error"]
+        assert script.needs_fetch(db, "sk")
+
+    def test_a_malformed_response_keeps_the_names_on_disk(
+        self, script, monkeypatch, tmp_path
+    ):
+        db = self._run(
+            script, monkeypatch, tmp_path, PARTIAL_DB, self._answer({"nope": 1})
+        )
+
+        assert db["sk"]["poll_titles"] == PARTIAL_ENTRY["poll_titles"]
+        assert "earlier fetch" in db["sk"]["retry_error"]
+
+    def test_a_clean_retry_replaces_what_was_there(self, script, monkeypatch, tmp_path):
+        payload = {
+            "contamination": [
+                {"poll_title": "Trávy (Poaceae)", "poll_id": 5},
+                {"poll_title": "Breza (Betula)", "poll_id": 2},
+            ]
+        }
+        db = self._run(script, monkeypatch, tmp_path, PARTIAL_DB, self._answer(payload))
+
+        assert len(db["sk"]["poll_titles"]) == 2
+        assert "incomplete" not in db["sk"]
+        assert "retry_error" not in db["sk"]
+        assert not script.needs_fetch(db, "sk")
+
+    def test_a_language_with_nothing_to_lose_records_the_error(
+        self, script, monkeypatch, tmp_path
+    ):
+        def boom(*args, **kwargs):
+            raise RuntimeError("timeout")
+
+        db = self._run(script, monkeypatch, tmp_path, {}, boom)
+
+        assert "error" in db["sk"]
+        assert "poll_titles" not in db["sk"]
 
 
 class TestNeedsFetch:

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -9,6 +9,7 @@ import requests at import time, which is why those live inside run_fetch.
 import importlib.util
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -305,6 +306,26 @@ class TestNeedsFetch:
 
     def test_a_language_that_is_not_an_object_is_refetched(self, script):
         assert script.needs_fetch({"sk": "oops"}, "sk")
+
+
+class TestLoadDb:
+    """The level above the root: the file may not be JSON at all."""
+
+    def test_a_missing_file_is_an_empty_db(self, script, tmp_path):
+        with patch.object(script, "DB_FILE", str(tmp_path / "nothing.json")):
+            assert script.load_db() == {}
+
+    def test_a_file_that_is_not_json_stops_the_run(self, script, tmp_path):
+        # Reading it as an empty db would be the destructive answer: the fetch
+        # would refetch every language and write over whatever is in there.
+        broken = tmp_path / "language_map.json"
+        broken.write_text('{"sk": ', encoding="utf-8")
+        with (
+            patch.object(script, "DB_FILE", str(broken)),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            script.load_db()
+        assert "not valid JSON" in str(excinfo.value)
 
 
 class TestRepairDbRoot:

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -490,6 +490,28 @@ class TestRepairDb:
 
         assert json.dumps(db, sort_keys=True) == before
 
+    @pytest.mark.parametrize("poll_titles", [0, False, "", {}])
+    def test_a_falsy_poll_titles_of_the_wrong_type_is_reported(
+        self, script, poll_titles
+    ):
+        # The third `or` default, found in the same sweep: these read as an
+        # empty list and were skipped in silence.
+        db = {"x": {"lang_code": "x", "poll_titles": poll_titles}}
+        changes, warnings = script.repair_db(db)
+
+        assert changes == []
+        assert len(warnings) == 1
+        assert warnings[0].startswith("x: ")
+        assert db["x"]["poll_titles"] == poll_titles
+
+    def test_a_missing_poll_titles_is_not_a_complaint(self, script):
+        # The one default that is deliberate: an error entry has no allergens
+        # and never had any.
+        assert script.repair_db({"x": {"lang_code": "x"}}) == ([], [])
+
+    def test_a_null_poll_titles_is_not_a_complaint(self, script):
+        assert script.repair_db({"x": {"poll_titles": None}}) == ([], [])
+
     def test_tolerates_an_error_entry(self, script):
         db = {"tr": {"lang_code": "tr", "error": "request error: timeout"}}
         assert script.repair_db(db) == ([], [])
@@ -497,9 +519,20 @@ class TestRepairDb:
     @pytest.mark.parametrize(
         "poll",
         [
+            # Truthy non-strings: these reached canonical_latin and raised.
             {"name": "Trávy", "latin": 5},
             {"name": 5, "latin": ""},
             {"name": ["Trávy"], "latin": "Poaceae"},
+            # Falsy non-strings: these walked past the type check, because
+            # `or ""` had already turned them into a valid-looking empty
+            # string. The latin ones were then REWRITTEN from the display
+            # name, which is the malformed entry being turned into a
+            # well-formed record rather than reported.
+            {"name": "Artemisia", "latin": 0},
+            {"name": "Artemisia", "latin": False},
+            {"name": "Artemisia", "latin": []},
+            {"name": 0, "latin": "Poaceae"},
+            {"name": False, "latin": ""},
         ],
     )
     def test_a_scalar_that_is_not_a_string_does_not_abort_the_run(self, script, poll):
@@ -511,6 +544,9 @@ class TestRepairDb:
         assert changes == []
         assert len(warnings) == 1
         assert warnings[0].startswith("x: ")
+        # Reported AS a type error, not as some downstream consequence of a
+        # value that was quietly defaulted before the check could see it.
+        assert "not a string" in warnings[0]
         # The entry is left exactly as it was: a defect is reported, never
         # quietly rewritten into a well-formed record.
         assert db["x"]["poll_titles"][0] == poll

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -1130,6 +1130,29 @@ class TestTheFileAndTheRuntimeAgree:
         assert self._runtime_allergen("Artemisia (") == "mugwort"
         assert self._recorded_allergen(script, "Artemisia (") == "mugwort"
 
+    @pytest.mark.parametrize(
+        "name",
+        ["Artemisia", "Ambrosia hojas", "Ailanthus altissima", "Trávy", "Ragweed", ""],
+    )
+    @pytest.mark.parametrize(
+        "brackets",
+        ["", " ()", " (   )", " (", " )", " (Poaceae)", " (ambrózia)", " (Asteraceae)"],
+    )
+    def test_the_two_sides_agree_on_every_generated_title(self, script, name, brackets):
+        """The differential, generated rather than listed.
+
+        The named rows above are the cases we thought of, and the drift this
+        class exists to catch has twice been a case nobody thought of: it was
+        invisible here until a row happened to carry the shape. Crossing the
+        display names that have caused trouble with every bracket shape the
+        API has been seen to send, or could, covers the combinations rather
+        than the instances.
+        """
+        poll_title = name + brackets
+        assert self._recorded_allergen(script, poll_title) == self._runtime_allergen(
+            poll_title
+        )
+
 
 class TestShippedLanguageMap:
     """The file itself, as shipped.

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -399,10 +399,60 @@ class TestLoadDb:
         assert "not valid JSON" in str(excinfo.value)
 
 
+class TestRunRepairReachesTheValidator:
+    """The entry point may not decide what the validator gets to see.
+
+    `if not db` sent every falsy root down the "nothing to repair" path: a
+    file holding [], "", 0, false or null was reported as an empty database,
+    which is the one answer that is certainly wrong for the mode whose job is
+    to diagnose a malformed file.
+    """
+
+    @staticmethod
+    def _run(script, monkeypatch, capsys, db):
+        monkeypatch.setattr(script, "load_db", lambda: db)
+        script.run_repair()
+        return capsys.readouterr().out
+
+    @pytest.mark.parametrize("db", [[], "", 0, False, None, ["sk"], "oops", 42])
+    def test_a_non_dict_root_reaches_the_validator(
+        self, script, monkeypatch, capsys, db
+    ):
+        out = self._run(script, monkeypatch, capsys, db)
+
+        assert "root" in out
+        assert "No languages" not in out
+
+    def test_an_empty_database_is_not_a_malformed_one(
+        self, script, monkeypatch, capsys
+    ):
+        # A missing file reads as {} too, and that is the ordinary first run.
+        out = self._run(script, monkeypatch, capsys, {})
+
+        assert "No languages" in out
+        assert "root" not in out
+
+    def test_a_good_database_is_repaired_as_before(self, script, monkeypatch, capsys):
+        db = {
+            "sk": {
+                "lang_code": "sk",
+                "poll_titles": [{"name": "Trávy", "latin": "Poaceae"}],
+            }
+        }
+        out = self._run(script, monkeypatch, capsys, db)
+
+        assert "Nothing to repair" in out
+
+
 class TestRepairDbRoot:
     """The level above the per-language checks: the file's own root."""
 
-    @pytest.mark.parametrize("db", [["sk"], "oops", 42, True])
+    @pytest.mark.parametrize(
+        "db",
+        # Truthy and falsy alike: the validator never saw the falsy ones,
+        # because the entry point above returned before calling it.
+        [["sk"], "oops", 42, True, [], "", 0, False, None],
+    )
     def test_a_root_that_is_not_an_object_is_reported(self, script, db):
         changes, warnings = script.repair_db(db)
 

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -333,6 +333,28 @@ class TestNeedsFetch:
         assert script.needs_fetch({"sk": "oops"}, "sk")
 
 
+class TestDbFilePath:
+    """The map's path is a property of the repo, not of the shell.
+
+    Relative, it resolved against the working directory, so a run from
+    anywhere else read no file, found no languages, fetched all sixteen and
+    wrote a new map into that directory. Nothing downstream can catch it: a
+    file that is merely absent looks exactly like an empty database.
+    """
+
+    def test_the_path_is_absolute(self, script):
+        assert Path(script.DB_FILE).is_absolute()
+
+    def test_it_points_at_the_map_in_this_repo(self, script):
+        assert Path(script.DB_FILE) == LANGUAGE_MAP
+
+    def test_the_map_is_found_from_another_directory(
+        self, script, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        assert len(script.load_db()) == 16
+
+
 class TestLoadDb:
     """The level above the root: the file may not be JSON at all."""
 

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -13,6 +13,12 @@ from unittest.mock import patch
 
 import pytest
 
+from custom_components.polleninformation.sensor import (
+    allergen_slug_for_item,
+    english_name_for_latin,
+)
+from custom_components.polleninformation.utils import slugify
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT_PATH = REPO_ROOT / "scripts" / "generate_language_codes.py"
 LANGUAGE_MAP = (
@@ -719,6 +725,71 @@ class TestRepairDb:
         assert changes == []
         assert len(warnings) == 1
         assert warnings[0].startswith("x: ")
+
+
+class TestTheFileAndTheRuntimeAgree:
+    """The invariant the individual fixes keep failing to hold.
+
+    An entry the generator records and the same entry as the API sends it
+    must identify the SAME allergen, or nothing, in the same cases. When they
+    disagree the file files an allergen under an identity the sensors refuse
+    to read it as, and the restore path then attaches the wrong localized
+    name to it during an outage.
+
+    "Ambrosia hojas" is the input that has caused this three times, from
+    three different directions: the setup path read it as ragweed, then a
+    reverse English-name lookup would have, then the generator's genus
+    fallback did. It is prose that begins with a genus, and neither side may
+    treat that as an identity.
+    """
+
+    @staticmethod
+    def _runtime_allergen(poll_title):
+        """The allergen the sensors read this title as, or None."""
+        return allergen_slug_for_item({"poll_title": poll_title})
+
+    @staticmethod
+    def _recorded_allergen(script, poll_title):
+        """The allergen the map entry for this title identifies, or None."""
+        poll_titles, _ = script.poll_titles_from_contamination(
+            [{"poll_title": poll_title, "poll_id": 1}]
+        )
+        if not poll_titles:
+            return None
+        name_en = english_name_for_latin(poll_titles[0]["latin"])
+        return slugify(name_en) if name_en else None
+
+    @pytest.mark.parametrize(
+        "poll_title",
+        [
+            "Ambrosia hojas",
+            "Artemisia",
+            "Ailanthus altissima",
+            "Ambrosia artemisiifolia",
+            "Ragweed (Ambrosia artemisiifolia)",
+            "Ragweed (Ambrosia)",
+            "Artemisia (Asteraceae)",
+            "(Poaceae)",
+            "Trávy (Poaceae)",
+            "Ragweed (ambrózia)",
+            "Nässlor (Nonexistentia)",
+            "Något nytt",
+        ],
+    )
+    def test_both_sides_resolve_the_same_input_the_same_way(self, script, poll_title):
+        assert self._recorded_allergen(script, poll_title) == self._runtime_allergen(
+            poll_title
+        )
+
+    def test_the_prose_case_resolves_to_nothing_on_both_sides(self, script):
+        # Stated separately from the parametrize above, because "they agree"
+        # would also be satisfied by both being wrong in the same way.
+        assert self._runtime_allergen("Ambrosia hojas") is None
+        assert self._recorded_allergen(script, "Ambrosia hojas") is None
+
+    def test_a_display_name_that_is_a_latin_name_resolves_on_both_sides(self, script):
+        assert self._runtime_allergen("Artemisia") == "mugwort"
+        assert self._recorded_allergen(script, "Artemisia") == "mugwort"
 
 
 class TestShippedLanguageMap:

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -638,6 +638,81 @@ POORER_RETRY = {
 }
 
 
+class TestTheMergeKeyIsTotal:
+    """The key goes into a set, so every field it reads is type-checked.
+
+    An id that arrives as a list or an object is unhashable. Building the set
+    would raise, and the raise lands in run_fetch: not one bad entry, but the
+    partial result unsaved and every language after it in the loop unfetched.
+    The two fallbacks had the same hole one step down, since a latin or a name
+    of the wrong type has no .strip().
+    """
+
+    @pytest.mark.parametrize("junk", [["x"], {"a": 1}, ("x",), set()])
+    def test_an_unhashable_id_falls_back_rather_than_raising(self, script, junk):
+        key = script.allergen_key(
+            {"name": "Trávy", "latin": "Poaceae", "poll_id": junk}
+        )
+
+        assert key == ("latin", "poaceae")
+        hash(key)
+
+    @pytest.mark.parametrize("junk", [["x"], {"a": 1}, 5, 5.0, True])
+    def test_a_latin_of_the_wrong_type_falls_back_to_the_name(self, script, junk):
+        key = script.allergen_key({"name": "Trávy", "latin": junk, "poll_id": None})
+
+        assert key == ("name", "trávy")
+        hash(key)
+
+    @pytest.mark.parametrize("junk", [["x"], {"a": 1}, 5, 5.0, True])
+    def test_an_entry_with_no_usable_field_has_no_key(self, script, junk):
+        assert script.allergen_key({"name": junk, "latin": "", "poll_id": None}) is None
+
+    @pytest.mark.parametrize("poll_id", ["6", 6, 6.0, True])
+    def test_a_scalar_id_is_still_the_identity(self, script, poll_id):
+        key = script.allergen_key(
+            {"name": "Trávy", "latin": "Poaceae", "poll_id": poll_id}
+        )
+
+        assert key == ("poll_id", poll_id)
+
+    def test_the_merge_survives_an_unhashable_id(self, script):
+        # The failure Codex describes, at the level where it aborts the run.
+        previous = {
+            "lang_code": "sk",
+            "poll_titles": [{"name": "Breza", "latin": "Betula", "poll_id": 2}],
+            "incomplete": True,
+        }
+        fresh = {
+            "lang_code": "sk",
+            "poll_titles": [{"name": "Traviny", "latin": "Poaceae", "poll_id": ["x"]}],
+            "incomplete": True,
+        }
+        got = script.entry_after_retry(previous, fresh)
+
+        assert [poll["name"] for poll in got["poll_titles"]] == ["Traviny", "Breza"]
+
+    def test_a_junk_id_is_reported_when_it_is_recorded(self, script):
+        _, warnings = script.poll_titles_from_contamination(
+            [{"poll_title": "Trávy (Poaceae)", "poll_id": ["x"]}]
+        )
+
+        assert len(warnings) == 1
+        assert "not a scalar" in warnings[0]
+
+    def test_a_junk_id_already_in_the_file_is_reported_by_repair(self, script):
+        db = {
+            "sk": {
+                "poll_titles": [{"name": "Trávy", "latin": "Poaceae", "poll_id": {}}]
+            }
+        }
+        changes, warnings = script.repair_db(db)
+
+        assert changes == []
+        assert any("not a scalar" in w for w in warnings)
+        assert db["sk"]["poll_titles"][0]["poll_id"] == {}
+
+
 class TestAPoorerRetryIsMergedPerAllergen:
     """The success-but-poorer path, which is the same invariant as the failure.
 

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -956,6 +956,11 @@ class TestTheFileAndTheRuntimeAgree:
             "Ragweed (ambrózia)",
             "Nässlor (Nonexistentia)",
             "Något nytt",
+            # Brackets with nothing in them: the API sent no latin name, so
+            # both sides fall back to the display name. The runtime used to
+            # read the empty brackets as a latin name it could not place and
+            # resolve to nothing, while the file recorded Artemisia.
+            "Artemisia ()",
         ],
     )
     def test_both_sides_resolve_the_same_input_the_same_way(self, script, poll_title):
@@ -972,6 +977,10 @@ class TestTheFileAndTheRuntimeAgree:
     def test_a_display_name_that_is_a_latin_name_resolves_on_both_sides(self, script):
         assert self._runtime_allergen("Artemisia") == "mugwort"
         assert self._recorded_allergen(script, "Artemisia") == "mugwort"
+
+    def test_empty_brackets_resolve_to_the_display_name_on_both_sides(self, script):
+        assert self._runtime_allergen("Artemisia ()") == "mugwort"
+        assert self._recorded_allergen(script, "Artemisia ()") == "mugwort"
 
 
 class TestShippedLanguageMap:

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -978,6 +978,14 @@ class TestTheFileAndTheRuntimeAgree:
         assert self._runtime_allergen("Artemisia") == "mugwort"
         assert self._recorded_allergen(script, "Artemisia") == "mugwort"
 
+    def test_the_alias_resolves_to_ragweed_on_both_sides(self, script):
+        # Named rather than compared, for the same reason as the two above:
+        # emptying LATIN_NAME_ALIASES makes both sides resolve this to
+        # nothing, and "they agree" would still hold while the allergen had
+        # quietly stopped being identifiable.
+        assert self._runtime_allergen("Ragweed (ambrózia)") == "ragweed"
+        assert self._recorded_allergen(script, "Ragweed (ambrózia)") == "ragweed"
+
     def test_empty_brackets_resolve_to_the_display_name_on_both_sides(self, script):
         assert self._runtime_allergen("Artemisia ()") == "mugwort"
         assert self._recorded_allergen(script, "Artemisia ()") == "mugwort"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -215,6 +215,21 @@ MALFORMED_RISK_WITH_POLLEN_PAYLOAD = {
     "allergyrisk_hourly": "x",
 }
 
+# A risk block that is a non-empty object with nothing readable in it. This is
+# what an API sends to say something went wrong, so reading it as fresh data is
+# the worst of the available readings.
+UNREADABLE_RISK_PAYLOAD = {
+    "contamination": [{"poll_title": "()"}],
+    "allergyrisk": {"error": "upstream failure"},
+    "allergyrisk_hourly": {},
+}
+
+READABLE_RISK_PAYLOAD = {
+    "contamination": [{"poll_title": "()"}],
+    "allergyrisk": {"allergyrisk_1": 7.0},
+    "allergyrisk_hourly": {},
+}
+
 RISK_ONLY_PAYLOAD = {
     "contamination": [],
     "allergyrisk": {"allergyrisk_1": 7.5},
@@ -297,6 +312,29 @@ class TestEmptySince:
         # reports unknown without a marker.
         coordinator = self._make_coordinator(hass)
         await self._fetch(coordinator, MALFORMED_RISK_WITH_POLLEN_PAYLOAD, E1)
+        assert coordinator.empty_since is None
+
+    async def test_a_risk_block_with_nothing_readable_stamps_it(self, hass):
+        # Nonempty is not usable, three levels down: the entries, then the
+        # block being an object, now the fields inside it.
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, UNREADABLE_RISK_PAYLOAD, E1)
+        assert coordinator.empty_since == E1.isoformat()
+
+    async def test_a_real_reading_beside_unusable_pollen_is_not_an_outage(self, hass):
+        # The case ORDER #21 restored, which this must not undo: the API sent
+        # a forecast we can read, so the response carried data.
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, READABLE_RISK_PAYLOAD, E1)
+        assert coordinator.empty_since is None
+
+    async def test_a_risk_of_zero_is_a_reading(self, hass):
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(
+            coordinator,
+            {**READABLE_RISK_PAYLOAD, "allergyrisk": {"allergyrisk_1": 0}},
+            E1,
+        )
         assert coordinator.empty_since is None
 
     async def test_it_holds_for_the_duration_of_one_outage(self, hass):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -188,6 +188,18 @@ class TestOptionsReloadConsistency:
 
 EMPTY_PAYLOAD = {"contamination": []}
 FULL_PAYLOAD = {"contamination": [{"poll_title": "Birch (Betula)"}]}
+# Entries in the block, none of which identify an allergen. No sensor is built
+# from any of them, so the response carried no pollen data whatever its length.
+ALL_UNUSABLE_PAYLOAD = {
+    "contamination": [{"poll_title": "()"}, {"poll_title": ""}, {}],
+}
+
+ALL_UNUSABLE_WITH_RISK_PAYLOAD = {
+    "contamination": [{"poll_title": "()"}],
+    "allergyrisk": {"allergyrisk_1": 7.5},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [7.5] * 24},
+}
+
 RISK_ONLY_PAYLOAD = {
     "contamination": [],
     "allergyrisk": {"allergyrisk_1": 7.5},
@@ -239,6 +251,23 @@ class TestEmptySince:
         coordinator = self._make_coordinator(hass)
         await self._fetch(coordinator, EMPTY_PAYLOAD, E1)
         assert coordinator.empty_since == E1.isoformat()
+
+    async def test_a_block_of_unusable_entries_stamps_it(self, hass):
+        # The block is not empty, but nothing in it identifies an allergen, so
+        # it carried no more data than an empty one. Counting the raw length
+        # here would call this a response with data while the sensors were
+        # being recreated as stale for want of any.
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, ALL_UNUSABLE_PAYLOAD, E1)
+        assert coordinator.empty_since == E1.isoformat()
+
+    async def test_risk_data_beside_unusable_entries_is_still_data(self, hass):
+        # Deliberately not the same answer as the sensors give: the pollen
+        # block carried nothing usable, so those sensors are recreated, while
+        # the risk sensors report real readings and nothing is stale.
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, ALL_UNUSABLE_WITH_RISK_PAYLOAD, E1)
+        assert coordinator.empty_since is None
 
     async def test_it_holds_for_the_duration_of_one_outage(self, hass):
         coordinator = self._make_coordinator(hass)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -200,6 +200,21 @@ ALL_UNUSABLE_WITH_RISK_PAYLOAD = {
     "allergyrisk_hourly": {"allergyrisk_hourly_1": [7.5] * 24},
 }
 
+# Blocks that are present but not objects. The sensors read them as absent and
+# report unknown, so counting them as data here would leave a response nothing
+# can be read from without an outage for its sensors to point at.
+MALFORMED_RISK_PAYLOAD = {
+    "contamination": [],
+    "allergyrisk": ["oops"],
+    "allergyrisk_hourly": "x",
+}
+
+MALFORMED_RISK_WITH_POLLEN_PAYLOAD = {
+    "contamination": [{"poll_title": "Birch (Betula)"}],
+    "allergyrisk": ["oops"],
+    "allergyrisk_hourly": "x",
+}
+
 RISK_ONLY_PAYLOAD = {
     "contamination": [],
     "allergyrisk": {"allergyrisk_1": 7.5},
@@ -267,6 +282,21 @@ class TestEmptySince:
         # the risk sensors report real readings and nothing is stale.
         coordinator = self._make_coordinator(hass)
         await self._fetch(coordinator, ALL_UNUSABLE_WITH_RISK_PAYLOAD, E1)
+        assert coordinator.empty_since is None
+
+    async def test_risk_blocks_that_are_not_objects_stamp_it(self, hass):
+        # Nothing in this response can be read, so it is an outage even though
+        # two of its three blocks are non-empty.
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, MALFORMED_RISK_PAYLOAD, E1)
+        assert coordinator.empty_since == E1.isoformat()
+
+    async def test_a_malformed_risk_block_alone_is_not_an_outage(self, hass):
+        # The pollen block carried data, so the response did. A risk sensor
+        # with nothing to read is a missing reading, not an outage, and
+        # reports unknown without a marker.
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, MALFORMED_RISK_WITH_POLLEN_PAYLOAD, E1)
         assert coordinator.empty_since is None
 
     async def test_it_holds_for_the_duration_of_one_outage(self, hass):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2240,6 +2240,52 @@ class TestANonObjectEntryCostsOnlyItself:
         assert len(sensor.extra_state_attributes["forecast"]) == 4
 
 
+class TestFindItemIsSafeWithoutItsCallers:
+    """The block is filtered by _find_item itself, not by its callers.
+
+    These pass today and are meant to: they document the invariant rather
+    than fix a reachable bug. _find_item filters the block through the shared
+    predicate before either pass, so handing it the raw block directly is
+    already safe, and the unpack below that filter cannot meet a None. What
+    they pin is that the filter stays inside the function, where it does not
+    depend on who calls it.
+    """
+
+    @staticmethod
+    def _sensor(hass_coordinator):
+        return PolleninformationSensor(
+            coordinator=hass_coordinator,
+            sensor_type="pollen",
+            allergen_name="Birke",
+            allergen_en="birch",
+            allergen_slug="birch",
+            allergen_latin="Betula",
+            levels_current=["none", "low", "moderate", "high", "very high"],
+            levels_en=["none", "low", "moderate", "high", "very high"],
+            location_slug="hamburg",
+            location_title="Hamburg",
+            icon="mdi:tree-outline",
+        )
+
+    def test_an_unusable_entry_handed_straight_to_it_is_skipped(self):
+        sensor = self._sensor(_make_coordinator({"contamination": []}))
+        block = [
+            "oops",
+            {"poll_title": "()"},
+            {"poll_title": 5},
+            {},
+            {"poll_title": "Birke (Betula)", "contamination_1": 2},
+        ]
+
+        # The raw block, unfiltered by any caller.
+        assert sensor._find_item(block) == block[-1]
+
+    def test_a_block_of_nothing_usable_finds_nothing(self):
+        sensor = self._sensor(_make_coordinator({"contamination": []}))
+
+        assert sensor._find_item(["oops", {"poll_title": "()"}, {}]) is None
+
+
 class TestABlockThatIsNotAnObject:
     """The same assumption one level up, over the risk blocks.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2159,6 +2159,87 @@ class TestABlockOfUnusableEntriesReadsAsEmpty:
         assert "data_stale" not in sensor.extra_state_attributes
 
 
+# One non-object element beside a good one. The coordinator validates that
+# contamination is a list and says nothing about what is in it.
+NON_OBJECT_ELEMENT_RESPONSE = {
+    "contamination": [
+        "oops",
+        123,
+        None,
+        ["x"],
+        {
+            "poll_title": "Birke (Betula)",
+            "contamination_1": 3,
+            "contamination_2": 2,
+            "contamination_3": 1,
+            "contamination_4": 0,
+        },
+    ],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+
+class TestANonObjectEntryCostsOnlyItself:
+    """One junk element may not take the whole location down with it.
+
+    Everything else on this branch degrades a single sensor. This one raised
+    inside setup, which fails the config entry: every sensor for the location
+    disappears, risk sensors included. It raised again on every read, so
+    fixing setup alone would not have been enough.
+    """
+
+    async def test_setup_survives_and_keeps_the_good_entry(self, hass):
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=NON_OBJECT_ELEMENT_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_birch" in unique_ids
+
+    async def test_the_risk_sensors_survive_too(self, hass):
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=NON_OBJECT_ELEMENT_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_allergy_risk" in unique_ids
+
+    async def test_the_junk_is_warned_about(self, hass, caplog):
+        with caplog.at_level(logging.WARNING):
+            await _setup_entities(
+                hass,
+                "de",
+                response=NON_OBJECT_ELEMENT_RESPONSE,
+                language_block=EMPTY_LANGUAGE_BLOCK,
+            )
+        skipped = [
+            r for r in caplog.records if "identifies no allergen" in r.getMessage()
+        ]
+        assert len(skipped) == 4
+
+    async def test_reading_the_sensor_survives_it(self, hass):
+        # The read path matters as much as setup: the response is re-read on
+        # every refresh, so a fix in setup alone would leave the sensor
+        # raising for as long as the API sends that element.
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=NON_OBJECT_ELEMENT_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        sensor = _by_type(entities, PolleninformationSensor)
+
+        assert sensor.native_value == "hoch"
+        assert len(sensor.extra_state_attributes["forecast"]) == 4
+
+
 class TestEveryEntityReportsTheSameOutage:
     """The timestamp belongs to the response, so siblings must agree on it.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -16,12 +16,14 @@ from custom_components.polleninformation.const import DOMAIN
 from custom_components.polleninformation.sensor import (
     ALLERGEN_ICON_MAP,
     KNOWN_ALLERGEN_SLUGS,
+    LATIN_NAME_ALIASES,
     LATIN_TO_ENGLISH_NAME,
     RISK_SLUGS,
     AllergyRiskHourlySensor,
     AllergyRiskSensor,
     PolleninformationSensor,
     async_setup_entry,
+    canonical_latin,
     capitalize_first,
     english_name_for_latin,
     entity_id_available,
@@ -1358,6 +1360,70 @@ class TestPresentLatinIsAuthoritative:
             )
             is None
         )
+
+
+# The Slovak response spells ragweed's latin name "ambrózia", which is the
+# Slovak word rather than a candidate scientific name. Nothing in the static
+# map matches it, so before it was declared an alias the allergen was unknown.
+SLOVAK_RAGWEED_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Ragweed (ambrózia)",
+            "contamination_1": 1,
+            "contamination_2": 0,
+            "contamination_3": 0,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+
+class TestDeclaredLatinNameAliases:
+    """A spelling declared in LATIN_NAME_ALIASES resolves like the name itself.
+
+    The alias table is an allow-list: only a spelling we have seen the API
+    send is rewritten, so an unknown latin name is never guessed at.
+    """
+
+    def test_the_alias_resolves_to_its_allergen(self):
+        assert english_name_for_latin("ambrózia") == "ragweed"
+
+    def test_the_alias_is_matched_case_insensitively(self):
+        assert english_name_for_latin("Ambrózia") == "ragweed"
+
+    def test_canonical_latin_rewrites_only_a_declared_alias(self):
+        assert canonical_latin("ambrózia") == "Ambrosia"
+        assert canonical_latin("Asteraceae") == "Asteraceae"
+        assert canonical_latin("") == ""
+        assert canonical_latin(None) is None
+
+    def test_every_alias_names_an_allergen_the_map_knows(self):
+        assert set(LATIN_NAME_ALIASES.values()) <= set(LATIN_TO_ENGLISH_NAME)
+
+    async def _setup(self, hass):
+        return await _setup_entities(
+            hass,
+            "sk",
+            response=SLOVAK_RAGWEED_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+
+    async def test_a_slovak_install_gets_the_canonical_slug(self, hass):
+        entities = await self._setup(hass)
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+        assert "polleninformation_hamburg_ragweed" in unique_ids
+
+    async def test_the_latin_name_is_reported_canonically(self, hass):
+        entities = await self._setup(hass)
+        sensor = _by_type(entities, PolleninformationSensor)
+        assert sensor.extra_state_attributes["name_la"] == "Ambrosia"
+
+    async def test_no_unknown_allergen_warning(self, hass, caplog):
+        with caplog.at_level(logging.WARNING):
+            await self._setup(hass)
+        assert not [r for r in caplog.records if "Unknown allergen" in r.getMessage()]
 
 
 # The canonical slug for every allergen, pinned. These slugs are a public

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1746,6 +1746,20 @@ class TestStateMachineCollision:
 
 EMPTY_RESPONSE = {"contamination": [], "allergyrisk": {}, "allergyrisk_hourly": {}}
 
+GERMAN_BIRCH_RESPONSE_WITHOUT_LATIN = {
+    "contamination": [
+        {
+            "poll_title": "Birke",
+            "contamination_1": 3,
+            "contamination_2": 2,
+            "contamination_3": 1,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {},
+    "allergyrisk_hourly": {},
+}
+
 GERMAN_BIRCH_RESPONSE = {
     "contamination": [
         {
@@ -1912,6 +1926,65 @@ class TestStaleSensorRecovery:
         sensor = await _recreate_stale(hass, "es", "polleninformation_hamburg_ragweed")
         sensor.coordinator.data = GENUS_PREFIXED_NAME_RESPONSE
         assert sensor.native_value is None
+
+
+# A title with no name part and no brackets, beside a language map entry whose
+# name is blank. The map can hold one for an allergen the API named by its
+# latin name alone, which is the "(Poaceae)" shape the generator records.
+NAMELESS_TITLE_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "",
+            "contamination_1": 1,
+            "contamination_2": 0,
+            "contamination_3": 0,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+BLANK_NAMED_LANGUAGE_BLOCK = {"poll_titles": [{"name": "", "latin": "Poaceae"}]}
+
+
+class TestABlankNameNeverMatchesABlankName:
+    """The backfill matches an API title against the language map by name.
+
+    Both sides can be blank: the API sends a title with no name part and no
+    brackets, and the map can hold an entry whose name is blank. Letting those
+    match would hand the nameless entry the other one's latin name and make it
+    that allergen, with nothing in the response saying so.
+    """
+
+    async def _setup(self, hass):
+        return await _setup_entities(
+            hass,
+            "de",
+            response=NAMELESS_TITLE_RESPONSE,
+            language_block=BLANK_NAMED_LANGUAGE_BLOCK,
+        )
+
+    async def test_the_nameless_entry_does_not_become_that_allergen(self, hass):
+        entities = await self._setup(hass)
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+        assert "polleninformation_hamburg_grasses" not in unique_ids
+
+    async def test_it_claims_no_latin_name_of_its_own(self, hass):
+        entities = await self._setup(hass)
+        sensor = _by_type(entities, PolleninformationSensor)
+        assert sensor.extra_state_attributes["name_la"] == ""
+
+    async def test_a_named_entry_still_matches_the_map(self, hass):
+        # The guard may not cost the backfill its actual job.
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=GERMAN_BIRCH_RESPONSE_WITHOUT_LATIN,
+            language_block={"poll_titles": [{"name": "Birke", "latin": "Betula"}]},
+        )
+        sensor = _by_type(entities, PolleninformationSensor)
+        assert sensor.extra_state_attributes["name_la"] == "Betula"
 
 
 class TestReportedLatinNameAcrossAnOutage:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2440,6 +2440,49 @@ class TestTheRiskGateAtSetup:
         assert "polleninformation_hamburg_allergy_risk_hourly" in unique_ids
 
 
+class TestTheHourlyReaderTakesAnyShape:
+    """A day of readings is a sequence, and the reader says so.
+
+    usable_risk_block answers the shared question, whether there is anything
+    here to read. What a value must LOOK like to be read is per reader: the
+    daily one wants a number and already swallows anything else, this one
+    wants a sequence of hours. A scalar has no length and a mapping is indexed
+    by key, so both used to raise inside the property, once per entity per
+    read.
+    """
+
+    @staticmethod
+    def _sensor(values):
+        return AllergyRiskHourlySensor(
+            coordinator=_make_coordinator(
+                {"allergyrisk_hourly": {"allergyrisk_hourly_1": values}}
+            ),
+            levels_current=["none", "low", "moderate", "high", "very high"],
+            location_slug="hamburg",
+            location_title="Hamburg",
+        )
+
+    @pytest.mark.parametrize("values", [5, 5.0, True, "abc", {"a": 1}, None, []])
+    def test_a_day_that_is_not_a_sequence_reports_unknown(self, values):
+        sensor = self._sensor(values)
+
+        assert sensor.native_value is None
+        # No forecast, whether the block was refused by the predicate or the
+        # day inside it turned out not to be a day.
+        assert sensor.extra_state_attributes.get("forecast", []) == []
+
+    def test_a_real_day_still_reads(self):
+        sensor = self._sensor([6.0] * 24)
+
+        assert sensor.native_value is not None
+        assert len(sensor.extra_state_attributes["forecast"]) == 24
+
+    def test_a_short_day_reads_the_hours_it_has(self):
+        sensor = self._sensor([6.0, 6.0, 6.0])
+
+        assert len(sensor.extra_state_attributes["forecast"]) == 3
+
+
 class TestARiskBlockWithNothingReadable:
     """Nonempty is not usable, one level deeper than last time.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2280,6 +2280,71 @@ class TestABlockThatIsNotAnObject:
         assert sensor.native_value is None
 
 
+class TestTheRiskGateAtSetup:
+    """Risk sensors are gated on the API having SENT pollen data.
+
+    Not on our having read it. An empty contamination block means the API had
+    nothing to say and a risk number beside it is meaningless, which is what
+    the gate was written for. A block we could not parse is the opposite: the
+    forecast was there, we failed at it, and the risk reading is real.
+    """
+
+    @staticmethod
+    def _response(contamination, **blocks):
+        return {
+            "contamination": contamination,
+            "allergyrisk": {"allergyrisk_1": 7.0},
+            "allergyrisk_hourly": {"allergyrisk_hourly_1": [7.0] * 24},
+            **blocks,
+        }
+
+    async def _setup(self, hass, response):
+        return await _setup_entities(
+            hass, "de", response=response, language_block=EMPTY_LANGUAGE_BLOCK
+        )
+
+    async def test_a_real_reading_survives_a_block_we_could_not_parse(self, hass):
+        entities = await self._setup(
+            hass, self._response([{"poll_title": "()"}, {"poll_title": ""}])
+        )
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_allergy_risk" in unique_ids
+        assert "polleninformation_hamburg_allergy_risk_hourly" in unique_ids
+
+    async def test_the_reading_is_the_one_the_api_sent(self, hass):
+        entities = await self._setup(hass, self._response([{"poll_title": "()"}]))
+        sensor = _by_type(entities, AllergyRiskSensor)
+
+        # 7.0 on the API's 0-10 scale, scaled to the 0-4 level names.
+        assert sensor.native_value == "hoch"
+
+    async def test_an_empty_block_still_suppresses_them(self, hass):
+        # Unchanged, and the reason the gate exists: the API said nothing at
+        # all, so a risk number beside it means nothing either.
+        entities = await self._setup(hass, self._response([]))
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_allergy_risk" not in unique_ids
+
+    async def test_a_risk_block_that_is_not_an_object_builds_no_sensor(self, hass):
+        # The fifth emptiness site. This gate kept its own raw read, so a
+        # non-object block was truthy here and empty for every other reader:
+        # the entity was built and then reported unknown forever.
+        entities = await self._setup(
+            hass,
+            self._response(
+                [{"poll_title": "Birke (Betula)", "contamination_1": 1}],
+                allergyrisk=["x"],
+            ),
+        )
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_allergy_risk" not in unique_ids
+        # The hourly block is fine, so its sensor is unaffected.
+        assert "polleninformation_hamburg_allergy_risk_hourly" in unique_ids
+
+
 class TestEveryEntityReportsTheSameOutage:
     """The timestamp belongs to the response, so siblings must agree on it.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1928,75 +1928,15 @@ class TestStaleSensorRecovery:
         assert sensor.native_value is None
 
 
-# A title with brackets but nothing in them, beside a language map entry whose
-# name is blank. The map can hold such an entry for an allergen the API named
-# by its latin name alone, which is the "(Poaceae)" shape the generator
-# records. The title is readable, so it still becomes a sensor; it just has no
-# name part, which is what the backfill compares on.
-NAMELESS_TITLE_RESPONSE = {
-    "contamination": [
-        {
-            "poll_title": "()",
-            "contamination_1": 1,
-            "contamination_2": 0,
-            "contamination_3": 0,
-            "contamination_4": 0,
-        }
-    ],
-    "allergyrisk": {"allergyrisk_1": 5.0},
-    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
-}
-
-BLANK_NAMED_LANGUAGE_BLOCK = {"poll_titles": [{"name": "", "latin": "Poaceae"}]}
-
-
-class TestABlankNameNeverMatchesABlankName:
-    """The backfill matches an API title against the language map by name.
-
-    Both sides can be blank: the API sends a title with no name part and no
-    brackets, and the map can hold an entry whose name is blank. Letting those
-    match would hand the nameless entry the other one's latin name and make it
-    that allergen, with nothing in the response saying so.
-    """
-
-    async def _setup(self, hass):
-        return await _setup_entities(
-            hass,
-            "de",
-            response=NAMELESS_TITLE_RESPONSE,
-            language_block=BLANK_NAMED_LANGUAGE_BLOCK,
-        )
-
-    async def test_the_nameless_entry_does_not_become_that_allergen(self, hass):
-        entities = await self._setup(hass)
-        unique_ids = {e.unique_id for e in entities if e.unique_id}
-        assert "polleninformation_hamburg_grasses" not in unique_ids
-
-    async def test_it_claims_no_latin_name_of_its_own(self, hass):
-        entities = await self._setup(hass)
-        sensor = _by_type(entities, PolleninformationSensor)
-        assert sensor.extra_state_attributes["name_la"] == ""
-
-    async def test_a_named_entry_still_matches_the_map(self, hass):
-        # The guard may not cost the backfill its actual job.
-        entities = await _setup_entities(
-            hass,
-            "de",
-            response=GERMAN_BIRCH_RESPONSE_WITHOUT_LATIN,
-            language_block={"poll_titles": [{"name": "Birke", "latin": "Betula"}]},
-        )
-        sensor = _by_type(entities, PolleninformationSensor)
-        assert sensor.extra_state_attributes["name_la"] == "Betula"
-
-
-class TestAnEntryWithNoReadableTitleGetsNoSensor:
+class TestAnEntryThatIdentifiesNothingGetsNoSensor:
     """The setup path agrees with the language map generator.
 
-    An entry with no readable title identifies nothing, so building a sensor
-    from it manufactures an entity with no name, no latin name and an
-    entity_id ending in nothing, which no later response and no restore path
-    can match back to an allergen. The generator refuses to record such an
-    entry; the runtime refuses to build one.
+    The test is what the entry identifies, not whether its title can be read:
+    "()" is a non-blank title with nothing in either half of it. Such an entry
+    names no allergen, so building a sensor from it manufactures an entity
+    with no name, no latin name and an entity_id ending in nothing, which no
+    later response and no restore path can match back to an allergen. The
+    generator refuses to record one; the runtime refuses to build one.
     """
 
     @staticmethod
@@ -2019,10 +1959,16 @@ class TestAnEntryWithNoReadableTitleGetsNoSensor:
     @pytest.mark.parametrize(
         "item",
         [
+            # Nothing to read at all.
             {"poll_title": "", "contamination_1": 1},
             {"poll_title": "   ", "contamination_1": 1},
             {"poll_title": 123, "contamination_1": 1},
             {"contamination_1": 1},
+            # Readable, and still naming nothing.
+            {"poll_title": "()", "contamination_1": 1},
+            {"poll_title": "( )", "contamination_1": 1},
+            {"poll_title": "  (  )  ", "contamination_1": 1},
+            {"poll_title": "()extra", "contamination_1": 1},
         ],
     )
     async def test_no_sensor_is_built_for_it(self, hass, item):
@@ -2038,16 +1984,30 @@ class TestAnEntryWithNoReadableTitleGetsNoSensor:
         assert len(pollen) == 1
         assert pollen[0].unique_id == "polleninformation_hamburg_birch"
 
-    async def test_no_entity_id_ending_in_nothing(self, hass):
+    @pytest.mark.parametrize("poll_title", ["", "()"])
+    async def test_no_entity_id_ending_in_nothing(self, hass, poll_title):
         entities = await _setup_entities(
             hass,
             "de",
-            response=self._response({"poll_title": "", "contamination_1": 1}),
+            response=self._response({"poll_title": poll_title, "contamination_1": 1}),
             language_block=EMPTY_LANGUAGE_BLOCK,
         )
         unique_ids = {e.unique_id for e in entities if e.unique_id}
 
         assert "polleninformation_hamburg_" not in unique_ids
+
+    async def test_a_latin_name_alone_is_still_an_allergen(self, hass):
+        # The other side of the rule: "(Poaceae)" has no display name in this
+        # language, but it identifies an allergen and keeps its sensor.
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=self._response({"poll_title": "(Poaceae)", "contamination_1": 1}),
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_grasses" in unique_ids
 
     async def test_it_is_warned_about(self, hass, caplog):
         with caplog.at_level(logging.WARNING):
@@ -2057,7 +2017,7 @@ class TestAnEntryWithNoReadableTitleGetsNoSensor:
                 response=self._response({"poll_title": "", "contamination_1": 1}),
                 language_block=EMPTY_LANGUAGE_BLOCK,
             )
-        assert [r for r in caplog.records if "no readable title" in r.getMessage()]
+        assert [r for r in caplog.records if "identifies no allergen" in r.getMessage()]
 
     async def test_a_readable_entry_is_untouched(self, hass):
         # The guard may not cost an ordinary allergen its sensor.

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1928,13 +1928,15 @@ class TestStaleSensorRecovery:
         assert sensor.native_value is None
 
 
-# A title with no name part and no brackets, beside a language map entry whose
-# name is blank. The map can hold one for an allergen the API named by its
-# latin name alone, which is the "(Poaceae)" shape the generator records.
+# A title with brackets but nothing in them, beside a language map entry whose
+# name is blank. The map can hold such an entry for an allergen the API named
+# by its latin name alone, which is the "(Poaceae)" shape the generator
+# records. The title is readable, so it still becomes a sensor; it just has no
+# name part, which is what the backfill compares on.
 NAMELESS_TITLE_RESPONSE = {
     "contamination": [
         {
-            "poll_title": "",
+            "poll_title": "()",
             "contamination_1": 1,
             "contamination_2": 0,
             "contamination_3": 0,
@@ -1985,6 +1987,83 @@ class TestABlankNameNeverMatchesABlankName:
         )
         sensor = _by_type(entities, PolleninformationSensor)
         assert sensor.extra_state_attributes["name_la"] == "Betula"
+
+
+class TestAnEntryWithNoReadableTitleGetsNoSensor:
+    """The setup path agrees with the language map generator.
+
+    An entry with no readable title identifies nothing, so building a sensor
+    from it manufactures an entity with no name, no latin name and an
+    entity_id ending in nothing, which no later response and no restore path
+    can match back to an allergen. The generator refuses to record such an
+    entry; the runtime refuses to build one.
+    """
+
+    @staticmethod
+    def _response(item):
+        return {
+            "contamination": [
+                item,
+                {
+                    "poll_title": "Birke (Betula)",
+                    "contamination_1": 3,
+                    "contamination_2": 2,
+                    "contamination_3": 1,
+                    "contamination_4": 0,
+                },
+            ],
+            "allergyrisk": {"allergyrisk_1": 5.0},
+            "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+        }
+
+    @pytest.mark.parametrize(
+        "item",
+        [
+            {"poll_title": "", "contamination_1": 1},
+            {"poll_title": "   ", "contamination_1": 1},
+            {"poll_title": 123, "contamination_1": 1},
+            {"contamination_1": 1},
+        ],
+    )
+    async def test_no_sensor_is_built_for_it(self, hass, item):
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=self._response(item),
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        pollen = [e for e in entities if isinstance(e, PolleninformationSensor)]
+
+        # Only the birch entry beside it became a sensor.
+        assert len(pollen) == 1
+        assert pollen[0].unique_id == "polleninformation_hamburg_birch"
+
+    async def test_no_entity_id_ending_in_nothing(self, hass):
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=self._response({"poll_title": "", "contamination_1": 1}),
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_" not in unique_ids
+
+    async def test_it_is_warned_about(self, hass, caplog):
+        with caplog.at_level(logging.WARNING):
+            await _setup_entities(
+                hass,
+                "de",
+                response=self._response({"poll_title": "", "contamination_1": 1}),
+                language_block=EMPTY_LANGUAGE_BLOCK,
+            )
+        assert [r for r in caplog.records if "no readable title" in r.getMessage()]
+
+    async def test_a_readable_entry_is_untouched(self, hass):
+        # The guard may not cost an ordinary allergen its sensor.
+        entities = await _setup_entities(hass, "de")
+        sensor = _by_type(entities, PolleninformationSensor)
+        assert sensor.unique_id == "polleninformation_hamburg_ragweed"
 
 
 class TestReportedLatinNameAcrossAnOutage:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1452,7 +1452,11 @@ class TestDeclaredLatinNameAliases:
         unique_ids = {e.unique_id for e in entities if e.unique_id}
         assert "polleninformation_hamburg_ragweed" in unique_ids
 
-    async def test_the_latin_name_is_reported_canonically(self, hass):
+    async def test_the_alias_is_reported_as_the_name_it_stands_for(self, hass):
+        # Not a canonicalization rule: the alias case is the one where what
+        # the API sent and the map key happen to coincide. What the two paths
+        # do with a latin name that is not an alias is pinned in
+        # TestReportedLatinNameAcrossAnOutage.
         entities = await self._setup(hass)
         sensor = _by_type(entities, PolleninformationSensor)
         assert sensor.extra_state_attributes["name_la"] == "Ambrosia"
@@ -1908,6 +1912,47 @@ class TestStaleSensorRecovery:
         sensor = await _recreate_stale(hass, "es", "polleninformation_hamburg_ragweed")
         sensor.coordinator.data = GENUS_PREFIXED_NAME_RESPONSE
         assert sensor.native_value is None
+
+
+class TestReportedLatinNameAcrossAnOutage:
+    """What name_la says on each path, including where they differ.
+
+    The setup path reports what the API sent about this allergen, species
+    included. The restore path has only the slug to work from, so the most it
+    can say is the key of LATIN_TO_ENGLISH_NAME. For an allergen the API
+    spells with a genus alone the two coincide; for one it spells with a
+    species they do not, and that difference is deliberate: matching them
+    would mean discarding a species the API did send.
+    """
+
+    async def test_the_setup_path_reports_the_species_the_api_sent(self, hass):
+        entities = await _setup_entities(hass, "de")
+        sensor = _by_type(entities, PolleninformationSensor)
+        assert sensor.extra_state_attributes["name_la"] == "Ambrosia artemisiifolia"
+
+    async def test_the_restore_path_reports_the_map_key(self, hass):
+        sensor = await _recreate_stale(hass, "de", "polleninformation_hamburg_ragweed")
+        assert sensor.extra_state_attributes["name_la"] == "Ambrosia"
+
+    async def test_the_difference_lasts_no_longer_than_the_outage(self, hass):
+        # The restore path only runs while the API is answering with nothing.
+        # The first answer that carries data goes through setup again, so the
+        # species comes back with it.
+        stale = await _recreate_stale(hass, "de", "polleninformation_hamburg_ragweed")
+        assert stale.extra_state_attributes["name_la"] == "Ambrosia"
+
+        entities = await _setup_entities(hass, "de")
+        recovered = _by_type(entities, PolleninformationSensor)
+        assert recovered.extra_state_attributes["name_la"] == "Ambrosia artemisiifolia"
+
+    async def test_the_paths_agree_when_the_api_sends_the_genus_alone(self, hass):
+        # Most allergens, and the reason the difference is easy to miss.
+        entities = await _setup_entities(hass, "de", response=GERMAN_BIRCH_RESPONSE)
+        setup_sensor = _by_type(entities, PolleninformationSensor)
+        stale = await _recreate_stale(hass, "de", "polleninformation_hamburg_birch")
+
+        assert setup_sensor.extra_state_attributes["name_la"] == "Betula"
+        assert stale.extra_state_attributes["name_la"] == "Betula"
 
 
 class TestEveryEntityReportsTheSameOutage:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -29,6 +29,7 @@ from custom_components.polleninformation.sensor import (
     entity_id_available,
     extract_allergen_slug_from_unique_id,
     localized_risk_object_id_suffixes,
+    resolve_latin_alias,
     scale_allergy_risk,
 )
 from custom_components.polleninformation.utils import slugify
@@ -1393,10 +1394,29 @@ class TestDeclaredLatinNameAliases:
     def test_the_alias_is_matched_case_insensitively(self):
         assert english_name_for_latin("Ambrózia") == "ragweed"
 
-    def test_canonical_latin_rewrites_only_a_declared_alias(self):
+    def test_the_alias_resolver_rewrites_only_a_declared_alias(self):
+        # What the sensor reports as name_la: a declared spelling becomes the
+        # name it stands for, and everything else is left exactly as sent,
+        # species and all.
+        assert resolve_latin_alias("ambrózia") == "Ambrosia"
+        assert resolve_latin_alias("Asteraceae") == "Asteraceae"
+        assert resolve_latin_alias("Ambrosia artemisiifolia") == (
+            "Ambrosia artemisiifolia"
+        )
+        assert resolve_latin_alias("") == ""
+        assert resolve_latin_alias(None) is None
+
+    def test_canonical_latin_returns_the_map_key(self):
+        # What anything keyed by latin name has to store, since the language
+        # block lookups match exactly.
         assert canonical_latin("ambrózia") == "Ambrosia"
-        assert canonical_latin("Asteraceae") == "Asteraceae"
-        assert canonical_latin("") == ""
+        assert canonical_latin("poaceae") == "Poaceae"
+        assert canonical_latin(" Poaceae ") == "Poaceae"
+        assert canonical_latin("Ambrosia artemisiifolia") == "Ambrosia"
+
+    def test_canonical_latin_knows_nothing_it_should_not(self):
+        assert canonical_latin("Asteraceae") is None
+        assert canonical_latin("") is None
         assert canonical_latin(None) is None
 
     def test_every_alias_names_an_allergen_the_map_knows(self):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2067,6 +2067,98 @@ class TestReportedLatinNameAcrossAnOutage:
         assert stale.extra_state_attributes["name_la"] == "Betula"
 
 
+# A response with entries in it, none of which identify an allergen. The raw
+# block is non-empty, so before the emptiness test was moved onto the usable
+# entries this looked like a response carrying data while building no sensors
+# at all.
+ALL_UNUSABLE_RESPONSE = {
+    "contamination": [
+        {"poll_title": "()", "contamination_1": 1},
+        {"poll_title": "", "contamination_1": 2},
+        {"contamination_1": 3},
+    ],
+    "allergyrisk": {},
+    "allergyrisk_hourly": {},
+}
+
+ALL_UNUSABLE_WITH_RISK_RESPONSE = {
+    "contamination": [{"poll_title": "()", "contamination_1": 1}],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+
+class TestABlockOfUnusableEntriesReadsAsEmpty:
+    """Entities are kept and marked stale, not lost.
+
+    Every entry in the block identifies nothing, so no sensor is built from
+    any of them. Counting the raw list would call that a response carrying
+    data, and the sensors this location already has would then simply not be
+    added: absent from Home Assistant rather than present and stale, which is
+    what the user sees.
+    """
+
+    async def _setup_with_registered(self, hass, response, slugs=("birch",)):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        for slug in slugs:
+            unique_id = f"polleninformation_hamburg_{slug}"
+            ent_reg.async_get_or_create(
+                "sensor",
+                DOMAIN,
+                unique_id,
+                suggested_object_id=unique_id,
+                config_entry=entry,
+            )
+        return await _setup_entities(
+            hass,
+            "de",
+            entry=entry,
+            response=response,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+
+    async def test_a_registered_sensor_is_recreated_rather_than_lost(self, hass):
+        entities = await self._setup_with_registered(hass, ALL_UNUSABLE_RESPONSE)
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_birch" in unique_ids
+
+    async def test_the_recreated_sensor_is_marked_stale(self, hass):
+        entities = await self._setup_with_registered(hass, ALL_UNUSABLE_RESPONSE)
+        sensor = _by_type(entities, PolleninformationSensor)
+
+        assert sensor.extra_state_attributes["data_stale"] is True
+
+    async def test_no_sensor_is_built_from_the_unusable_entries(self, hass):
+        entities = await self._setup_with_registered(hass, ALL_UNUSABLE_RESPONSE)
+        pollen = [e for e in entities if isinstance(e, PolleninformationSensor)]
+
+        # Only the recreated one, nothing manufactured from the junk.
+        assert len(pollen) == 1
+
+    async def test_risk_entities_are_recreated_too(self, hass):
+        entities = await self._setup_with_registered(
+            hass, ALL_UNUSABLE_RESPONSE, slugs=("birch", "allergy_risk")
+        )
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_allergy_risk" in unique_ids
+
+    async def test_risk_data_keeps_the_response_from_being_stale(self, hass):
+        # The two tests are not the same question and are allowed to disagree:
+        # the pollen block carried nothing usable, so its sensors are
+        # recreated, while the response as a whole did carry data, so nothing
+        # is marked stale and the risk sensors report real readings.
+        entities = await self._setup_with_registered(
+            hass, ALL_UNUSABLE_WITH_RISK_RESPONSE
+        )
+        sensor = _by_type(entities, PolleninformationSensor)
+
+        assert "data_stale" not in sensor.extra_state_attributes
+
+
 class TestEveryEntityReportsTheSameOutage:
     """The timestamp belongs to the response, so siblings must agree on it.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2440,7 +2440,79 @@ class TestTheRiskGateAtSetup:
         assert "polleninformation_hamburg_allergy_risk_hourly" in unique_ids
 
 
-class TestEveryEntityReportsTheSameOutage:
+class TestARiskBlockWithNothingReadable:
+    """Nonempty is not usable, one level deeper than last time.
+
+    block_of answers whether there is a block; the callers were using it to
+    answer whether there is anything to read. {"error": "upstream failure"}
+    is an object, so the outage was cleared, the pollen sensors were
+    recreated for want of data, and nothing carried the marker.
+    """
+
+    UNREADABLE = {
+        "contamination": [{"poll_title": "()"}, {"poll_title": ""}],
+        "allergyrisk": {"error": "upstream failure"},
+        "allergyrisk_hourly": {},
+    }
+
+    READABLE = {
+        "contamination": [{"poll_title": "()"}],
+        "allergyrisk": {"allergyrisk_1": 7.0},
+        "allergyrisk_hourly": {"allergyrisk_hourly_1": [7.0] * 24},
+    }
+
+    async def _with_registered(self, hass, response):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        for slug in ("birch", "allergy_risk"):
+            unique_id = f"polleninformation_hamburg_{slug}"
+            ent_reg.async_get_or_create(
+                "sensor",
+                DOMAIN,
+                unique_id,
+                suggested_object_id=unique_id,
+                config_entry=entry,
+            )
+        return await _setup_entities(
+            hass,
+            "de",
+            entry=entry,
+            response=response,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+
+    async def test_the_sensors_carry_the_marker(self, hass):
+        entities = await self._with_registered(hass, self.UNREADABLE)
+        sensor = _by_type(entities, PolleninformationSensor)
+
+        assert sensor.extra_state_attributes["data_stale"] is True
+
+    async def test_no_risk_sensor_is_built_from_it(self, hass):
+        entities = await _setup_entities(
+            hass, "de", response=self.UNREADABLE, language_block=EMPTY_LANGUAGE_BLOCK
+        )
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_allergy_risk" not in unique_ids
+
+    async def test_a_readable_reading_beside_unusable_pollen_still_survives(self, hass):
+        # ORDER #21 A restored this; it must not regress.
+        entities = await _setup_entities(
+            hass, "de", response=self.READABLE, language_block=EMPTY_LANGUAGE_BLOCK
+        )
+        risk = _by_type(entities, AllergyRiskSensor)
+
+        assert risk.native_value == "hoch"
+        assert "data_stale" not in risk.extra_state_attributes
+
+    async def test_reading_an_unreadable_block_reports_unknown(self, hass):
+        entities = await _setup_entities(hass, "de")
+        risk = _by_type(entities, AllergyRiskSensor)
+        risk.coordinator.data = self.UNREADABLE
+
+        assert risk.native_value is None
+
     """The timestamp belongs to the response, so siblings must agree on it.
 
     The per-outage semantics themselves are the coordinator's, and are tested

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2240,6 +2240,55 @@ class TestANonObjectEntryCostsOnlyItself:
         assert len(sensor.extra_state_attributes["forecast"]) == 4
 
 
+class TestTheLanguageMapIsReadDefensively:
+    """The shipped map is an input too, and the only one nothing type checks.
+
+    The API's response is parsed and filtered before anything reads it. The
+    language block is loaded from a file and its latin name goes straight into
+    a lookup that calls .strip(), so a map holding the wrong shape would raise
+    inside setup and take the whole config entry down: every sensor for the
+    location, for a bad row in a file the user can edit.
+    """
+
+    RESPONSE = {
+        "contamination": [
+            {"poll_title": "Birke", "contamination_1": 3},
+        ],
+        "allergyrisk": {"allergyrisk_1": 5.0},
+        "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+    }
+
+    @pytest.mark.parametrize(
+        "block",
+        [
+            {"poll_titles": [{"name": "Birke", "latin": ["Betula"]}]},
+            {"poll_titles": [{"name": "Birke", "latin": 5}]},
+            {"poll_titles": ["oops", {"name": "Birke", "latin": "Betula"}]},
+            {"poll_titles": None},
+            {"poll_titles": {}},
+        ],
+    )
+    async def test_setup_survives_a_map_of_the_wrong_shape(self, hass, block):
+        entities = await _setup_entities(
+            hass, "de", response=self.RESPONSE, language_block=block
+        )
+
+        # The entry still becomes a sensor; only its latin name is missing.
+        assert [e for e in entities if isinstance(e, PolleninformationSensor)]
+
+    async def test_a_well_formed_map_still_supplies_the_latin_name(self, hass):
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=self.RESPONSE,
+            language_block={"poll_titles": [{"name": "Birke", "latin": "Betula"}]},
+        )
+        sensor = _by_type(entities, PolleninformationSensor)
+
+        assert sensor.extra_state_attributes["name_la"] == "Betula"
+        assert sensor.unique_id == "polleninformation_hamburg_birch"
+
+
 class TestFindItemIsSafeWithoutItsCallers:
     """The block is filtered by _find_item itself, not by its callers.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1422,6 +1422,23 @@ class TestDeclaredLatinNameAliases:
     def test_every_alias_names_an_allergen_the_map_knows(self):
         assert set(LATIN_NAME_ALIASES.values()) <= set(LATIN_TO_ENGLISH_NAME)
 
+    def test_no_alias_shadows_a_latin_name_the_map_knows(self):
+        # The other half of the same property. Both indexes fold the aliases
+        # in with setdefault, so a real latin name wins there, while
+        # resolve_latin_alias reads the table directly and lets the alias win.
+        # A key that is also a real latin name would therefore make the file
+        # and the sensors disagree about the same string, with nothing to warn
+        # about it and every test green.
+        known = {latin.lower() for latin in LATIN_TO_ENGLISH_NAME}
+        known |= {latin.split()[0].lower() for latin in LATIN_TO_ENGLISH_NAME}
+        assert not (set(LATIN_NAME_ALIASES) & known)
+
+    def test_the_two_resolvers_agree_on_every_alias(self):
+        """What the shadowing rule is for, stated as the property itself."""
+        for alias, latin in LATIN_NAME_ALIASES.items():
+            assert resolve_latin_alias(alias) == latin
+            assert canonical_latin(alias) == latin
+
     async def _setup(self, hass):
         return await _setup_entities(
             hass,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2240,6 +2240,46 @@ class TestANonObjectEntryCostsOnlyItself:
         assert len(sensor.extra_state_attributes["forecast"]) == 4
 
 
+class TestABlockThatIsNotAnObject:
+    """The same assumption one level up, over the risk blocks.
+
+    allergyrisk and allergyrisk_hourly are read with .get, so a block that
+    arrives as a list or a string raised on the first read and took the
+    entity down with it. A block that is not an object carries nothing, which
+    is what an absent one means too.
+    """
+
+    @pytest.mark.parametrize("risk", [["oops"], "x", 42, None])
+    async def test_the_daily_risk_sensor_reports_nothing(self, hass, risk):
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response={**RAGWEED_RESPONSE, "allergyrisk": risk},
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        sensor = _by_type(entities, PolleninformationSensor)
+
+        # The pollen sensor is unaffected, and nothing raised on the way here.
+        assert sensor.native_value is not None
+
+    @pytest.mark.parametrize("risk", [["oops"], "x", 42])
+    async def test_reading_a_risk_sensor_survives_it(self, hass, risk):
+        entities = await _setup_entities(hass, "de")
+        sensor = _by_type(entities, AllergyRiskSensor)
+        sensor.coordinator.data = {**RAGWEED_RESPONSE, "allergyrisk": risk}
+
+        assert sensor.native_value is None
+        assert "forecast" not in sensor.extra_state_attributes
+
+    @pytest.mark.parametrize("risk", [["oops"], "x", 42])
+    async def test_reading_an_hourly_risk_sensor_survives_it(self, hass, risk):
+        entities = await _setup_entities(hass, "de")
+        sensor = _by_type(entities, AllergyRiskHourlySensor)
+        sensor.coordinator.data = {**RAGWEED_RESPONSE, "allergyrisk_hourly": risk}
+
+        assert sensor.native_value is None
+
+
 class TestEveryEntityReportsTheSameOutage:
     """The timestamp belongs to the response, so siblings must agree on it.
 


### PR DESCRIPTION
## Summary

Closes the last known defect before v0.5.5. `scripts/generate_language_codes.py`
transcribed the API's `poll_title` into `language_map.json` by splitting on
brackets, with no validation, so whatever sat between the brackets was recorded
as a latin name and a bracketless title recorded an empty one.

Two shipped entries showed it: `sk` carried `"latin": "ambrózia"` for ragweed,
and `es` carried `"latin": ""` for `Artemisia`. Nothing broke, because the slug
pass added in this release recovers both. The visible effect was that a sensor
kept through an outage on those two installations fell back to an English name.

## Validation that warns rather than drops

The script now exposes three pure, importable functions instead of one inline
block: `split_poll_title`, `resolve_latin` and
`poll_titles_from_contamination`. `resolve_latin` tries, in order:

1. the parsed latin via `english_name_for_latin`, keeping genus-plus-species as sent
2. the display name via `english_name_for_display_name`, which is the `es` shape
3. the display name against the reverse of `LATIN_TO_ENGLISH_NAME`, which is the
   `sk` shape: the API left the display name untranslated (`Ragweed`) and put a
   Slovak word in the brackets, so neither 1 nor 2 resolves it. English names in
   the map are unique, so the reverse is lossless.
4. no match: warn loudly and record exactly what the API sent, empty latin included

Steps 2 and 3 warn as well, so a corrected entry is never silent, and nothing is
ever discarded. That last point is deliberate. The integration keeps an escape
hatch for allergens no map knows about, the `Unknown allergen` warning that asks
for a bug report. A generator that silently dropped an unrecognized latin would
close that hatch at the source, and a genuinely new allergen would vanish from
the language map without a trace.

The helpers are imported from `sensor.py` rather than duplicated. `sensor.py` and
`__init__.py` are untouched.

## Repairing the shipped entries

`main()` skips languages already present, so the generator could never
self-correct an existing entry. A new `--repair` flag revalidates every entry
already in the file through the same `resolve_latin`, offline, with no API key
and no network. It is idempotent and saves only when something changed.

It is a flag rather than part of every run because the fetch path already
validates what it writes, so repair only ever corrects entries written under
older rules. That is a deliberate act whose diff wants reviewing, not a side
effect of a fetch.

The two entries were fixed by running it, not by hand. The diff to
`language_map.json` is exactly those two lines.

## Tests

`scripts/` had no tests. `tests/test_generate_language_codes.py` adds 19, loading
the script by path since `scripts/` is not a package. They cover the three
`poll_title` shapes and an empty title, `resolve_latin` across recognized,
genus-plus-species, both defect shapes, an unknown latin and an unknown allergen,
that no contamination entry is ever dropped, and `repair_db` repairing, being
idempotent, keeping an unknown allergen and tolerating an error entry.

Two tests run against the shipped file itself: every recorded latin is
recognized, and the file needs no repair. Those are the regression pin that would
have caught this in the first place, and they fail against the unrepaired map.

275 passed, up from 256 on `dev`.

## Incidental

Two small changes in the script were required to make any of it testable. The API
key and the `requests`/`dotenv` imports moved from module level into the fetch
path, since importing the script previously raised `KeyError` on a missing key.
And `save_db` now writes a trailing newline, which `json.dump` omits, so repeated
saves do not produce a spurious last-line diff.
