### PR TITLE
Queue the slug a previous version gave the allergen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,37 @@
   missing since a gap that ended hours ago. Each outage now carries its own
   timestamp.
 
+- **A rename can no longer take a different allergen's sensor** — an
+  installation whose sensor IDs were built from a localized allergen name has
+  them renamed to the English form, and the old name is worked out from the
+  API's own answer. The API sends a display name and a latin name, and they do
+  not always describe the same allergen: a response whose display name is one
+  allergen's English name while its latin name identifies another one made the
+  integration look for a sensor under the first allergen's name and rename it
+  to the second. That took an existing sensor, its ID and its whole history,
+  and nothing undid it afterwards. A candidate that is another allergen's own
+  name is now refused, and the refusal is logged. In v0.5.4 this could happen
+  for the ten allergens the integration's English allergen list does not carry
+  (Ailanthus altissima, Castanea, Fagus, Fraxinus, Plantago, Quercus, Rumex,
+  Salix, Tilia, Ulmus), where the old name always falls back to the name the
+  API sent.
+
+- **Sensors record which allergen they are** — an allergen the integration's
+  maps do not know keeps a sensor under the localized name the API sent, and
+  Home Assistant's registry stores nothing that says which allergen such a
+  sensor is: the name it was created under is all there is to go on. If the
+  API later sends that same name for a different allergen, the rename above
+  has nothing to check against and would take the sensor and its history for
+  the newcomer. Each sensor now records its latin name on its own registry
+  entry, where a restart keeps it, and a rename contradicting what a sensor
+  records is refused and logged. The record is written for every allergen the
+  API identifies, not only for sensors created from now on, so an existing
+  installation starts recording the sensors it already has on the first update
+  after upgrading. A sensor that has recorded nothing yet is treated exactly as
+  before, so nothing that works today stops working. Only this integration's
+  own entry is written and only when the value would change, so the rest of the
+  registry entry, including anything you have customized, is left alone.
+
 ## v0.5.4 — Allergen icons (2026-08-10)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@
   entry, where a restart keeps it, and a rename contradicting what a sensor
   records is refused and logged. The record is written for every allergen the
   API identifies, not only for sensors created from now on, so an existing
-  installation starts recording the sensors it already has on the first update
+  installation starts recording the sensors it already has on the first start
   after upgrading. A sensor that has recorded nothing yet is treated exactly as
   before, so nothing that works today stops working. Only this integration's
   own entry is written and only when the value would change, so the rest of the

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -611,9 +611,24 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 poll_title_local,
             )
         slug_en = slugify(allergen_en) if allergen_en else slugify(poll_title_local)
-        legacy_slug = slugify(legacy_en) if legacy_en else slug_en
-        if legacy_slug and legacy_slug != slug_en:
-            allergen_renames.append((legacy_slug, slug_en))
+        # Every slug a previous version could have given this allergen, not
+        # only the one the current language block implies. Before the display
+        # name was resolvable, an allergen the block could not place was
+        # slugged from the name the API sent, so that slug is a candidate
+        # whatever the block says NOW. It matters because the block itself
+        # changes: repairing a missing latin name in the map turned the
+        # English-block lookup from a miss into a hit, which made legacy_en
+        # equal allergen_en and queued no rename at all, leaving the old
+        # entity orphaned beside a new one. A candidate is only ever acted on
+        # when an entity with that unique_id actually exists, so listing one
+        # that never occurred costs nothing.
+        legacy_candidates = [
+            slugify(legacy_en) if legacy_en else "",
+            slugify(poll_title_local),
+        ]
+        for legacy_slug in dict.fromkeys(legacy_candidates):
+            if legacy_slug and legacy_slug != slug_en:
+                allergen_renames.append((legacy_slug, slug_en))
         icon = ALLERGEN_ICON_MAP.get(slug_en, ALLERGEN_ICON_MAP["default"])
 
         sensor = PolleninformationSensor(

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -324,15 +324,30 @@ def allergen_identity_key(latin) -> str | None:
     """Return the key two latin names must share to be the same allergen.
 
     The map's own spelling when it knows the name, so that "Ambrosia",
-    "Ambrosia artemisiifolia" and every alias of them answer alike; the name
-    itself, folded, when no map knows it. That second half is the point: the
-    rows this exists to protect are exactly the ones no map can place, so a
-    key that only spoke for known allergens would say "unknown" for the whole
-    population it was written for.
+    "Ambrosia artemisiifolia" and every alias of them answer alike; the genus
+    of the name itself when no map knows it. That second half is the point:
+    the rows this exists to protect are exactly the ones no map can place, so
+    a key that only spoke for known allergens would say "unknown" for the
+    whole population it was written for.
+
+    Both halves fall back to the genus, and they have to fall together. A
+    known name resolves through canonical_latin, which drops a species; if an
+    unknown name did not, one allergen would contradict ITSELF as soon as the
+    API sent "Nonexistentia" for one language and "Nonexistentia vulgaris" for
+    another, and the migration would be refused naming the very allergen it
+    is. That is the whole unmapped population, which is the population this
+    was written for.
+
+    The cost is that two unmapped names sharing a first word answer alike.
+    They share a genus, and a genus is what this integration means by an
+    allergen everywhere else: LATIN_TO_ENGLISH_NAME is keyed by one, and every
+    lookup that reads the API's latin field already drops the species. Folding
+    here is that same rule reaching the names no map happens to carry, rather
+    than a new rule invented for them.
     """
     if not isinstance(latin, str) or not latin.strip():
         return None
-    return canonical_latin(latin) or latin.strip().lower()
+    return canonical_latin(latin) or latin.strip().lower().split()[0]
 
 
 def stored_allergen_latin(ent_reg, entity_id) -> str | None:

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -385,9 +385,12 @@ def store_allergen_identity(ent_reg, entity_id, latin) -> None:
 def migrate_localized_allergen_ids(hass, location_slug, renames) -> None:
     """Rename allergen ids that were derived from a localized allergen name.
 
-    The renames are (legacy_slug, canonical_slug) pairs derived from the
-    current API response, so only ids this integration can itself have
-    produced are ever considered. The unique_id is always migrated; the
+    The renames are (legacy_slug, canonical_slug, claim_latin) triples derived
+    from the current API response, so only ids this integration can itself
+    have produced are ever considered. The latin name travels with the pair
+    because it is what the claiming allergen IS, and the slug it wants is not:
+    two allergens can want the same slug across time, which is the whole
+    reason a row records what it is. The unique_id is always migrated; the
     entity_id only when it is exactly what this integration would have
     generated, so an entity_id the user chose is kept even when it happens to
     end in the old slug. Either step is skipped with a warning when its
@@ -397,10 +400,33 @@ def migrate_localized_allergen_ids(hass, location_slug, renames) -> None:
         return
 
     ent_reg = er.async_get(hass)
-    for legacy_slug, canonical_slug in renames:
+    for legacy_slug, canonical_slug, claim_latin in renames:
         legacy_unique_id = f"polleninformation_{location_slug}_{legacy_slug}"
         entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, legacy_unique_id)
         if entity_id is None:
+            continue
+
+        # A row that records which allergen it is settles what its slug
+        # cannot. The display name it was created under can since have been
+        # given to a different allergen, and renaming then does not recover
+        # this allergen's old entity, it takes another one's row and its
+        # history with nothing to reverse it.
+        #
+        # A row that records nothing keeps exactly the behaviour it had
+        # before there was anywhere to record it, and so does a claim with no
+        # latin name of its own: absent is unknown on either side, never
+        # mismatch. Only two names that both say something, and say different
+        # things, stop a migration.
+        recorded = stored_allergen_latin(ent_reg, entity_id)
+        recorded_key = allergen_identity_key(recorded)
+        claim_key = allergen_identity_key(claim_latin)
+        if recorded_key and claim_key and recorded_key != claim_key:
+            _LOGGER.warning(
+                "Not migrating %s to %s: it is recorded as %s",
+                entity_id,
+                canonical_slug,
+                recorded,
+            )
             continue
 
         canonical_unique_id = f"polleninformation_{location_slug}_{canonical_slug}"
@@ -710,7 +736,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
                     legacy_slug,
                 )
                 continue
-            allergen_renames.append((legacy_slug, slug_en))
+            allergen_renames.append((legacy_slug, slug_en, allergen_la))
         icon = ALLERGEN_ICON_MAP.get(slug_en, ALLERGEN_ICON_MAP["default"])
 
         sensor = PolleninformationSensor(

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -17,14 +17,13 @@ import logging
 from datetime import timedelta
 from functools import lru_cache
 from pathlib import Path
-
-from homeassistant.util import dt as dt_util
-from homeassistant.util import slugify as ha_slugify
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
+from homeassistant.util import slugify as ha_slugify
 
 from .const import (
     CONF_COUNTRY,
@@ -316,6 +315,71 @@ def entity_id_available(hass, ent_reg, entity_id: str) -> bool:
     return not ent_reg.async_is_registered(entity_id) and hass.states.async_available(
         entity_id
     )
+
+
+ALLERGEN_IDENTITY_OPTION = "latin"
+
+
+def allergen_identity_key(latin) -> str | None:
+    """Return the key two latin names must share to be the same allergen.
+
+    The map's own spelling when it knows the name, so that "Ambrosia",
+    "Ambrosia artemisiifolia" and every alias of them answer alike; the name
+    itself, folded, when no map knows it. That second half is the point: the
+    rows this exists to protect are exactly the ones no map can place, so a
+    key that only spoke for known allergens would say "unknown" for the whole
+    population it was written for.
+    """
+    if not isinstance(latin, str) or not latin.strip():
+        return None
+    return canonical_latin(latin) or latin.strip().lower()
+
+
+def stored_allergen_latin(ent_reg, entity_id) -> str | None:
+    """Return the latin name a registry row records for itself, or None.
+
+    None means the row does not say, which is every row on every installation
+    that upgraded into this. Absent has to mean UNKNOWN rather than mismatch:
+    a row that says nothing about itself gets exactly the behaviour it had
+    before there was anywhere to say it.
+    """
+    entry = ent_reg.async_get(entity_id)
+    if entry is None:
+        return None
+    stored = (entry.options.get(DOMAIN) or {}).get(ALLERGEN_IDENTITY_OPTION)
+    return stored if isinstance(stored, str) and stored.strip() else None
+
+
+def store_allergen_identity(ent_reg, entity_id, latin) -> None:
+    """Record which allergen a registry row is, where a restart keeps it.
+
+    The registry stores a slug, a display name and an icon, and no allergen
+    identity, so for a slug no map can place there has been nothing to check a
+    rename against and a legacy candidate had to be trusted on its name alone.
+    Per-entity options under this integration's own domain are the sanctioned
+    place to keep something of ours: they are written to the registry store
+    and read back at load, unlike state attributes, which are not persisted at
+    all.
+
+    Only this integration's key is written, and the other keys under it are
+    carried over, so nothing else on the row is touched. A row already
+    recorded as this allergen is left alone rather than rewritten, and the
+    comparison is by identity rather than by spelling so that the two paths
+    which can name the same allergen -- the response, which may send a
+    species, and a recreated sensor, which can only name the genus -- do not
+    take turns overwriting each other.
+    """
+    key = allergen_identity_key(latin)
+    if not key or not entity_id:
+        return
+    entry = ent_reg.async_get(entity_id)
+    if entry is None:
+        return
+    options = dict(entry.options.get(DOMAIN) or {})
+    if allergen_identity_key(options.get(ALLERGEN_IDENTITY_OPTION)) == key:
+        return
+    options[ALLERGEN_IDENTITY_OPTION] = latin.strip()
+    ent_reg.async_update_entity_options(entity_id, DOMAIN, options)
 
 
 def migrate_localized_allergen_ids(hass, location_slug, renames) -> None:
@@ -662,6 +726,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             location_title=location_title,
             icon=icon,
             display_name=display_overrides.get(slug_en, poll_title_local),
+            identity_from_response=True,
         )
         entities.append(sensor)
         if sensor.unique_id:
@@ -832,6 +897,7 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
         location_title: str,
         icon: str,
         display_name: str | None = None,
+        identity_from_response: bool = False,
     ) -> None:
         super().__init__(coordinator)
         self.sensor_type = sensor_type
@@ -845,6 +911,10 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
         self._levels_en = levels_en
         self._location_slug = location_slug
         self._location_title = location_title
+        # Whether this response identified the allergen, rather than the slug
+        # in the registry having been read back and turned into a latin name
+        # again. Only the first is evidence about the row.
+        self._identity_from_response = identity_from_response
 
         self._attr_name = self._display_name
         self._attr_unique_id = f"polleninformation_{location_slug}_{allergen_slug}"
@@ -854,6 +924,33 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
             "name": f"Polleninformation ({location_title})",
             "manufacturer": "Austrian Pollen Information Service",
         }
+
+    async def async_added_to_hass(self) -> None:
+        """Record on the registry row which allergen this sensor is.
+
+        Here rather than in setup for two reasons. The row of an entity being
+        created does not exist while setup runs, so setup could only ever
+        record the allergens that already had a sensor; and by this point the
+        entity_id is the migrated one, where writing earlier would stamp the
+        very row the migration is still deciding about, with a latin name
+        taken from the same response that is claiming it. Evidence a rename
+        manufactures for itself is not evidence.
+
+        Every allergen this response identified is recorded, not only a newly
+        created one, so an installation upgrading into this starts accounting
+        for the sensors it already has on the first start rather than only for
+        sensors made afterwards. An allergen the response does not carry is
+        not recorded, which includes every sensor recreated from the registry
+        during an outage: what such a sensor knows about its latin name it
+        derived from its own slug, so recording it would write down the
+        assumption the recording exists to check rather than something the API
+        said. Its row keeps whatever it already had.
+        """
+        await super().async_added_to_hass()
+        if self._identity_from_response:
+            store_allergen_identity(
+                er.async_get(self.hass), self.entity_id, self._allergen_latin
+            )
 
     @property
     def suggested_object_id(self) -> str:

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -620,7 +620,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     entities: list[SensorEntity] = []
     new_unique_ids: set[str] = set()
-    allergen_renames: list[tuple[str, str]] = []
+    allergen_renames: list[tuple[str, str, str]] = []
 
     for item in contamination:
         # Every entry here identifies an allergen: usable_contamination has

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -627,8 +627,26 @@ async def async_setup_entry(hass, entry, async_add_entities):
             slugify(poll_title_local),
         ]
         for legacy_slug in dict.fromkeys(legacy_candidates):
-            if legacy_slug and legacy_slug != slug_en:
-                allergen_renames.append((legacy_slug, slug_en))
+            if not legacy_slug or legacy_slug == slug_en:
+                continue
+            if legacy_slug in KNOWN_ALLERGEN_SLUGS:
+                # The candidate names a DIFFERENT allergen, so renaming would
+                # not recover this allergen's old entity, it would take that
+                # other allergen's row and its history. Both candidates come
+                # from the live response in the end: the display name always,
+                # and the English-block name whenever the block has no entry
+                # for the latin the API sent, which is the case for the ten
+                # allergens the map does not cover. A title like
+                # "Birch (Artemisia)" resolves to mugwort and would otherwise
+                # claim the birch row.
+                _LOGGER.warning(
+                    "Not migrating %r to %r: %r is another allergen's name",
+                    legacy_slug,
+                    slug_en,
+                    legacy_slug,
+                )
+                continue
+            allergen_renames.append((legacy_slug, slug_en))
         icon = ALLERGEN_ICON_MAP.get(slug_en, ALLERGEN_ICON_MAP["default"])
 
         sensor = PolleninformationSensor(

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -382,6 +382,39 @@ def store_allergen_identity(ent_reg, entity_id, latin) -> None:
     ent_reg.async_update_entity_options(entity_id, DOMAIN, options)
 
 
+def record_identified_allergens(hass, location_slug, identified_latins) -> None:
+    """Record the response's allergens on rows this pass will not add.
+
+    An entity disabled in the registry is aborted before it is added -- the
+    platform checks registry_entry.disabled and returns without ever calling
+    add_to_platform_finish -- so async_added_to_hass never runs for it and its
+    row would stay unrecorded for exactly as long as it stayed disabled, which
+    is exactly as long as it stays unprotected. The row is there and the
+    response identifies its allergen; only the entity is absent.
+
+    Called AFTER the migration and never before. A row stamped first would be
+    stamped with the claiming allergen's own latin name, and the guard would
+    then be weighing evidence the rename manufactured for itself. By this
+    point every rename is settled, so the row found under a canonical slug is
+    the row that allergen ended up with.
+
+    Rows created in this pass have no registry entry yet and are not reached
+    here; async_added_to_hass records those. Where the two overlap the second
+    write is a no-op, because a row already recorded as this allergen is left
+    alone.
+    """
+    if not identified_latins:
+        return
+
+    ent_reg = er.async_get(hass)
+    for slug, latin in identified_latins.items():
+        entity_id = ent_reg.async_get_entity_id(
+            "sensor", DOMAIN, f"polleninformation_{location_slug}_{slug}"
+        )
+        if entity_id:
+            store_allergen_identity(ent_reg, entity_id, latin)
+
+
 def migrate_localized_allergen_ids(hass, location_slug, renames) -> None:
     """Rename allergen ids that were derived from a localized allergen name.
 
@@ -621,6 +654,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     entities: list[SensorEntity] = []
     new_unique_ids: set[str] = set()
     allergen_renames: list[tuple[str, str, str]] = []
+    identified_latins: dict[str, str] = {}
 
     for item in contamination:
         # Every entry here identifies an allergen: usable_contamination has
@@ -737,6 +771,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 )
                 continue
             allergen_renames.append((legacy_slug, slug_en, allergen_la))
+        if allergen_la:
+            identified_latins.setdefault(slug_en, allergen_la)
         icon = ALLERGEN_ICON_MAP.get(slug_en, ALLERGEN_ICON_MAP["default"])
 
         sensor = PolleninformationSensor(
@@ -759,6 +795,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             new_unique_ids.add(sensor.unique_id)
 
     migrate_localized_allergen_ids(hass, location_slug, allergen_renames)
+    record_identified_allergens(hass, location_slug, identified_latins)
 
     # The risk sensors are gated on the API having SENT pollen data, not on our
     # having been able to read it. An empty contamination block means the API

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1712,6 +1712,37 @@ class TestARenameThatContradictsWhatTheRowRecords:
         assert migrated is not None
         assert migrated.id == foo_id
 
+    async def test_an_unknown_name_does_not_contradict_its_own_genus(self, hass):
+        # The counterpart of the test above for a name no map carries, which
+        # is the whole population this guard exists for. The API sends the
+        # genus in one language and the genus with a species in another, and
+        # one allergen must not read as two, or the migration is refused
+        # naming the allergen it actually is.
+        entry, ent_reg, foo_id = self._register(
+            hass, "foo", latin="Nonexistentia vulgaris"
+        )
+
+        migrate_localized_allergen_ids(
+            hass, "hamburg", [("foo", "birch", "Nonexistentia")]
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert migrated is not None
+        assert migrated.id == foo_id
+        assert entry.entry_id
+
+    async def test_two_unmapped_allergens_are_still_told_apart(self, hass):
+        # The price of folding, pinned so it stays a price and not a surprise:
+        # only a shared FIRST word folds. Two unmapped names that merely
+        # resemble each other still contradict.
+        _, ent_reg, foo_id = self._register(hass, "foo", latin="Nonexistentia")
+
+        migrate_localized_allergen_ids(hass, "hamburg", [("foo", "birch", "Alia")])
+
+        kept = ent_reg.async_get("sensor.polleninformation_hamburg_foo")
+        assert kept is not None
+        assert kept.id == foo_id
+
     async def test_a_claim_that_names_no_allergen_is_not_a_contradiction(self, hass):
         # Unknown on the claiming side is unknown too, never mismatch. Setup
         # cannot currently queue such a rename -- an entry with no latin name

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1301,6 +1301,109 @@ ITALIAN_RAGWEED_RESPONSE = {
 }
 
 
+class TestALegacyCandidateFromTheLiveResponse:
+    """The candidate comes from the RESPONSE, so no test over the map binds it.
+
+    poll_title_local is whatever the API sent, and the English-block name
+    falls back to it whenever the block has no entry for the latin, which is
+    the case for the ten allergens the map does not cover. A title like
+    "Birch (Artemisia)" resolves to mugwort while its display name slugs to
+    birch, so the candidate would have renamed the birch row, taking that
+    allergen's history with it. Nothing creates a duplicate here and nothing
+    reverses it afterwards.
+    """
+
+    @staticmethod
+    def _response(poll_title):
+        return {
+            "contamination": [{"poll_title": poll_title, "contamination_1": 2}],
+            "allergyrisk": {},
+            "allergyrisk_hourly": {},
+        }
+
+    @staticmethod
+    def _register(hass, slug):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        registered = ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            f"polleninformation_hamburg_{slug}",
+            suggested_object_id=f"polleninformation_hamburg_{slug}",
+            config_entry=entry,
+        )
+        return entry, ent_reg, registered.id
+
+    async def test_the_other_allergens_row_is_left_alone(self, hass):
+        entry, ent_reg, birch_id = self._register(hass, "birch")
+
+        await _setup_with_shipped_blocks(
+            hass, "de", self._response("Birch (Artemisia)"), entry=entry
+        )
+
+        kept = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert kept is not None
+        assert kept.id == birch_id
+        assert kept.unique_id == "polleninformation_hamburg_birch"
+
+    async def test_no_mugwort_row_is_manufactured_from_it(self, hass):
+        entry, ent_reg, _ = self._register(hass, "birch")
+
+        await _setup_with_shipped_blocks(
+            hass, "de", self._response("Birch (Artemisia)"), entry=entry
+        )
+
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_mugwort"
+            )
+            is None
+        )
+
+    async def test_the_refusal_is_logged(self, hass, caplog):
+        entry, _, _ = self._register(hass, "birch")
+
+        with caplog.at_level(logging.WARNING):
+            await _setup_with_shipped_blocks(
+                hass, "de", self._response("Birch (Artemisia)"), entry=entry
+            )
+
+        assert [
+            r
+            for r in caplog.records
+            if "another allergen" in r.getMessage() and "birch" in r.getMessage()
+        ]
+
+    async def test_the_same_holds_for_an_allergen_the_map_does_not_cover(self, hass):
+        # The English-block candidate, which falls back to the display name
+        # when the block has no entry for the latin. Quercus is one of ten
+        # such allergens, so this shape reaches the same line by the other
+        # route, and it did so before the display-name candidate existed.
+        entry, ent_reg, birch_id = self._register(hass, "birch")
+
+        await _setup_with_shipped_blocks(
+            hass, "de", self._response("Birch (Quercus)"), entry=entry
+        )
+
+        kept = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert kept is not None
+        assert kept.id == birch_id
+
+    async def test_an_ordinary_localized_name_is_still_migrated(self, hass):
+        # The guard may not cost the migration its actual job: "Beifuß" is
+        # nobody else's canonical slug, so it is still a candidate.
+        entry, ent_reg, original_id = self._register(hass, "beifuss")
+
+        await _setup_with_shipped_blocks(
+            hass, "de", self._response("Beifuß (Artemisia)"), entry=entry
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_mugwort")
+        assert migrated is not None
+        assert migrated.id == original_id
+
+
 class TestNoLegacyCandidateCanClaimAnotherAllergen:
     """A rename candidate that does not exist is free; one that collides is not.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1731,10 +1731,29 @@ class TestARenameThatContradictsWhatTheRowRecords:
         assert migrated.id == foo_id
         assert entry.entry_id
 
-    async def test_two_unmapped_allergens_are_still_told_apart(self, hass):
-        # The price of folding, pinned so it stays a price and not a surprise:
-        # only a shared FIRST word folds. Two unmapped names that merely
-        # resemble each other still contradict.
+    async def test_two_unmapped_names_sharing_a_first_word_fold_together(self, hass):
+        # THE PRICE of folding, and the only test that charges it. Two
+        # DIFFERENT unmapped allergens whose latin names share a genus are one
+        # allergen to this integration, so a rename the old rule refused now
+        # goes through. That is the trade taken deliberately: a genus is what
+        # this integration means by an allergen everywhere else, and the
+        # alternative made every unmapped allergen contradict itself whenever
+        # the API varied its spelling.
+        _, ent_reg, foo_id = self._register(hass, "foo", latin="Nonexistentia bar")
+
+        migrate_localized_allergen_ids(
+            hass, "hamburg", [("foo", "birch", "Nonexistentia baz")]
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert migrated is not None
+        assert migrated.id == foo_id
+
+    async def test_two_unmapped_names_sharing_nothing_still_contradict(self, hass):
+        # The limit of the fold: only the FIRST word folds, so names that do
+        # not share one are still two allergens. This held before the fold as
+        # well, and it is here to catch a future widening of the rule rather
+        # than to charge its price.
         _, ent_reg, foo_id = self._register(hass, "foo", latin="Nonexistentia")
 
         migrate_localized_allergen_ids(hass, "hamburg", [("foo", "birch", "Alia")])

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1495,6 +1495,63 @@ class TestTheRegistryRowRecordsWhichAllergenItIs:
             _recorded_latin(ent_reg, "sensor.polleninformation_hamburg_birch") is None
         )
 
+    async def test_a_disabled_row_is_recorded_too(self, hass):
+        # An entity disabled in the registry is aborted before it is added,
+        # so it never hears that it was added and could never record itself.
+        # The row is there and the response identifies its allergen; only the
+        # entity is missing. Left unrecorded it would stay unprotected for as
+        # long as it stayed disabled.
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        disabled = ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_mugwort",
+            suggested_object_id="polleninformation_hamburg_mugwort",
+            config_entry=entry,
+            disabled_by=er.RegistryEntryDisabler.USER,
+        )
+        assert disabled.disabled
+
+        await _setup_through_the_platform(
+            hass, "de", self._response("Beifu\u00df (Artemisia)"), entry=entry
+        )
+
+        row = ent_reg.async_get("sensor.polleninformation_hamburg_mugwort")
+        assert row.disabled
+        assert row.options[DOMAIN]["latin"] == "Artemisia"
+
+    async def test_a_legacy_row_is_not_recorded_before_the_migration_decides(
+        self, hass
+    ):
+        # Order, pinned. Recording first would overwrite what this row says
+        # about itself with the latin name of the allergen that is trying to
+        # claim it, and the guard would then be weighing evidence the rename
+        # made for itself. The row is refused and keeps its own record.
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        legacy = ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_foo",
+            suggested_object_id="polleninformation_hamburg_foo",
+            config_entry=entry,
+        )
+        ent_reg.async_update_entity_options(
+            legacy.entity_id, DOMAIN, {"latin": "Nonexistentia"}
+        )
+
+        await _setup_through_the_platform(
+            hass, "de", self._response("Foo (Betula)"), entry=entry
+        )
+
+        kept = ent_reg.async_get("sensor.polleninformation_hamburg_foo")
+        assert kept is not None
+        assert kept.id == legacy.id
+        assert kept.options[DOMAIN]["latin"] == "Nonexistentia"
+
     async def test_a_sensor_recreated_during_an_outage_records_nothing(self, hass):
         # Such a sensor derived its latin name from its own slug, so
         # recording it would write down the assumption the record exists to

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1522,13 +1522,39 @@ class TestTheRegistryRowRecordsWhichAllergenItIs:
         assert row.disabled
         assert row.options[DOMAIN]["latin"] == "Artemisia"
 
-    async def test_a_legacy_row_is_not_recorded_before_the_migration_decides(
-        self, hass
-    ):
-        # Order, pinned. Recording first would overwrite what this row says
-        # about itself with the latin name of the allergen that is trying to
-        # claim it, and the guard would then be weighing evidence the rename
-        # made for itself. The row is refused and keeps its own record.
+    async def test_a_disabled_row_migrated_in_this_pass_is_recorded_after(self, hass):
+        # The ordering pin. A disabled row is never added as an entity, so the
+        # setup-side write is its only chance, and it is renamed in this same
+        # pass. Only a write that runs AFTER the migration finds it: before,
+        # nothing carries the canonical unique_id this resolves rows by, and
+        # the row would be left unrecorded exactly as it was.
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        legacy = ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_foo",
+            suggested_object_id="polleninformation_hamburg_foo",
+            config_entry=entry,
+            disabled_by=er.RegistryEntryDisabler.USER,
+        )
+
+        await _setup_through_the_platform(
+            hass, "de", self._response("Foo (Betula)"), entry=entry
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert migrated is not None
+        assert migrated.id == legacy.id
+        assert migrated.disabled
+        assert migrated.options[DOMAIN]["latin"] == "Betula"
+
+    async def test_a_refused_row_keeps_its_own_record(self, hass):
+        # A refused row is not then recorded as the allergen that was refused
+        # it. Nothing looks it up under its own legacy slug, and the write
+        # site resolves rows by canonical unique_id only, so the record it
+        # carries is the one thing about it nothing in this pass can rewrite.
         entry = _make_entry("de")
         entry.add_to_hass(hass)
         ent_reg = er.async_get(hass)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1390,6 +1390,50 @@ class TestALegacyCandidateFromTheLiveResponse:
         assert kept is not None
         assert kept.id == birch_id
 
+    async def test_a_localized_name_normalizing_onto_another_allergen(self, hass):
+        # The realistic route, and the one that needs no English from the API
+        # at all: the shipped Latvian name for olive is "Olīve", which
+        # slugify folds to "olive", a canonical slug. It lands on its own
+        # allergen today. Sent for a DIFFERENT allergen it would claim the
+        # olive row, so the guard has to refuse it on the slug rather than on
+        # the language it looks like.
+        entry, ent_reg, olive_id = self._register(hass, "olive")
+
+        await _setup_with_shipped_blocks(
+            hass, "lv", self._response("Olīve (Betula)"), entry=entry
+        )
+
+        kept = ent_reg.async_get("sensor.polleninformation_hamburg_olive")
+        assert kept is not None
+        assert kept.id == olive_id
+        assert kept.unique_id == "polleninformation_hamburg_olive"
+
+    @pytest.mark.parametrize(
+        ("lang", "poll_title", "slug"),
+        [
+            # The three entries in the shipped map whose display name already
+            # slugifies to a canonical allergen slug. Each lands on its OWN
+            # allergen, so each must keep working: the guard refuses a
+            # candidate that names a DIFFERENT allergen, not one that agrees.
+            ("de", "Ragweed (Ambrosia)", "ragweed"),
+            ("sk", "Ragweed (Ambrosia)", "ragweed"),
+            ("lv", "Olīve (Olea)", "olive"),
+        ],
+    )
+    async def test_the_shipped_near_collisions_keep_their_own_row(
+        self, hass, lang, poll_title, slug
+    ):
+        entry, ent_reg, original_id = self._register(hass, slug)
+
+        await _setup_with_shipped_blocks(
+            hass, lang, self._response(poll_title), entry=entry
+        )
+
+        kept = ent_reg.async_get(f"sensor.polleninformation_hamburg_{slug}")
+        assert kept is not None
+        assert kept.id == original_id
+        assert kept.unique_id == f"polleninformation_hamburg_{slug}"
+
     async def test_an_ordinary_localized_name_is_still_migrated(self, hass):
         # The guard may not cost the migration its actual job: "Beifuß" is
         # nobody else's canonical slug, so it is still a candidate.

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
 
 import pytest
+from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -1299,6 +1300,225 @@ ITALIAN_RAGWEED_RESPONSE = {
     "allergyrisk": {"allergyrisk_1": 5.0},
     "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
 }
+
+
+async def _setup_through_the_platform(hass, lang, response, entry=None):
+    """Run setup the way Home Assistant does, so the entities are really added.
+
+    The helper above hands async_add_entities a list collector, which is
+    enough for anything decided during setup but never registers an entity or
+    runs its lifecycle. Anything an entity does on being added -- writing to
+    its own registry row, here -- is invisible to that helper and has to be
+    exercised through the platform.
+    """
+    if entry is None:
+        entry = _make_entry(lang)
+        entry.add_to_hass(hass)
+
+    async def _block(_hass, lang_code):
+        return shipped_block(lang_code)
+
+    with (
+        patch(
+            "custom_components.polleninformation.async_get_pollenat_data",
+            AsyncMock(return_value=response),
+        ),
+        patch(
+            "custom_components.polleninformation.sensor.async_get_language_block",
+            AsyncMock(side_effect=_block),
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _recorded_latin(ent_reg, entity_id):
+    """The latin name a registry row records for itself, or None."""
+    entry = ent_reg.async_get(entity_id)
+    assert entry is not None, entity_id
+    return (entry.options.get(DOMAIN) or {}).get("latin")
+
+
+class TestTheRegistryRowRecordsWhichAllergenItIs:
+    """The registry keeps nothing that says which allergen a row is.
+
+    A slug no map can place is checkable against nothing, so a rename
+    candidate has had to be trusted on its name alone. Per-entity options
+    under this integration's domain are where something of ours survives a
+    restart, so that is where the latin name goes.
+    """
+
+    @staticmethod
+    def _response(*poll_titles):
+        return {
+            "contamination": [
+                {"poll_title": title, "contamination_1": 2} for title in poll_titles
+            ],
+            "allergyrisk": {},
+            "allergyrisk_hourly": {},
+        }
+
+    async def test_a_newly_created_sensor_records_its_allergen(self, hass):
+        await _setup_through_the_platform(
+            hass, "de", self._response("Beifu\u00df (Artemisia)")
+        )
+
+        ent_reg = er.async_get(hass)
+        assert (
+            _recorded_latin(ent_reg, "sensor.polleninformation_hamburg_mugwort")
+            == "Artemisia"
+        )
+
+    async def test_a_row_that_already_existed_is_recorded_too(self, hass):
+        # The backfill. An installation upgrading into this has a row for
+        # every allergen it has ever seen and an option on none of them, so
+        # recording only what is created afterwards would leave the whole
+        # existing population unaccounted for.
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        existing = ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_mugwort",
+            suggested_object_id="polleninformation_hamburg_mugwort",
+            config_entry=entry,
+        )
+        assert existing.options.get(DOMAIN) is None
+
+        await _setup_through_the_platform(
+            hass, "de", self._response("Beifu\u00df (Artemisia)"), entry=entry
+        )
+
+        assert (
+            _recorded_latin(ent_reg, "sensor.polleninformation_hamburg_mugwort")
+            == "Artemisia"
+        )
+
+    async def test_recording_the_same_allergen_again_writes_nothing(self, hass):
+        entry = await _setup_through_the_platform(
+            hass, "de", self._response("Beifu\u00df (Artemisia)")
+        )
+        ent_reg = er.async_get(hass)
+        entity_id = "sensor.polleninformation_hamburg_mugwort"
+        before = ent_reg.async_get(entity_id).modified_at
+
+        writes = []
+
+        @callback
+        def _seen(event):
+            if "options" in event.data.get("changes", {}):
+                writes.append(event.data["entity_id"])
+
+        hass.bus.async_listen(er.EVENT_ENTITY_REGISTRY_UPDATED, _seen)
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await _setup_through_the_platform(
+            hass, "de", self._response("Beifu\u00df (Artemisia)"), entry=entry
+        )
+
+        assert writes == []
+        assert ent_reg.async_get(entity_id).modified_at == before
+
+    async def test_the_genus_a_recreated_sensor_knows_does_not_overwrite_a_species(
+        self, hass
+    ):
+        # The two paths that can name this allergen disagree in detail: the
+        # response can send a species, while a sensor rebuilt from its slug
+        # can only name the genus. They mean the same allergen, so neither
+        # may keep rewriting the other.
+        entry = await _setup_through_the_platform(
+            hass, "de", self._response("Beifu\u00df (Artemisia vulgaris)")
+        )
+        ent_reg = er.async_get(hass)
+        entity_id = "sensor.polleninformation_hamburg_mugwort"
+        assert _recorded_latin(ent_reg, entity_id) == "Artemisia vulgaris"
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await _setup_through_the_platform(
+            hass, "de", self._response("Beifu\u00df (Artemisia)"), entry=entry
+        )
+
+        assert _recorded_latin(ent_reg, entity_id) == "Artemisia vulgaris"
+
+    async def test_nothing_else_on_the_row_is_disturbed(self, hass):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_mugwort",
+            suggested_object_id="polleninformation_hamburg_mugwort",
+            config_entry=entry,
+        )
+        entity_id = "sensor.polleninformation_hamburg_mugwort"
+        ent_reg.async_update_entity(entity_id, name="My mugwort", icon="mdi:custom")
+        # Another integration's options, which this must carry across
+        # untouched: async_update_entity_options replaces one domain's key
+        # and leaves the rest of the mapping alone.
+        ent_reg.async_update_entity_options(
+            entity_id, "conversation", {"should_expose": False}
+        )
+
+        await _setup_through_the_platform(
+            hass, "de", self._response("Beifu\u00df (Artemisia)"), entry=entry
+        )
+
+        row = ent_reg.async_get(entity_id)
+        assert row.name == "My mugwort"
+        assert row.icon == "mdi:custom"
+        assert row.options["conversation"] == {"should_expose": False}
+        assert row.options[DOMAIN]["latin"] == "Artemisia"
+
+    async def test_an_allergen_this_response_does_not_carry_records_nothing(self, hass):
+        # Nothing identified this row's allergen in this response, so nothing
+        # is known about it that was not known before.
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_birch",
+            suggested_object_id="polleninformation_hamburg_birch",
+            config_entry=entry,
+        )
+
+        await _setup_through_the_platform(
+            hass, "de", self._response("Beifu\u00df (Artemisia)"), entry=entry
+        )
+
+        assert (
+            _recorded_latin(ent_reg, "sensor.polleninformation_hamburg_birch") is None
+        )
+
+    async def test_a_sensor_recreated_during_an_outage_records_nothing(self, hass):
+        # Such a sensor derived its latin name from its own slug, so
+        # recording it would write down the assumption the record exists to
+        # check rather than anything the API said.
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_mugwort",
+            suggested_object_id="polleninformation_hamburg_mugwort",
+            config_entry=entry,
+        )
+
+        await _setup_through_the_platform(
+            hass,
+            "de",
+            {"contamination": [], "allergyrisk": {}, "allergyrisk_hourly": {}},
+            entry=entry,
+        )
+
+        assert (
+            _recorded_latin(ent_reg, "sensor.polleninformation_hamburg_mugwort") is None
+        )
 
 
 class TestALegacyCandidateFromTheLiveResponse:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -32,6 +32,7 @@ from custom_components.polleninformation.sensor import (
     entity_id_available,
     extract_allergen_slug_from_unique_id,
     localized_risk_object_id_suffixes,
+    migrate_localized_allergen_ids,
     resolve_latin_alias,
     scale_allergy_risk,
 )
@@ -1519,6 +1520,128 @@ class TestTheRegistryRowRecordsWhichAllergenItIs:
         assert (
             _recorded_latin(ent_reg, "sensor.polleninformation_hamburg_mugwort") is None
         )
+
+
+class TestARenameThatContradictsWhatTheRowRecords:
+    """The slug guard covers known allergens; this covers the rest.
+
+    A candidate whose slug is another allergen's canonical slug is refused
+    already, because known is detectable. A slug no map can place is not, and
+    those are the rows the escape hatch keeps making: "Foo" was some allergen
+    when its row was created, and a response titled "Foo (Betula)" claims it
+    for birch now. What the row records about itself is the only thing that
+    can tell the two apart, and it is the only thing that outlives the
+    response.
+    """
+
+    @staticmethod
+    def _response(poll_title):
+        return {
+            "contamination": [{"poll_title": poll_title, "contamination_1": 2}],
+            "allergyrisk": {},
+            "allergyrisk_hourly": {},
+        }
+
+    @staticmethod
+    def _register(hass, slug, latin=None):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        registered = ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            f"polleninformation_hamburg_{slug}",
+            suggested_object_id=f"polleninformation_hamburg_{slug}",
+            config_entry=entry,
+        )
+        if latin is not None:
+            ent_reg.async_update_entity_options(
+                registered.entity_id, DOMAIN, {"latin": latin}
+            )
+        return entry, ent_reg, registered.id
+
+    async def test_the_recorded_allergen_keeps_its_row(self, hass):
+        # Nonexistentia is in no map, which is the point: this row belongs to
+        # the population the slug guard cannot speak for, and reading the
+        # record through the allergen slugs would call it unknown and migrate
+        # it anyway.
+        entry, ent_reg, foo_id = self._register(hass, "foo", latin="Nonexistentia")
+
+        await _setup_with_shipped_blocks(
+            hass, "de", self._response("Foo (Betula)"), entry=entry
+        )
+
+        kept = ent_reg.async_get("sensor.polleninformation_hamburg_foo")
+        assert kept is not None
+        assert kept.id == foo_id
+        assert kept.unique_id == "polleninformation_hamburg_foo"
+
+    async def test_the_refusal_is_logged(self, hass, caplog):
+        entry, _, _ = self._register(hass, "foo", latin="Nonexistentia")
+
+        with caplog.at_level(logging.WARNING):
+            await _setup_with_shipped_blocks(
+                hass, "de", self._response("Foo (Betula)"), entry=entry
+            )
+
+        assert [
+            r
+            for r in caplog.records
+            if "recorded as" in r.getMessage() and "Nonexistentia" in r.getMessage()
+        ]
+
+    async def test_a_row_that_records_nothing_is_migrated_as_before(self, hass):
+        # Every row on every installation that upgrades into this. Absent has
+        # to mean unknown, or the feature would arrive by breaking the
+        # migration for everyone who has not run it yet.
+        entry, ent_reg, foo_id = self._register(hass, "foo")
+
+        await _setup_with_shipped_blocks(
+            hass, "de", self._response("Foo (Betula)"), entry=entry
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert migrated is not None
+        assert migrated.id == foo_id
+
+    async def test_a_row_recording_this_same_allergen_is_migrated(self, hass):
+        entry, ent_reg, foo_id = self._register(hass, "foo", latin="Betula")
+
+        await _setup_with_shipped_blocks(
+            hass, "de", self._response("Foo (Betula)"), entry=entry
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert migrated is not None
+        assert migrated.id == foo_id
+
+    async def test_a_species_does_not_contradict_its_own_genus(self, hass):
+        # The response can name a species where the record holds the genus,
+        # or the reverse. They are the same allergen and must not read as a
+        # contradiction.
+        entry, ent_reg, foo_id = self._register(hass, "foo", latin="Betula pendula")
+
+        await _setup_with_shipped_blocks(
+            hass, "de", self._response("Foo (Betula)"), entry=entry
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert migrated is not None
+        assert migrated.id == foo_id
+
+    async def test_a_claim_that_names_no_allergen_is_not_a_contradiction(self, hass):
+        # Unknown on the claiming side is unknown too, never mismatch. Setup
+        # cannot currently queue such a rename -- an entry with no latin name
+        # is slugged from its display name, which is then the slug it already
+        # has -- so the migration is called directly rather than through a
+        # response that cannot produce this.
+        _, ent_reg, foo_id = self._register(hass, "foo", latin="Nonexistentia")
+
+        migrate_localized_allergen_ids(hass, "hamburg", [("foo", "birch", "")])
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert migrated is not None
+        assert migrated.id == foo_id
 
 
 class TestALegacyCandidateFromTheLiveResponse:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2442,6 +2442,13 @@ class TestANonObjectEntryCostsOnlyItself:
         assert len(sensor.extra_state_attributes["forecast"]) == 4
 
 
+NAMED_BIRCH_RESPONSE = {
+    "contamination": [{"poll_title": "Birke", "contamination_1": 3}],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+
 class TestTheLanguageMapIsReadDefensively:
     """The shipped map is an input too, and the only one nothing type checks.
 
@@ -2451,14 +2458,6 @@ class TestTheLanguageMapIsReadDefensively:
     inside setup and take the whole config entry down: every sensor for the
     location, for a bad row in a file the user can edit.
     """
-
-    RESPONSE = {
-        "contamination": [
-            {"poll_title": "Birke", "contamination_1": 3},
-        ],
-        "allergyrisk": {"allergyrisk_1": 5.0},
-        "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
-    }
 
     @pytest.mark.parametrize(
         "block",
@@ -2472,7 +2471,7 @@ class TestTheLanguageMapIsReadDefensively:
     )
     async def test_setup_survives_a_map_of_the_wrong_shape(self, hass, block):
         entities = await _setup_entities(
-            hass, "de", response=self.RESPONSE, language_block=block
+            hass, "de", response=NAMED_BIRCH_RESPONSE, language_block=block
         )
 
         # The entry still becomes a sensor; only its latin name is missing.
@@ -2482,7 +2481,7 @@ class TestTheLanguageMapIsReadDefensively:
         entities = await _setup_entities(
             hass,
             "de",
-            response=self.RESPONSE,
+            response=NAMED_BIRCH_RESPONSE,
             language_block={"poll_titles": [{"name": "Birke", "latin": "Betula"}]},
         )
         sensor = _by_type(entities, PolleninformationSensor)
@@ -2685,6 +2684,19 @@ class TestTheHourlyReaderTakesAnyShape:
         assert len(sensor.extra_state_attributes["forecast"]) == 3
 
 
+UNREADABLE_RISK_RESPONSE = {
+    "contamination": [{"poll_title": "()"}, {"poll_title": ""}],
+    "allergyrisk": {"error": "upstream failure"},
+    "allergyrisk_hourly": {},
+}
+
+READABLE_RISK_RESPONSE = {
+    "contamination": [{"poll_title": "()"}],
+    "allergyrisk": {"allergyrisk_1": 7.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [7.0] * 24},
+}
+
+
 class TestARiskBlockWithNothingReadable:
     """Nonempty is not usable, one level deeper than last time.
 
@@ -2693,18 +2705,6 @@ class TestARiskBlockWithNothingReadable:
     is an object, so the outage was cleared, the pollen sensors were
     recreated for want of data, and nothing carried the marker.
     """
-
-    UNREADABLE = {
-        "contamination": [{"poll_title": "()"}, {"poll_title": ""}],
-        "allergyrisk": {"error": "upstream failure"},
-        "allergyrisk_hourly": {},
-    }
-
-    READABLE = {
-        "contamination": [{"poll_title": "()"}],
-        "allergyrisk": {"allergyrisk_1": 7.0},
-        "allergyrisk_hourly": {"allergyrisk_hourly_1": [7.0] * 24},
-    }
 
     async def _with_registered(self, hass, response):
         entry = _make_entry("de")
@@ -2728,14 +2728,17 @@ class TestARiskBlockWithNothingReadable:
         )
 
     async def test_the_sensors_carry_the_marker(self, hass):
-        entities = await self._with_registered(hass, self.UNREADABLE)
+        entities = await self._with_registered(hass, UNREADABLE_RISK_RESPONSE)
         sensor = _by_type(entities, PolleninformationSensor)
 
         assert sensor.extra_state_attributes["data_stale"] is True
 
     async def test_no_risk_sensor_is_built_from_it(self, hass):
         entities = await _setup_entities(
-            hass, "de", response=self.UNREADABLE, language_block=EMPTY_LANGUAGE_BLOCK
+            hass,
+            "de",
+            response=UNREADABLE_RISK_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
         )
         unique_ids = {e.unique_id for e in entities if e.unique_id}
 
@@ -2744,7 +2747,10 @@ class TestARiskBlockWithNothingReadable:
     async def test_a_readable_reading_beside_unusable_pollen_still_survives(self, hass):
         # ORDER #21 A restored this; it must not regress.
         entities = await _setup_entities(
-            hass, "de", response=self.READABLE, language_block=EMPTY_LANGUAGE_BLOCK
+            hass,
+            "de",
+            response=READABLE_RISK_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
         )
         risk = _by_type(entities, AllergyRiskSensor)
 
@@ -2754,7 +2760,7 @@ class TestARiskBlockWithNothingReadable:
     async def test_reading_an_unreadable_block_reports_unknown(self, hass):
         entities = await _setup_entities(hass, "de")
         risk = _by_type(entities, AllergyRiskSensor)
-        risk.coordinator.data = self.UNREADABLE
+        risk.coordinator.data = UNREADABLE_RISK_RESPONSE
 
         assert risk.native_value is None
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,7 +1,9 @@
 """Tests for sensor helper functions and sensor classes."""
 
+import json
 import logging
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
 
@@ -446,6 +448,54 @@ def _make_entry(lang, options=None):
         },
         options=options or {},
     )
+
+
+SHIPPED_LANGUAGE_MAP = json.loads(
+    (
+        Path(__file__).resolve().parent.parent
+        / "custom_components"
+        / "polleninformation"
+        / "language_map.json"
+    ).read_text(encoding="utf-8")
+)
+
+
+def shipped_block(lang):
+    """The language block this integration actually ships for a language."""
+    return next(
+        block
+        for block in SHIPPED_LANGUAGE_MAP.values()
+        if block.get("lang_code") == lang
+    )
+
+
+async def _setup_with_shipped_blocks(hass, lang, response, entry=None):
+    """Run setup with the REAL map, one block per language, as at runtime.
+
+    Every other setup helper here hands the same block to both lookups, and
+    most migration tests hand them an empty one. The map is an input, and an
+    empty one is a configuration we never ship: the bug this exists for was
+    invisible until the block carried what the file carries.
+    """
+    if entry is None:
+        entry = _make_entry(lang)
+        entry.add_to_hass(hass)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _make_coordinator(response)
+
+    entities = []
+
+    def _add(new_entities, update_before_add=False):
+        entities.extend(new_entities)
+
+    async def _block(_hass, lang_code):
+        return shipped_block(lang_code)
+
+    with patch(
+        "custom_components.polleninformation.sensor.async_get_language_block",
+        AsyncMock(side_effect=_block),
+    ):
+        await async_setup_entry(hass, entry, _add)
+    return entities
 
 
 async def _setup_entities(
@@ -1219,6 +1269,158 @@ class TestLatinGenusAsDisplayName:
             )
             is None
         )
+
+
+# The Spanish response for mugwort, which the API sends as a bare latin genus.
+SPANISH_MUGWORT_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Artemisia",
+            "contamination_1": 2,
+            "contamination_2": 1,
+            "contamination_3": 0,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+ITALIAN_RAGWEED_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Ambrosia",
+            "contamination_1": 2,
+            "contamination_2": 1,
+            "contamination_3": 0,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+
+class TestMigrationAgainstTheShippedMap:
+    """The migration under the configuration we actually ship.
+
+    Every other migration test hands setup an EMPTY language block, so the
+    latin backfill finds nothing and the legacy slug falls out of the display
+    name by default. With the real map the backfill DOES find a latin, the
+    English-block lookup then succeeds, and the legacy name becomes the
+    English one: identical to the canonical name, so no rename was queued and
+    the user's entity was orphaned beside a new one. The data changed what the
+    code did, which is why reading the code did not show it.
+    """
+
+    @staticmethod
+    def _register(hass, lang, slug):
+        entry = _make_entry(lang)
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        registered = ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            f"polleninformation_hamburg_{slug}",
+            suggested_object_id=f"polleninformation_hamburg_{slug}",
+            config_entry=entry,
+        )
+        return entry, ent_reg, registered.id
+
+    async def test_a_spanish_install_is_migrated(self, hass):
+        entry, ent_reg, _ = self._register(hass, "es", "artemisia")
+
+        await _setup_with_shipped_blocks(
+            hass, "es", SPANISH_MUGWORT_RESPONSE, entry=entry
+        )
+
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_mugwort"
+            )
+            == "sensor.polleninformation_hamburg_mugwort"
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_artemisia"
+            )
+            is None
+        )
+
+    async def test_the_registry_row_is_the_same_row(self, hass):
+        # The point of migrating rather than recreating: the history hangs off
+        # the registry id, so a new row beside the old one loses it.
+        entry, ent_reg, original_id = self._register(hass, "es", "artemisia")
+
+        await _setup_with_shipped_blocks(
+            hass, "es", SPANISH_MUGWORT_RESPONSE, entry=entry
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_mugwort")
+        assert migrated is not None
+        assert migrated.id == original_id
+
+    async def test_only_one_entity_remains_for_the_allergen(self, hass):
+        entry, ent_reg, _ = self._register(hass, "es", "artemisia")
+
+        await _setup_with_shipped_blocks(
+            hass, "es", SPANISH_MUGWORT_RESPONSE, entry=entry
+        )
+
+        rows = [
+            e
+            for e in er.async_entries_for_config_entry(ent_reg, entry.entry_id)
+            if e.unique_id
+            and e.unique_id.startswith("polleninformation_hamburg_")
+            and not e.unique_id.endswith(("allergy_risk", "allergy_risk_hourly"))
+        ]
+        assert len(rows) == 1
+
+    async def test_an_italian_install_is_migrated_too(self, hass):
+        # The same shape in another language: the API sends the latin genus as
+        # the display name, so a pre-0.5.5 install could hold "..._ambrosia".
+        entry, ent_reg, original_id = self._register(hass, "it", "ambrosia")
+
+        await _setup_with_shipped_blocks(
+            hass, "it", ITALIAN_RAGWEED_RESPONSE, entry=entry
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_ragweed")
+        assert migrated is not None
+        assert migrated.id == original_id
+
+    async def test_a_localized_name_is_still_migrated(self, hass):
+        # The case the old tests covered, re-run against the real map so the
+        # fix cannot buy the new case at its expense.
+        entry, ent_reg, original_id = self._register(hass, "de", "birke")
+
+        await _setup_with_shipped_blocks(
+            hass,
+            "de",
+            {
+                "contamination": [
+                    {"poll_title": "Birke (Betula)", "contamination_1": 2},
+                ],
+                "allergyrisk": {},
+                "allergyrisk_hourly": {},
+            },
+            entry=entry,
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert migrated is not None
+        assert migrated.id == original_id
+
+    async def test_an_install_already_on_the_canonical_slug_is_left_alone(self, hass):
+        entry, ent_reg, original_id = self._register(hass, "es", "mugwort")
+
+        await _setup_with_shipped_blocks(
+            hass, "es", SPANISH_MUGWORT_RESPONSE, entry=entry
+        )
+
+        kept = ent_reg.async_get("sensor.polleninformation_hamburg_mugwort")
+        assert kept is not None
+        assert kept.id == original_id
 
 
 # An allergen whose latin name the static map does not know, but whose display

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1301,6 +1301,61 @@ ITALIAN_RAGWEED_RESPONSE = {
 }
 
 
+class TestNoLegacyCandidateCanClaimAnotherAllergen:
+    """A rename candidate that does not exist is free; one that collides is not.
+
+    The legacy candidates include the slug of the raw display name, so if any
+    language called an allergen something that slugifies to a DIFFERENT
+    allergen's canonical slug, setup would queue a rename that moves that
+    other allergen's entity onto this one. Nothing in the map does that today.
+    It is pinned because the map is data and regenerating it is a data change
+    that no code review would show, which is how the bug this fixes arrived.
+    """
+
+    @staticmethod
+    def _entries():
+        for block in SHIPPED_LANGUAGE_MAP.values():
+            lang = block.get("lang_code")
+            for entry in block.get("poll_titles", []):
+                yield lang, entry
+
+    def test_no_display_name_slugs_to_another_allergen(self):
+        collisions = [
+            (lang, entry["name"], slugify(capitalize_first(entry["name"])))
+            for lang, entry in self._entries()
+            if slugify(capitalize_first(entry["name"])) in KNOWN_ALLERGEN_SLUGS
+            and slugify(capitalize_first(entry["name"]))
+            != slugify(english_name_for_latin(entry["latin"]) or "")
+        ]
+        assert collisions == []
+
+    def test_no_two_allergens_in_one_language_share_a_display_slug(self):
+        # The other way a candidate could move the wrong entity: two entries
+        # in one language producing the same legacy slug for two canonical
+        # slugs, so whichever renames first takes the other's entity.
+        for block in SHIPPED_LANGUAGE_MAP.values():
+            seen = {}
+            for entry in block.get("poll_titles", []):
+                seen.setdefault(slugify(capitalize_first(entry["name"])), []).append(
+                    entry["name"]
+                )
+            assert all(len(names) == 1 for names in seen.values()), (
+                block.get("lang_code"),
+                {k: v for k, v in seen.items() if len(v) > 1},
+            )
+
+    def test_every_recorded_latin_still_resolves_to_a_known_allergen(self):
+        # What the collision test rests on: a display name is compared against
+        # the canonical slug its latin name resolves to, so that resolution
+        # has to exist for every entry.
+        unresolved = [
+            (lang, entry["name"], entry["latin"])
+            for lang, entry in self._entries()
+            if english_name_for_latin(entry["latin"]) is None
+        ]
+        assert unresolved == []
+
+
 class TestMigrationAgainstTheShippedMap:
     """The migration under the configuration we actually ship.
 


### PR DESCRIPTION
## Summary

Live testing on a real Home Assistant instance found a migration bug that 580
unit tests did not, and it is the bug this release claims to fix.

## What happened

Installed v0.5.4 on a test instance, configured a Madrid/ES location, restarted.
Issue #71 reproduced exactly: `sensor.polleninformation_madrid_artemisia`,
`name_la` empty, and the `Unknown allergen 'Artemisia' (latin '')` warning. Then
installed the current branch and restarted.

The migration did not run. The registry ended up with two rows for one allergen:
the original `..._artemisia`, still holding the history, and a brand new
`..._mugwort` beside it. No migration line in the log at all, so no rename had
been queued.

## Cause

The language map repair in #76 reintroduced a trap that had been identified and
avoided in code. With the repaired map, on a Spanish install:

1. `poll_title` is `Artemisia` with no brackets, so `latin` starts empty
2. the backfill loop matches the display name against the `es` block, which now
   carries `latin: "Artemisia"` because #76 repaired it
3. `get_allergen_info_by_latin("Artemisia", en_block)` therefore succeeds, so
   `legacy_en` becomes `mugwort`
4. `legacy_slug == slug_en == "mugwort"`, so no rename pair is queued
5. the existing entity is orphaned and a new one is created beside it

Adding a symmetric English-block fallback in code was explicitly avoided for this
exact reason. The map repair achieved the same effect through data, which is why
no review caught it: reviewers were reading code. Every unit test missed it
because the tests use an empty language block, so the backfill never finds a
latin and `legacy_en` stays `Artemisia`.

## Fix

The legacy candidate set now holds both slugs a previous version could have
produced: the English-block name, as before, and the raw display name, whatever
the block says now. An addition, not a replacement. A candidate that does not
exist in the registry is a no-op, so the cost of the extra candidate is nothing.

Verified live, same v0.5.4 to branch cycle with the registry reset to its
pre-upgrade state: 8 registry rows rather than 9, `entity_id` and `unique_id`
both renamed, and the registry id preserved as the original, which is what
carries the history.

## Scope of the claim

Simulating each released version over the map that version shipped, across all
192 entries, exactly one entry resolves differently today than it did then: `es`
`Artemisia`. For the twelve allergens the language map covers, the English-block
lookup has succeeded since v0.5.1, so those slugs were always canonical. For the
ten it does not cover the migration already worked. The changelog claim is
therefore about the Spanish case specifically, not about migration having been
broken generally.

## Tests

Three pins over the shipped map, because the map is data and regenerating it is a
change no code review would show, which is how this arrived: no display-name slug
resolves to another allergen's canonical slug, no two entries in one language
share a display slug, and every recorded latin still resolves. Plus the migration
tests with the language block populated as it actually ships, which the existing
migration tests did not cover.

580 passed, up from 571 on `dev`.
