### PR TITLE
Release v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,16 +56,27 @@
   latin name first, and a name is only used for an entry no other sensor
   claims.
 
-- **Two allergens keep their localized name during an outage** (issue #75) —
-  the integration ships a map of the allergen names the API answers with in
-  each language, and falls back to it when the API is unreachable. Two entries
-  in that map had been recorded with the wrong latin name, because the API had
-  put a Slovak word where the latin name goes and had sent no latin name at
-  all for mugwort in Spanish. A sensor kept through an API outage on a Slovak
-  or Spanish installation now keeps its own name instead of falling back to
-  English. The script that builds the map now checks every latin name it
-  records against the allergens the integration knows, and reports the ones it
-  cannot place instead of transcribing them silently.
+- **Ragweed is recognized on a Slovak installation** (issue #75) — the API
+  answers a Slovak request with the Slovak word for ragweed where the latin
+  name belongs, and the integration looks allergens up by their latin name, so
+  it did not recognize this one: an "Unknown allergen" warning asking for a
+  bug report was logged at every restart, and the sensor reported that word as
+  its latin name. The spelling is now known to be ragweed's, so the warning is
+  gone and the sensor reports `Ambrosia`. Only spellings the API has actually
+  been seen to send are treated this way, so a latin name the integration does
+  not know is still left exactly as the API sent it and still asks to be
+  reported.
+
+- **Two allergens keep their localized name during an outage** — the
+  integration ships a map of the allergen names the API answers with in each
+  language, and falls back to it when the API is unreachable. Two entries in
+  that map had been recorded with the wrong latin name: the Slovak word above,
+  and no latin name at all for mugwort in Spanish, where the API sends the
+  latin name as the display name instead. A sensor kept through an API outage
+  on a Slovak or Spanish installation now keeps its own name instead of
+  falling back to English. The script that builds the map now checks every
+  latin name it records against the allergens the integration knows, and
+  reports the ones it cannot place instead of transcribing them silently.
 
 - **A new outage is timed from when it started** — the `stale_since`
   timestamp was recorded once, when Home Assistant happened to start during an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@
   its allergen slug, which is the same in every language, and it reports its
   real latin name instead of a blank one.
 
+- **A recovered sensor no longer reports its data as stale** — when the API
+  returns nothing, the integration keeps its sensors and marks them stale so
+  automations can tell. That mark was set once and never cleared, so a sensor
+  that found its allergen again kept reporting `data_stale` and a `stale_since`
+  timestamp from hours earlier next to a perfectly current pollen level. The
+  mark now follows the data and is reported only while the sensor really is
+  without a reading, the way the allergy risk sensors already worked.
+
 ## v0.5.4 — Allergen icons (2026-08-10)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## v0.5.5 — Allergen identification (2026-08-18)
+
+### Bug fixes
+
+- **Mugwort is recognized again** (issue #71) — the API sometimes sends an
+  allergen's latin genus as its display name ("Artemisia") and leaves the latin
+  field empty. The integration looks allergens up by their latin name, so this
+  one was not found: the sensor was slugged `artemisia` instead of the
+  canonical `mugwort`, it got the generic pollen icon rather than the flower
+  icon, and an "Unknown allergen" warning was logged for it at every restart.
+  The display name is now tried against the same map when the API sends no
+  latin name of its own, and an entity already created as `..._artemisia` is
+  renamed to `..._mugwort`, so its history is kept. The lookup only runs once
+  nothing else has identified the allergen, so it can never override an
+  allergen the integration already knows.
+  (PR #72 by @ethanhawkes-gif, thanks @robercrack)
+
+- **The latin name is reported even when the API omits it** — an allergen
+  identified from its display name was left with an empty `name_la` attribute,
+  because the API had sent no latin name of its own. It now reports the genus
+  the lookup found.
+
+- **Sensors recover on their own after an empty API response** (issue #73) —
+  when the API returns no data the integration keeps the existing sensors and
+  marks them stale. It matched such a sensor back to the API's allergens by
+  English name, but the API sends allergen names in the language configured for
+  the integration, so on a non-English installation the sensor never found its
+  allergen again and stayed empty even after the API recovered, until Home
+  Assistant was restarted or the entry reloaded. English installations were
+  unaffected apart from dock/sorrel. A recreated sensor is now also matched on
+  its allergen slug, which is the same in every language, and it reports its
+  real latin name instead of a blank one.
+
 ## v0.5.4 — Allergen icons (2026-08-10)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@
   sensor that has always had a reading and then loses it is marked too, where
   before only sensors kept through an outage ever were.
 
+- **A sensor with nothing to show says so** — a response that carried a risk
+  block but nothing usable for today, only a later day or an empty value, left
+  the allergy risk sensors showing no value while reporting their data as
+  current. The stale marker now follows the value each sensor actually shows,
+  so an empty sensor is always marked as such. A risk of zero is a real
+  reading and is not affected.
+
 - **A new outage is timed from when it started** — the `stale_since`
   timestamp was recorded once, when Home Assistant happened to start during an
   outage, and was reused for every later outage of the same sensor. A card or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@
   icon, and an "Unknown allergen" warning was logged for it at every restart.
   The display name is now tried against the same map when the API sends no
   latin name of its own, and an entity already created as `..._artemisia` is
-  renamed to `..._mugwort`, so its history is kept. The lookup only runs once
-  nothing else has identified the allergen, so it can never override an
-  allergen the integration already knows.
+  renamed to `..._mugwort`, so its history is kept. The lookup only runs when
+  the API sent no latin name at all, so a latin name it did send is never
+  overridden by the display name.
   (PR #72 by @ethanhawkes-gif, thanks @robercrack)
 
 - **The latin name is reported even when the API omits it** — an allergen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@
   sensor that has always had a reading and then loses it is marked too, where
   before only sensors kept through an outage ever were.
 
+- **Two allergens that share a name no longer read each other's values** —
+  the API can send one allergen's name for two entries, one with a latin name
+  in brackets and one without. Both sensors then looked for their allergen by
+  that shared name and both found whichever entry came first, so one of them
+  showed the other's level and forecast. Sensors are now matched on their
+  latin name first, and a name is only used for an entry no other sensor
+  claims.
+
 - **A sensor with nothing to show says so** — a response that carried a risk
   block but nothing usable for today, only a later day or an empty value, left
   the allergy risk sensors showing no value while reporting their data as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,9 @@
   that found its allergen again kept reporting `data_stale` and a `stale_since`
   timestamp from hours earlier next to a perfectly current pollen level. The
   mark now follows the data and is reported only while the sensor really is
-  without a reading.
+  without a reading. It also follows the data for every sensor now, so a
+  sensor that has always had a reading and then loses it is marked too, where
+  before only sensors kept through an outage ever were.
 
 - **A new outage is timed from when it started** — the `stale_since`
   timestamp was recorded once, when Home Assistant happened to start during an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 
 - **A new outage is timed from when it started** — the `stale_since`
   timestamp was recorded once, when Home Assistant happened to start during an
-  outage, and was reused for every later outage. A card or automation
+  outage, and was reused for every later outage. An automation or template
   measuring how long data had been missing could therefore be told it had been
   missing since a gap that ended hours ago. Each outage now carries its own
   timestamp.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.5.5 — Allergen identification (2026-08-18)
+## v0.5.5 — Allergen identification (2026-08-23)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,37 @@
   missing since a gap that ended hours ago. Each outage now carries its own
   timestamp.
 
+- **A rename can no longer take a different allergen's sensor** — an
+  installation whose sensor IDs were built from a localized allergen name has
+  them renamed to the English form, and the old name is worked out from the
+  API's own answer. The API sends a display name and a latin name, and they do
+  not always describe the same allergen: a response whose display name is one
+  allergen's English name while its latin name identifies another one made the
+  integration look for a sensor under the first allergen's name and rename it
+  to the second. That took an existing sensor, its ID and its whole history,
+  and nothing undid it afterwards. A candidate that is another allergen's own
+  name is now refused, and the refusal is logged. In v0.5.4 this could happen
+  for the ten allergens the integration's English allergen list does not carry
+  (Ailanthus altissima, Castanea, Fagus, Fraxinus, Plantago, Quercus, Rumex,
+  Salix, Tilia, Ulmus), where the old name always falls back to the name the
+  API sent.
+
+- **Sensors record which allergen they are** — an allergen the integration's
+  maps do not know keeps a sensor under the localized name the API sent, and
+  Home Assistant's registry stores nothing that says which allergen such a
+  sensor is: the name it was created under is all there is to go on. If the
+  API later sends that same name for a different allergen, the rename above
+  has nothing to check against and would take the sensor and its history for
+  the newcomer. Each sensor now records its latin name on its own registry
+  entry, where a restart keeps it, and a rename contradicting what a sensor
+  records is refused and logged. The record is written for every allergen the
+  API identifies, not only for sensors created from now on, so an existing
+  installation starts recording the sensors it already has on the first update
+  after upgrading. A sensor that has recorded nothing yet is treated exactly as
+  before, so nothing that works today stops working. Only this integration's
+  own entry is written and only when the value would change, so the rest of the
+  registry entry, including anything you have customized, is left alone.
+
 ## v0.5.4 — Allergen icons (2026-08-10)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@
   entry, where a restart keeps it, and a rename contradicting what a sensor
   records is refused and logged. The record is written for every allergen the
   API identifies, not only for sensors created from now on, so an existing
-  installation starts recording the sensors it already has on the first update
+  installation starts recording the sensors it already has on the first start
   after upgrading. A sensor that has recorded nothing yet is treated exactly as
   before, so nothing that works today stops working. Only this integration's
   own entry is written and only when the value would change, so the rest of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,15 +37,16 @@
   language you configured, where it used to fall back to English until Home
   Assistant was restarted.
 
-- **A recovered sensor no longer reports its data as stale** — when the API
-  returns nothing, the integration keeps its sensors and marks them stale so
-  automations can tell. That mark was set once and never cleared, so a sensor
-  that found its allergen again kept reporting `data_stale` and a `stale_since`
-  timestamp from hours earlier next to a perfectly current pollen level. The
-  mark now follows the data and is reported only while the sensor really is
-  without a reading. It also follows the data for every sensor now, so a
-  sensor that has always had a reading and then loses it is marked too, where
-  before only sensors kept through an outage ever were.
+- **The stale marker follows the API, and clears when data returns** — when a
+  refresh succeeds but the API returns no pollen data at all, every sensor for
+  that location reports `data_stale` together with a `stale_since` timestamp,
+  and all of them report the same timestamp for the same outage. The marker
+  used to be set once, when Home Assistant happened to start during such an
+  outage, and was never cleared afterwards, so a sensor whose data had long
+  since come back still reported itself stale next to a perfectly current
+  pollen level. A sensor that is merely missing a value of its own, while the
+  API is answering normally, now shows `unknown` and carries no marker, which
+  is what Home Assistant expects of an entity in that state.
 
 - **Two allergens that share a name no longer read each other's values** —
   the API can send one allergen's name for two entries, one with a latin name
@@ -55,19 +56,12 @@
   latin name first, and a name is only used for an entry no other sensor
   claims.
 
-- **A sensor with nothing to show says so** — a response that carried a risk
-  block but nothing usable for today, only a later day or an empty value, left
-  the allergy risk sensors showing no value while reporting their data as
-  current. The stale marker now follows the value each sensor actually shows,
-  so an empty sensor is always marked as such. A risk of zero is a real
-  reading and is not affected.
-
 - **A new outage is timed from when it started** — the `stale_since`
   timestamp was recorded once, when Home Assistant happened to start during an
-  outage, and was reused for every later outage of the same sensor. A card or
-  automation measuring how long data had been missing could therefore be told
-  it had been missing since a gap that ended hours ago. Each outage now
-  carries its own timestamp. This applies to the allergy risk sensors as well.
+  outage, and was reused for every later outage. A card or automation
+  measuring how long data had been missing could therefore be told it had been
+  missing since a gap that ended hours ago. Each outage now carries its own
+  timestamp.
 
 ## v0.5.4 — Allergen icons (2026-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,17 @@
   latin name first, and a name is only used for an entry no other sensor
   claims.
 
+- **Two allergens keep their localized name during an outage** (issue #75) —
+  the integration ships a map of the allergen names the API answers with in
+  each language, and falls back to it when the API is unreachable. Two entries
+  in that map had been recorded with the wrong latin name, because the API had
+  put a Slovak word where the latin name goes and had sent no latin name at
+  all for mugwort in Spanish. A sensor kept through an API outage on a Slovak
+  or Spanish installation now keeps its own name instead of falling back to
+  English. The script that builds the map now checks every latin name it
+  records against the allergens the integration knows, and reports the ones it
+  cannot place instead of transcribing them silently.
+
 - **A new outage is timed from when it started** — the `stale_since`
   timestamp was recorded once, when Home Assistant happened to start during an
   outage, and was reused for every later outage. An automation or template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
   latin name of its own, and an entity already created as `..._artemisia` is
   renamed to `..._mugwort`, so its history is kept. The lookup only runs when
   the API sent no latin name at all, so a latin name it did send is never
-  overridden by the display name.
+  overridden by the display name, and it only accepts a display name that is
+  itself a latin name, so an ordinary allergen name that happens to begin with
+  one is left alone.
   (PR #72 by @ethanhawkes-gif, thanks @robercrack)
 
 - **The latin name is reported even when the API omits it** — an allergen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,14 @@
   that found its allergen again kept reporting `data_stale` and a `stale_since`
   timestamp from hours earlier next to a perfectly current pollen level. The
   mark now follows the data and is reported only while the sensor really is
-  without a reading, the way the allergy risk sensors already worked.
+  without a reading.
+
+- **A new outage is timed from when it started** — the `stale_since`
+  timestamp was recorded once, when Home Assistant happened to start during an
+  outage, and was reused for every later outage of the same sensor. A card or
+  automation measuring how long data had been missing could therefore be told
+  it had been missing since a gap that ended hours ago. Each outage now
+  carries its own timestamp. This applies to the allergy risk sensors as well.
 
 ## v0.5.4 — Allergen icons (2026-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,9 @@
   Assistant was restarted or the entry reloaded. English installations were
   unaffected apart from dock/sorrel. A recreated sensor is now also matched on
   its allergen slug, which is the same in every language, and it reports its
-  real latin name instead of a blank one.
+  real latin name instead of a blank one. It also keeps its name in the
+  language you configured, where it used to fall back to English until Home
+  Assistant was restarted.
 
 - **A recovered sensor no longer reports its data as stale** — when the API
   returns nothing, the integration keeps its sensors and marks them stale so

--- a/custom_components/polleninformation/__init__.py
+++ b/custom_components/polleninformation/__init__.py
@@ -37,7 +37,7 @@ from .const import (
     DOMAIN,
     PLATFORMS,
 )
-from .utils import get_country_code_map
+from .utils import get_country_code_map, usable_contamination
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -185,9 +185,18 @@ class PollenInformationDataUpdateCoordinator(DataUpdateCoordinator):
         Every block counts, not just contamination: a response carrying only
         risk data still carried data, and marking it stale would tell the
         risk sensors they are stale while they report a current reading.
+
+        The contamination block counts by what is usable in it rather than by
+        its length, for the same reason the sensors do: entries that identify
+        no allergen build nothing and read nothing, so a block of only those
+        carried no more data than an empty one. The two tests are not the same
+        question and still do not always agree, which is intended: a response
+        whose pollen entries are all unusable but whose risk blocks are full
+        did carry data, so nothing is stale, while the pollen sensors are
+        recreated with no readings of their own and report unknown.
         """
         if (
-            result.get("contamination")
+            usable_contamination(result.get("contamination"))
             or result.get("allergyrisk")
             or result.get("allergyrisk_hourly")
         ):

--- a/custom_components/polleninformation/__init__.py
+++ b/custom_components/polleninformation/__init__.py
@@ -156,6 +156,8 @@ class PollenInformationDataUpdateCoordinator(DataUpdateCoordinator):
         self.lang = lang
         self.apikey = apikey
         self.last_updated = None
+        # Response-level staleness: see _track_empty_response.
+        self.empty_since: str | None = None
 
     def _is_valid_api_response(self, result: dict | None) -> bool:
         if result is None:
@@ -167,6 +169,23 @@ class PollenInformationDataUpdateCoordinator(DataUpdateCoordinator):
         if not isinstance(result.get("contamination"), list):
             return False
         return True
+
+    def _track_empty_response(self, result: dict) -> None:
+        """Record when the API started answering with nothing usable.
+
+        data_stale is response level BY DEFINITION: it means the fetch
+        succeeded and the response carried no data at all, not that one
+        sensor is missing a reading. A sensor with no reading of its own is
+        unknown and carries no marker, which is what Home Assistant expects.
+
+        The timestamp is taken on the way into an outage and cleared on the
+        way out, so it dates the outage being reported and every entity of
+        the location reports the same value for it.
+        """
+        if result.get("contamination"):
+            self.empty_since = None
+        elif self.empty_since is None:
+            self.empty_since = dt_util.now().isoformat()
 
     async def _async_update_data(self) -> dict:
         """Fetch latest pollen data from API."""
@@ -191,6 +210,7 @@ class PollenInformationDataUpdateCoordinator(DataUpdateCoordinator):
                 )
 
             self.last_updated = dt_util.now()
+            self._track_empty_response(result)  # type: ignore[arg-type]
             return result  # type: ignore[return-value]
         except UpdateFailed:
             raise

--- a/custom_components/polleninformation/__init__.py
+++ b/custom_components/polleninformation/__init__.py
@@ -37,7 +37,7 @@ from .const import (
     DOMAIN,
     PLATFORMS,
 )
-from .utils import block_of, get_country_code_map, usable_contamination
+from .utils import get_country_code_map, usable_contamination, usable_risk_block
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -200,8 +200,8 @@ class PollenInformationDataUpdateCoordinator(DataUpdateCoordinator):
         """
         if (
             usable_contamination(result.get("contamination"))
-            or block_of(result, "allergyrisk")
-            or block_of(result, "allergyrisk_hourly")
+            or usable_risk_block(result, "allergyrisk")
+            or usable_risk_block(result, "allergyrisk_hourly")
         ):
             self.empty_since = None
         elif self.empty_since is None:

--- a/custom_components/polleninformation/__init__.py
+++ b/custom_components/polleninformation/__init__.py
@@ -181,8 +181,16 @@ class PollenInformationDataUpdateCoordinator(DataUpdateCoordinator):
         The timestamp is taken on the way into an outage and cleared on the
         way out, so it dates the outage being reported and every entity of
         the location reports the same value for it.
+
+        Every block counts, not just contamination: a response carrying only
+        risk data still carried data, and marking it stale would tell the
+        risk sensors they are stale while they report a current reading.
         """
-        if result.get("contamination"):
+        if (
+            result.get("contamination")
+            or result.get("allergyrisk")
+            or result.get("allergyrisk_hourly")
+        ):
             self.empty_since = None
         elif self.empty_since is None:
             self.empty_since = dt_util.now().isoformat()

--- a/custom_components/polleninformation/__init__.py
+++ b/custom_components/polleninformation/__init__.py
@@ -37,7 +37,7 @@ from .const import (
     DOMAIN,
     PLATFORMS,
 )
-from .utils import get_country_code_map, usable_contamination
+from .utils import block_of, get_country_code_map, usable_contamination
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -186,10 +186,13 @@ class PollenInformationDataUpdateCoordinator(DataUpdateCoordinator):
         risk data still carried data, and marking it stale would tell the
         risk sensors they are stale while they report a current reading.
 
-        The contamination block counts by what is usable in it rather than by
-        its length, for the same reason the sensors do: entries that identify
-        no allergen build nothing and read nothing, so a block of only those
-        carried no more data than an empty one. The two tests are not the same
+        Every block counts by what is usable in it rather than by its length,
+        for the same reason the sensors do. Entries that identify no allergen
+        build nothing and read nothing; a risk block that is not an object is
+        read as absent and reports unknown. A response of nothing but those
+        carried no more data than an empty one, and saying otherwise would
+        leave the sensors recreated for want of any data while no outage was
+        ever stamped for them to point at. The two tests are not the same
         question and still do not always agree, which is intended: a response
         whose pollen entries are all unusable but whose risk blocks are full
         did carry data, so nothing is stale, while the pollen sensors are
@@ -197,8 +200,8 @@ class PollenInformationDataUpdateCoordinator(DataUpdateCoordinator):
         """
         if (
             usable_contamination(result.get("contamination"))
-            or result.get("allergyrisk")
-            or result.get("allergyrisk_hourly")
+            or block_of(result, "allergyrisk")
+            or block_of(result, "allergyrisk_hourly")
         ):
             self.empty_since = None
         elif self.empty_since is None:

--- a/custom_components/polleninformation/language_map.json
+++ b/custom_components/polleninformation/language_map.json
@@ -786,7 +786,7 @@
       },
       {
         "name": "Ragweed",
-        "latin": "ambrózia",
+        "latin": "Ambrosia",
         "poll_id": 6
       }
     ]
@@ -817,7 +817,7 @@
       },
       {
         "name": "Artemisia",
-        "latin": "",
+        "latin": "Artemisia",
         "poll_id": 7
       },
       {

--- a/custom_components/polleninformation/manifest.json
+++ b/custom_components/polleninformation/manifest.json
@@ -11,6 +11,6 @@
     "async-timeout>=4.0.0",
     "Unidecode>=1.3.6"
   ],
-  "version": "0.5.4"
+  "version": "0.5.5"
 }
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -173,15 +173,47 @@ def _latin_name_index() -> dict[str, str]:
     return index
 
 
-def canonical_latin(latin: str | None) -> str | None:
-    """Return the spelling of a latin name the maps use.
+def resolve_latin_alias(latin: str | None) -> str | None:
+    """Return the latin name a declared spelling stands for.
 
     Only a spelling declared in LATIN_NAME_ALIASES is rewritten, so a latin
-    name the API sent that no map knows is returned unchanged.
+    name the API sent that no map knows is returned unchanged, species and
+    all.
     """
     if not latin:
         return latin
     return LATIN_NAME_ALIASES.get(latin.strip().lower(), latin)
+
+
+@lru_cache(maxsize=1)
+def _canonical_latin_index() -> dict[str, str]:
+    """The key of LATIN_TO_ENGLISH_NAME per spelling that resolves to it."""
+    index = {latin.lower(): latin for latin in LATIN_TO_ENGLISH_NAME}
+    for latin in LATIN_TO_ENGLISH_NAME:
+        index.setdefault(latin.split()[0].lower(), latin)
+    for alias, latin in LATIN_NAME_ALIASES.items():
+        index.setdefault(alias, latin)
+    return index
+
+
+def canonical_latin(latin: str | None) -> str | None:
+    """Return the key of LATIN_TO_ENGLISH_NAME a latin name resolves to.
+
+    None when no map knows it. This is the spelling anything keyed by latin
+    name has to store, because the lookups against a language block match
+    exactly: an entry recorded as "poaceae" or "Ambrosia artemisiifolia" is
+    never found again by a consumer holding "Poaceae" or "Ambrosia".
+
+    A latin name that carries a species falls back to its genus, exactly as
+    english_name_for_latin does, so the two agree on what is recognized.
+    """
+    if not latin:
+        return None
+    index = _canonical_latin_index()
+    key = latin.strip().lower()
+    if canonical := index.get(key):
+        return canonical
+    return index.get(key.split()[0]) if key.split() else None
 
 
 def english_name_for_latin(latin: str | None) -> str | None:
@@ -501,7 +533,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         # A spelling the API is known to send in place of a latin name is
         # reported as the name it stands for, so the attribute carries a latin
         # name rather than a localized word.
-        allergen_la = canonical_latin(latin) if latin else ""
+        allergen_la = resolve_latin_alias(latin) if latin else ""
         if allergen_la != latin:
             _LOGGER.debug(
                 "Reporting %r as %r for allergen %r",

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -611,9 +611,24 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 poll_title_local,
             )
         slug_en = slugify(allergen_en) if allergen_en else slugify(poll_title_local)
-        legacy_slug = slugify(legacy_en) if legacy_en else slug_en
-        if legacy_slug and legacy_slug != slug_en:
-            allergen_renames.append((legacy_slug, slug_en))
+        # Every slug a previous version could have given this allergen, not
+        # only the one the current language block implies. Before the display
+        # name was resolvable, an allergen the block could not place was
+        # slugged from the name the API sent, so that slug is a candidate
+        # whatever the block says NOW. It matters because the block itself
+        # changes: repairing a missing latin name in the map turned the
+        # English-block lookup from a miss into a hit, which made legacy_en
+        # equal allergen_en and queued no rename at all, leaving the old
+        # entity orphaned beside a new one. A candidate is only ever acted on
+        # when an entity with that unique_id actually exists, so listing one
+        # that never occurred costs nothing.
+        legacy_candidates = [
+            slugify(legacy_en) if legacy_en else "",
+            slugify(poll_title_local),
+        ]
+        for legacy_slug in dict.fromkeys(legacy_candidates):
+            if legacy_slug and legacy_slug != slug_en:
+                allergen_renames.append((legacy_slug, slug_en))
         icon = ALLERGEN_ICON_MAP.get(slug_en, ALLERGEN_ICON_MAP["default"])
 
         sensor = PolleninformationSensor(

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -1051,6 +1051,20 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
         return attrs
 
 
+def hourly_readings(block, field):
+    """Return one day's hourly readings as a sequence.
+
+    Deliberately NOT in usable_risk_block. That predicate answers the question
+    every caller shares, whether there is anything here to read. What shape a
+    value must have to BE read belongs to the reader: the daily sensor wants a
+    number and scale_allergy_risk already swallows anything that is not one,
+    while this one wants a sequence of hours. A scalar has no length, and a
+    mapping is indexed by key rather than by hour, so neither is a day.
+    """
+    values = block.get(field)
+    return values if isinstance(values, (list, tuple)) else []
+
+
 class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
     """Hourly allergy risk sensor."""
 
@@ -1100,7 +1114,7 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
         if not allergyrisk_hourly:
             return None
         now_hour = dt_util.now().hour
-        values = allergyrisk_hourly.get("allergyrisk_hourly_1", [])
+        values = hourly_readings(allergyrisk_hourly, "allergyrisk_hourly_1")
         if 0 <= now_hour < len(values):
             raw = values[now_hour]
             scaled = scale_allergy_risk(raw)
@@ -1125,7 +1139,7 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
         base_time = dt_util.now().replace(hour=0, minute=0, second=0, microsecond=0)
         forecast = []
         for day in range(1, 5):
-            values = allergyrisk_hourly.get(f"allergyrisk_hourly_{day}", [])
+            values = hourly_readings(allergyrisk_hourly, f"allergyrisk_hourly_{day}")
             for hour, raw in enumerate(values):
                 dt = base_time + timedelta(days=day - 1, hours=hour)
                 scaled = scale_allergy_risk(raw)
@@ -1144,7 +1158,7 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
                 )
 
         now_hour = dt_util.now().hour
-        values_today = allergyrisk_hourly.get("allergyrisk_hourly_1", [])
+        values_today = hourly_readings(allergyrisk_hourly, "allergyrisk_hourly_1")
         raw_now = values_today[now_hour] if 0 <= now_hour < len(values_today) else None
         scaled_now = scale_allergy_risk(raw_now) if raw_now is not None else None
         named_now = (

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -40,6 +40,7 @@ from .const_levels import ALLERGEN_DISPLAY_OVERRIDES, LEVELS, RISK_SENSOR_NAMES
 from .utils import (
     allergen_names_from_item,
     async_get_language_block,
+    block_of,
     get_allergen_info_by_latin,
     normalize,
     slugify,
@@ -934,11 +935,7 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self) -> str | None:
-        allergyrisk = (
-            self.coordinator.data.get("allergyrisk", {})
-            if self.coordinator.data
-            else {}
-        )
+        allergyrisk = block_of(self.coordinator.data, "allergyrisk")
         if not allergyrisk:
             return None
         value = allergyrisk.get("allergyrisk_1", None)
@@ -949,11 +946,7 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        allergyrisk = (
-            self.coordinator.data.get("allergyrisk", {})
-            if self.coordinator.data
-            else {}
-        )
+        allergyrisk = block_of(self.coordinator.data, "allergyrisk")
         if not allergyrisk:
             attrs: dict[str, Any] = {
                 "location_title": self._location_title,
@@ -1048,11 +1041,7 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self) -> str | None:
-        allergyrisk_hourly = (
-            self.coordinator.data.get("allergyrisk_hourly", {})
-            if self.coordinator.data
-            else {}
-        )
+        allergyrisk_hourly = block_of(self.coordinator.data, "allergyrisk_hourly")
         if not allergyrisk_hourly:
             return None
         now_hour = dt_util.now().hour
@@ -1066,11 +1055,7 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        allergyrisk_hourly = (
-            self.coordinator.data.get("allergyrisk_hourly", {})
-            if self.coordinator.data
-            else {}
-        )
+        allergyrisk_hourly = block_of(self.coordinator.data, "allergyrisk_hourly")
         if not allergyrisk_hourly:
             attrs: dict[str, Any] = {
                 "location_title": self._location_title,

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -173,6 +173,21 @@ def english_name_for_latin(latin: str | None) -> str | None:
     return index.get(key.split()[0]) if key.split() else None
 
 
+def allergen_slug_for_item(item: dict) -> str | None:
+    """Return the canonical allergen slug for a contamination entry, or None.
+
+    The latin name in poll_title is the only part of the entry that does not
+    vary with the configured language, so it is what identifies an allergen
+    for a sensor that only knows its own slug.
+    """
+    poll_title = item.get("poll_title", "")
+    if "(" not in poll_title or ")" not in poll_title:
+        return None
+    latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
+    name_en = english_name_for_latin(latin)
+    return slugify(name_en) if name_en else None
+
+
 def entity_id_available(hass, ent_reg, entity_id: str) -> bool:
     """Return True when the registry would accept this entity_id.
 
@@ -634,17 +649,28 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
         # Stale/empty data still shows as available but with state "unknown"
         return self.coordinator.last_update_success is not False
 
+    def _find_item(self, contamination: list) -> dict | None:
+        """Return this allergen's contamination entry, or None.
+
+        The name matches for a sensor built from the current response. A
+        sensor recreated from the registry while the API returned no data
+        knows only the English name behind its slug, so it also matches on
+        the slug, which holds in every language.
+        """
+        for item in contamination:
+            poll_title = item.get("poll_title", "").split("(", 1)[0].strip()
+            if poll_title.lower() == self._allergen_name.lower():
+                return item
+            if allergen_slug_for_item(item) == self._allergen_slug:
+                return item
+        return None
+
     @property
     def native_value(self) -> str | None:
         if not self.coordinator.data:
             return None
         contamination = self.coordinator.data.get("contamination", [])
-        found = None
-        for item in contamination:
-            poll_title = item.get("poll_title", "").split("(", 1)[0].strip()
-            if poll_title.lower() == self._allergen_name.lower():
-                found = item
-                break
+        found = self._find_item(contamination)
         if not found:
             return None
         raw_val = found.get("contamination_1", 0)
@@ -665,26 +691,23 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
         contamination = self.coordinator.data.get("contamination", [])
         forecast = []
         base_date = dt_util.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        for item in contamination:
-            poll_title = item.get("poll_title", "").split("(", 1)[0].strip()
-            if poll_title.lower() == self._allergen_name.lower():
-                for day in range(1, 5):
-                    val = item.get(f"contamination_{day}", 0)
-                    level_name = (
-                        self._levels_current[val]
-                        if isinstance(val, int) and val < len(self._levels_current)
-                        else str(val)
-                    )
-                    forecast.append(
-                        {
-                            "time": (base_date + timedelta(days=day - 1)).strftime(
-                                "%Y-%m-%dT%H:%M:%S"
-                            ),
-                            "level": val,
-                            "level_name": level_name,
-                        }
-                    )
-                break
+        if item := self._find_item(contamination):
+            for day in range(1, 5):
+                val = item.get(f"contamination_{day}", 0)
+                level_name = (
+                    self._levels_current[val]
+                    if isinstance(val, int) and val < len(self._levels_current)
+                    else str(val)
+                )
+                forecast.append(
+                    {
+                        "time": (base_date + timedelta(days=day - 1)).strftime(
+                            "%Y-%m-%dT%H:%M:%S"
+                        ),
+                        "level": val,
+                        "level_name": level_name,
+                    }
+                )
 
         today_raw = forecast[0] if forecast else None
         tomorrow_raw = forecast[1] if len(forecast) > 1 else None

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -324,15 +324,30 @@ def allergen_identity_key(latin) -> str | None:
     """Return the key two latin names must share to be the same allergen.
 
     The map's own spelling when it knows the name, so that "Ambrosia",
-    "Ambrosia artemisiifolia" and every alias of them answer alike; the name
-    itself, folded, when no map knows it. That second half is the point: the
-    rows this exists to protect are exactly the ones no map can place, so a
-    key that only spoke for known allergens would say "unknown" for the whole
-    population it was written for.
+    "Ambrosia artemisiifolia" and every alias of them answer alike; the genus
+    of the name itself when no map knows it. That second half is the point:
+    the rows this exists to protect are exactly the ones no map can place, so
+    a key that only spoke for known allergens would say "unknown" for the
+    whole population it was written for.
+
+    Both halves fall back to the genus, and they have to fall together. A
+    known name resolves through canonical_latin, which drops a species; if an
+    unknown name did not, one allergen would contradict ITSELF as soon as the
+    API sent "Nonexistentia" for one language and "Nonexistentia vulgaris" for
+    another, and the migration would be refused naming the very allergen it
+    is. That is the whole unmapped population, which is the population this
+    was written for.
+
+    The cost is that two unmapped names sharing a first word answer alike.
+    They share a genus, and a genus is what this integration means by an
+    allergen everywhere else: LATIN_TO_ENGLISH_NAME is keyed by one, and every
+    lookup that reads the API's latin field already drops the species. Folding
+    here is that same rule reaching the names no map happens to carry, rather
+    than a new rule invented for them.
     """
     if not isinstance(latin, str) or not latin.strip():
         return None
-    return canonical_latin(latin) or latin.strip().lower()
+    return canonical_latin(latin) or latin.strip().lower().split()[0]
 
 
 def stored_allergen_latin(ent_reg, entity_id) -> str | None:

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -173,6 +173,17 @@ def english_name_for_latin(latin: str | None) -> str | None:
     return index.get(key.split()[0]) if key.split() else None
 
 
+def english_name_for_display_name(name: str | None) -> str | None:
+    """Return the English allergen name for a display name that IS a latin name.
+
+    Unlike english_name_for_latin this does not fall back to the first token:
+    a display name that merely begins with a genus is prose, not an identity.
+    A latin name the map knows is matched whole, genus-plus-species keys
+    included.
+    """
+    return _latin_name_index().get(name.strip().lower()) if name else None
+
+
 @lru_cache(maxsize=1)
 def _slug_index() -> dict[str, tuple[str, str]]:
     """Canonical English name and latin name per allergen slug."""
@@ -191,17 +202,13 @@ def allergen_slug_for_item(item: dict) -> str | None:
     poll_title = item.get("poll_title", "")
     if "(" in poll_title and ")" in poll_title:
         latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
+        name_en = english_name_for_latin(latin)
     else:
-        # No latin at all: the API sometimes sends the latin genus as the
+        # No latin at all: the API sometimes sends the latin name as the
         # display name instead (e.g. "Artemisia"), so the name itself is the
         # last chance to identify the entry. Only tried when no latin was
-        # sent, so an entry that carries one is identified by that alone, and
-        # only for a single word, since a genus is one word: prose that merely
-        # begins with a genus would otherwise resolve through the genus
-        # fallback in english_name_for_latin.
-        stripped = poll_title.strip()
-        latin = stripped if len(stripped.split()) == 1 else ""
-    name_en = english_name_for_latin(latin)
+        # sent, so an entry that carries one is identified by that alone.
+        name_en = english_name_for_display_name(poll_title)
     return slugify(name_en) if name_en else None
 
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -173,6 +173,14 @@ def english_name_for_latin(latin: str | None) -> str | None:
     return index.get(key.split()[0]) if key.split() else None
 
 
+@lru_cache(maxsize=1)
+def _slug_index() -> dict[str, tuple[str, str]]:
+    """Canonical English name and latin name per allergen slug."""
+    return {
+        slugify(name): (name, latin) for latin, name in LATIN_TO_ENGLISH_NAME.items()
+    }
+
+
 def allergen_slug_for_item(item: dict) -> str | None:
     """Return the canonical allergen slug for a contamination entry, or None.
 
@@ -566,23 +574,28 @@ async def async_setup_entry(hass, entry, async_add_entities):
                     stale_since=stale_since,
                 )
             else:
-                allergen_en = allergen_slug.replace("_", " ").title()
+                # The slug is all the registry keeps, so the names are
+                # derived back from it; the API is not answering right now.
+                allergen_en, allergen_la = _slug_index().get(
+                    allergen_slug, (allergen_slug.replace("_", " "), "")
+                )
+                allergen_name = capitalize_first(allergen_en)
                 icon = ALLERGEN_ICON_MAP.get(
                     allergen_slug, ALLERGEN_ICON_MAP["default"]
                 )
                 sensor = PolleninformationSensor(
                     coordinator=coordinator,
                     sensor_type="pollen",
-                    allergen_name=allergen_en,
+                    allergen_name=allergen_name,
                     allergen_en=allergen_en,
                     allergen_slug=allergen_slug,
-                    allergen_latin="",
+                    allergen_latin=allergen_la,
                     levels_current=levels_current,
                     levels_en=levels_en,
                     location_slug=location_slug,
                     location_title=location_title,
                     icon=icon,
-                    display_name=display_overrides.get(allergen_slug, allergen_en),
+                    display_name=display_overrides.get(allergen_slug, allergen_name),
                     is_stale=True,
                     stale_since=stale_since,
                 )

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -225,6 +225,23 @@ def canonical_latin(latin: str | None) -> str | None:
     return index.get(key.split()[0]) if key.split() else None
 
 
+def canonical_latin_for_display_name(name: str | None) -> str | None:
+    """Return the map key for a display name that IS a latin name, or None.
+
+    The display-name half of canonical_latin, and it does NOT fall back to
+    the genus, exactly as english_name_for_display_name does not: a display
+    name that merely begins with a genus is prose, and "Ambrosia hojas" is
+    not ragweed. The genus fallback belongs to the latin field, where a name
+    carrying a species really does resolve to its genus.
+
+    The pair mirrors english_name_for_latin and english_name_for_display_name
+    on purpose. Anything keyed by latin name has to agree with the sensors
+    about which allergen an entry is, and the two cannot agree if one of them
+    guesses from a first word where the other refuses to.
+    """
+    return _canonical_latin_index().get(name.strip().lower()) if name else None
+
+
 def english_name_for_latin(latin: str | None) -> str | None:
     """Return the English allergen name for a latin name, or None if unknown.
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -801,7 +801,14 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
         to different allergens. The name pass therefore skips any entry that
         identifies as a different allergen, and a name match only ever lands
         on an entry that nothing else claims.
+
+        Entries that identify no allergen are dropped first, by the same
+        predicate the setup path uses to decide which ones become sensors. A
+        non-object entry beside a good one used to raise here on every update,
+        which takes out every pollen sensor of the location rather than the
+        one bad entry.
         """
+        contamination = usable_contamination(contamination)
         for item in contamination:
             if allergen_slug_for_item(item) == self._allergen_slug:
                 return item

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -795,8 +795,10 @@ class PolleninformationSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
             if self.coordinator.last_updated
             else None,
         }
-        # An empty forecast is what "no data for this allergen" looks like.
-        attrs.update(self._stale_attrs(has_data=bool(forecast)))
+        # Staleness follows the value the sensor reports: a forecast can be
+        # built from a level the level names do not cover, and a sensor
+        # showing unknown is not fresh whatever else the response held.
+        attrs.update(self._stale_attrs(has_data=self.native_value is not None))
         return attrs
 
 
@@ -911,7 +913,10 @@ class AllergyRiskSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
             if self.coordinator.last_updated
             else None,
         }
-        attrs.update(self._stale_attrs(has_data=True))
+        # The block being present is not a reading: it can carry only a later
+        # day, or a null, and leave the sensor unknown. Staleness therefore
+        # follows the value, so the two can never disagree.
+        attrs.update(self._stale_attrs(has_data=self.native_value is not None))
         return attrs
 
 
@@ -1037,5 +1042,8 @@ class AllergyRiskHourlySensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
             if self.coordinator.last_updated
             else None,
         }
-        attrs.update(self._stale_attrs(has_data=True))
+        # The block being present is not a reading: it can carry only a later
+        # day, or a null, and leave the sensor unknown. Staleness therefore
+        # follows the value, so the two can never disagree.
+        attrs.update(self._stale_attrs(has_data=self.native_value is not None))
         return attrs

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -189,9 +189,14 @@ def allergen_slug_for_item(item: dict) -> str | None:
     for a sensor that only knows its own slug.
     """
     poll_title = item.get("poll_title", "")
-    if "(" not in poll_title or ")" not in poll_title:
-        return None
-    latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
+    if "(" in poll_title and ")" in poll_title:
+        latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
+    else:
+        # No latin at all: the API sometimes sends the latin genus as the
+        # display name instead (e.g. "Artemisia"), so the name itself is the
+        # last chance to identify the entry. Only tried when no latin was
+        # sent, so an entry that carries one is identified by that alone.
+        latin = poll_title.strip()
     name_en = english_name_for_latin(latin)
     return slugify(name_en) if name_en else None
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -385,9 +385,12 @@ def store_allergen_identity(ent_reg, entity_id, latin) -> None:
 def migrate_localized_allergen_ids(hass, location_slug, renames) -> None:
     """Rename allergen ids that were derived from a localized allergen name.
 
-    The renames are (legacy_slug, canonical_slug) pairs derived from the
-    current API response, so only ids this integration can itself have
-    produced are ever considered. The unique_id is always migrated; the
+    The renames are (legacy_slug, canonical_slug, claim_latin) triples derived
+    from the current API response, so only ids this integration can itself
+    have produced are ever considered. The latin name travels with the pair
+    because it is what the claiming allergen IS, and the slug it wants is not:
+    two allergens can want the same slug across time, which is the whole
+    reason a row records what it is. The unique_id is always migrated; the
     entity_id only when it is exactly what this integration would have
     generated, so an entity_id the user chose is kept even when it happens to
     end in the old slug. Either step is skipped with a warning when its
@@ -397,10 +400,33 @@ def migrate_localized_allergen_ids(hass, location_slug, renames) -> None:
         return
 
     ent_reg = er.async_get(hass)
-    for legacy_slug, canonical_slug in renames:
+    for legacy_slug, canonical_slug, claim_latin in renames:
         legacy_unique_id = f"polleninformation_{location_slug}_{legacy_slug}"
         entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, legacy_unique_id)
         if entity_id is None:
+            continue
+
+        # A row that records which allergen it is settles what its slug
+        # cannot. The display name it was created under can since have been
+        # given to a different allergen, and renaming then does not recover
+        # this allergen's old entity, it takes another one's row and its
+        # history with nothing to reverse it.
+        #
+        # A row that records nothing keeps exactly the behaviour it had
+        # before there was anywhere to record it, and so does a claim with no
+        # latin name of its own: absent is unknown on either side, never
+        # mismatch. Only two names that both say something, and say different
+        # things, stop a migration.
+        recorded = stored_allergen_latin(ent_reg, entity_id)
+        recorded_key = allergen_identity_key(recorded)
+        claim_key = allergen_identity_key(claim_latin)
+        if recorded_key and claim_key and recorded_key != claim_key:
+            _LOGGER.warning(
+                "Not migrating %s to %s: it is recorded as %s",
+                entity_id,
+                canonical_slug,
+                recorded,
+            )
             continue
 
         canonical_unique_id = f"polleninformation_{location_slug}_{canonical_slug}"
@@ -710,7 +736,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
                     legacy_slug,
                 )
                 continue
-            allergen_renames.append((legacy_slug, slug_en))
+            allergen_renames.append((legacy_slug, slug_en, allergen_la))
         icon = ALLERGEN_ICON_MAP.get(slug_en, ALLERGEN_ICON_MAP["default"])
 
         sensor = PolleninformationSensor(

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -429,14 +429,16 @@ async def async_setup_entry(hass, entry, async_add_entities):
         )
         legacy_en = allergen_en_obj["name"] if allergen_en_obj else poll_title_local
         mapped_en = english_name_for_latin(latin)
-        if mapped_en is None:
+        if mapped_en is None and allergen_en_obj is None:
             # The API sometimes sends the latin genus as the display name and
-            # leaves the latin field empty (e.g. "Artemisia"). The static map
-            # is keyed by latin name, so try the display name against it too
-            # before giving up: this keeps the canonical English slug and icon
-            # and avoids a spurious "unknown allergen" warning. A localized
-            # display name that is not a latin genus stays unresolved here, so
-            # behaviour for a genuinely unknown allergen is unchanged.
+            # leaves the latin field empty (e.g. "Artemisia"), which is why no
+            # latin lookup found anything. The static map is keyed by latin
+            # name, so try the display name against it too before giving up:
+            # this keeps the canonical English slug and icon and avoids a
+            # spurious "unknown allergen" warning. The English language block
+            # keeps precedence, so this only runs once both latin lookups have
+            # failed and a localized name that is not a latin genus stays
+            # unresolved.
             mapped_en = english_name_for_latin(poll_title_local)
         if mapped_en is None and allergen_en_obj is None:
             _LOGGER.warning(

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -493,7 +493,16 @@ async def async_setup_entry(hass, entry, async_add_entities):
     allergen_renames: list[tuple[str, str]] = []
 
     for item in contamination:
-        poll_title_full = item.get("poll_title", "<unknown>")
+        poll_title_full = item.get("poll_title", "")
+        if not isinstance(poll_title_full, str) or not poll_title_full.strip():
+            # An entry with no readable title names nothing. Building a sensor
+            # from one gives an entity with no name, no latin name and an
+            # entity_id ending in nothing at all, which no later response and
+            # no restore can ever match back to an allergen. The same rule the
+            # language map generator applies: an allergen we can identify but
+            # not classify is kept, one that identifies nothing is not.
+            _LOGGER.warning("Skipping a pollen entry with no readable title: %r", item)
+            continue
         poll_title_local = capitalize_first(poll_title_full.split("(", 1)[0].strip())
         latin = None
         if "(" in poll_title_full and ")" in poll_title_full:

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -469,18 +469,18 @@ async def async_setup_entry(hass, entry, async_add_entities):
         legacy_en = allergen_en_obj["name"] if allergen_en_obj else poll_title_local
         mapped_en = english_name_for_latin(latin)
         if not latin:
-            # The API sometimes sends the latin genus as the display name and
+            # The API sometimes sends the latin name as the display name and
             # leaves the latin field empty (e.g. "Artemisia"), so nothing above
             # had a latin name to look up. The static map is keyed by latin
             # name, so try the display name against it before giving up: this
             # keeps the canonical English slug and icon and avoids a spurious
             # "unknown allergen" warning. A latin name the API did send is
             # authoritative even when no map knows it, so this never runs then;
-            # a localized display name that is not a latin genus stays
+            # a localized display name that is not itself a latin name stays
             # unresolved.
-            mapped_en = english_name_for_latin(poll_title_local)
+            mapped_en = english_name_for_display_name(poll_title_local)
             if mapped_en is not None:
-                # The display name is a latin genus, so report it as one
+                # The display name is a latin name, so report it as one
                 # instead of the empty latin field the API sent.
                 latin = poll_title_local
         if mapped_en is None and allergen_en_obj is None:

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -536,9 +536,14 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 latin or "",
             )
         allergen_en = mapped_en or legacy_en
-        # A spelling the API is known to send in place of a latin name is
-        # reported as the name it stands for, so the attribute carries a latin
-        # name rather than a localized word.
+        # name_la reports what the API said about this allergen, so a latin
+        # name that carries a species keeps it: "Ambrosia artemisiifolia" is
+        # more than the genus and the attribute is where that belongs. The one
+        # rewrite is a spelling the API is known to send in place of a latin
+        # name, so the attribute carries a latin name rather than a localized
+        # word. Deliberately not canonicalized: the restore path below can
+        # only report the genus, and matching it here would mean discarding a
+        # species the API did send. See the comment there.
         allergen_la = resolve_latin_alias(latin) if latin else ""
         if allergen_la != latin:
             _LOGGER.debug(
@@ -641,6 +646,16 @@ async def async_setup_entry(hass, entry, async_add_entities):
             else:
                 # The slug is all the registry keeps, so the names are
                 # derived back from it; the API is not answering right now.
+                # That makes name_la the key of LATIN_TO_ENGLISH_NAME here,
+                # which is the genus for every allergen the API spells with
+                # one, where the setup path reports the species alongside it
+                # when the API sends one. The slug does not carry a species,
+                # so this is the most this path can say. A sensor whose latin
+                # name has a species therefore reports the genus alone for as
+                # long as the outage lasts, and reports the species again on
+                # the first answer. Reporting the genus in both places would
+                # remove the difference by throwing away what the API told us,
+                # which is the wrong way to make two paths agree.
                 allergen_en, allergen_la = _slug_index().get(
                     allergen_slug, (allergen_slug.replace("_", " "), "")
                 )

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -494,26 +494,38 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     for item in contamination:
         poll_title_full = item.get("poll_title", "")
-        if not isinstance(poll_title_full, str) or not poll_title_full.strip():
-            # An entry with no readable title names nothing. Building a sensor
-            # from one gives an entity with no name, no latin name and an
-            # entity_id ending in nothing at all, which no later response and
-            # no restore can ever match back to an allergen. The same rule the
-            # language map generator applies: an allergen we can identify but
-            # not classify is kept, one that identifies nothing is not.
-            _LOGGER.warning("Skipping a pollen entry with no readable title: %r", item)
-            continue
+        if not isinstance(poll_title_full, str):
+            poll_title_full = ""
         poll_title_local = capitalize_first(poll_title_full.split("(", 1)[0].strip())
         latin = None
         if "(" in poll_title_full and ")" in poll_title_full:
             latin = poll_title_full.split("(", 1)[1].split(")", 1)[0].strip()
+        if not poll_title_local and not latin:
+            # The test is what the entry identifies, not whether its title is
+            # readable: "()" is a non-blank title with nothing in either half
+            # of it, and it names an allergen exactly as little as a missing
+            # title does. Building a sensor from one gives an entity with no
+            # name, no latin name and an entity_id ending in nothing at all,
+            # which no later response and no restore can match back to an
+            # allergen. The same rule the language map generator applies: an
+            # allergen we can identify but not classify is kept, one that
+            # identifies nothing is not.
+            _LOGGER.warning(
+                "Skipping a pollen entry that identifies no allergen: %r", item
+            )
+            continue
         if not latin and poll_title_local:
-            # A blank never matches a blank, in either direction. The API can
-            # send a title with no name part and no brackets, and the language
+            # A blank never matches a blank, in either direction: the language
             # map can hold an entry whose name is blank, for an allergen the
-            # API named by its latin name alone. Matching those two would hand
-            # the nameless entry the other one's latin name and make it that
-            # allergen.
+            # API named by its latin name alone, and matching that against a
+            # blank display name would hand the nameless entry the other one's
+            # latin name and make it that allergen.
+            #
+            # No accepted entry can reach here with a blank display name any
+            # more: reaching this line at all means no latin name was sent,
+            # and the guard above then refuses the entry unless it has a
+            # display name. Kept because it costs one comparison and it is
+            # what makes that reasoning safe to change.
             for allergen in language_block_current.get("poll_titles", []):
                 if allergen.get("name") and allergen["name"] == poll_title_local:
                     latin = allergen.get("latin")

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -195,8 +195,12 @@ def allergen_slug_for_item(item: dict) -> str | None:
         # No latin at all: the API sometimes sends the latin genus as the
         # display name instead (e.g. "Artemisia"), so the name itself is the
         # last chance to identify the entry. Only tried when no latin was
-        # sent, so an entry that carries one is identified by that alone.
-        latin = poll_title.strip()
+        # sent, so an entry that carries one is identified by that alone, and
+        # only for a single word, since a genus is one word: prose that merely
+        # begins with a genus would otherwise resolve through the genus
+        # fallback in english_name_for_latin.
+        stripped = poll_title.strip()
+        latin = stripped if len(stripped.split()) == 1 else ""
     name_en = english_name_for_latin(latin)
     return slugify(name_en) if name_en else None
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -40,11 +40,11 @@ from .const_levels import ALLERGEN_DISPLAY_OVERRIDES, LEVELS, RISK_SENSOR_NAMES
 from .utils import (
     allergen_names_from_item,
     async_get_language_block,
-    block_of,
     get_allergen_info_by_latin,
     normalize,
     slugify,
     usable_contamination,
+    usable_risk_block,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -647,7 +647,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         bool(raw_contamination) if isinstance(raw_contamination, list) else False
     )
     allergyrisk = (
-        block_of(coordinator.data, "allergyrisk")
+        usable_risk_block(coordinator.data, "allergyrisk")
         if has_data and api_sent_pollen
         else {}
     )
@@ -667,7 +667,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     # not an object is empty here exactly as it is for the sensor that reads
     # it and for the coordinator, rather than truthy in this one place.
     allergyrisk_hourly = (
-        block_of(coordinator.data, "allergyrisk_hourly")
+        usable_risk_block(coordinator.data, "allergyrisk_hourly")
         if has_data and api_sent_pollen
         else {}
     )
@@ -988,7 +988,7 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self) -> str | None:
-        allergyrisk = block_of(self.coordinator.data, "allergyrisk")
+        allergyrisk = usable_risk_block(self.coordinator.data, "allergyrisk")
         if not allergyrisk:
             return None
         value = allergyrisk.get("allergyrisk_1", None)
@@ -999,7 +999,7 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        allergyrisk = block_of(self.coordinator.data, "allergyrisk")
+        allergyrisk = usable_risk_block(self.coordinator.data, "allergyrisk")
         if not allergyrisk:
             attrs: dict[str, Any] = {
                 "location_title": self._location_title,
@@ -1094,7 +1094,9 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self) -> str | None:
-        allergyrisk_hourly = block_of(self.coordinator.data, "allergyrisk_hourly")
+        allergyrisk_hourly = usable_risk_block(
+            self.coordinator.data, "allergyrisk_hourly"
+        )
         if not allergyrisk_hourly:
             return None
         now_hour = dt_util.now().hour
@@ -1108,7 +1110,9 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        allergyrisk_hourly = block_of(self.coordinator.data, "allergyrisk_hourly")
+        allergyrisk_hourly = usable_risk_block(
+            self.coordinator.data, "allergyrisk_hourly"
+        )
         if not allergyrisk_hourly:
             attrs: dict[str, Any] = {
                 "location_title": self._location_title,

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -282,6 +282,7 @@ def allergen_slug_for_item(item: dict) -> str | None:
     The latin name in poll_title is the only part of the entry that does not
     vary with the configured language, so it is what identifies an allergen
     for a sensor that only knows its own slug.
+
     """
     poll_title = item.get("poll_title", "")
     if "(" in poll_title and ")" in poll_title:
@@ -620,10 +621,19 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     migrate_localized_allergen_ids(hass, location_slug, allergen_renames)
 
-    # Allergy risk daily sensor - only if contamination has data (otherwise allergyrisk is meaningless)
+    # The risk sensors are gated on the API having SENT pollen data, not on our
+    # having been able to read it. An empty contamination block means the API
+    # had nothing to say and a risk number beside it would be meaningless,
+    # which is what this gate was written for. A block we could not parse is
+    # the opposite case: the forecast was there, we failed at it, and the risk
+    # reading beside it is real and readable. Throwing it away would lose a
+    # number the API did send.
+    api_sent_pollen = (
+        bool(raw_contamination) if isinstance(raw_contamination, list) else False
+    )
     allergyrisk = (
-        coordinator.data.get("allergyrisk", {})
-        if has_data and not is_data_empty
+        block_of(coordinator.data, "allergyrisk")
+        if has_data and api_sent_pollen
         else {}
     )
     if allergyrisk:
@@ -638,10 +648,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
         if sensor.unique_id:
             new_unique_ids.add(sensor.unique_id)
 
-    # Allergy risk hourly sensor - only if contamination has data (otherwise allergyrisk is meaningless)
+    # Gated the same way, and read through the same helper: a block that is
+    # not an object is empty here exactly as it is for the sensor that reads
+    # it and for the coordinator, rather than truthy in this one place.
     allergyrisk_hourly = (
-        coordinator.data.get("allergyrisk_hourly", {})
-        if has_data and not is_data_empty
+        block_of(coordinator.data, "allergyrisk_hourly")
+        if has_data and api_sent_pollen
         else {}
     )
     if allergyrisk_hourly:

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -550,9 +550,16 @@ async def async_setup_entry(hass, entry, async_add_entities):
             # and the guard above then refuses the entry unless it has a
             # display name. Kept because it costs one comparison and it is
             # what makes that reasoning safe to change.
-            for allergen in language_block_current.get("poll_titles", []):
+            # Read defensively: this is the shipped language map, not the
+            # response, and it is the one input on this path nothing type
+            # checks. A latin name that is not a string would raise on the
+            # lookups below and take the whole config entry down.
+            for allergen in language_block_current.get("poll_titles") or []:
+                if not isinstance(allergen, dict):
+                    continue
                 if allergen.get("name") and allergen["name"] == poll_title_local:
-                    latin = allergen.get("latin")
+                    if isinstance(allergen.get("latin"), str):
+                        latin = allergen["latin"]
                     break
         # Resolution order: the static latin map, then the English language
         # block, then the name the API sent in the configured language. Only

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -17,14 +17,13 @@ import logging
 from datetime import timedelta
 from functools import lru_cache
 from pathlib import Path
-
-from homeassistant.util import dt as dt_util
-from homeassistant.util import slugify as ha_slugify
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
+from homeassistant.util import slugify as ha_slugify
 
 from .const import (
     CONF_COUNTRY,
@@ -316,6 +315,71 @@ def entity_id_available(hass, ent_reg, entity_id: str) -> bool:
     return not ent_reg.async_is_registered(entity_id) and hass.states.async_available(
         entity_id
     )
+
+
+ALLERGEN_IDENTITY_OPTION = "latin"
+
+
+def allergen_identity_key(latin) -> str | None:
+    """Return the key two latin names must share to be the same allergen.
+
+    The map's own spelling when it knows the name, so that "Ambrosia",
+    "Ambrosia artemisiifolia" and every alias of them answer alike; the name
+    itself, folded, when no map knows it. That second half is the point: the
+    rows this exists to protect are exactly the ones no map can place, so a
+    key that only spoke for known allergens would say "unknown" for the whole
+    population it was written for.
+    """
+    if not isinstance(latin, str) or not latin.strip():
+        return None
+    return canonical_latin(latin) or latin.strip().lower()
+
+
+def stored_allergen_latin(ent_reg, entity_id) -> str | None:
+    """Return the latin name a registry row records for itself, or None.
+
+    None means the row does not say, which is every row on every installation
+    that upgraded into this. Absent has to mean UNKNOWN rather than mismatch:
+    a row that says nothing about itself gets exactly the behaviour it had
+    before there was anywhere to say it.
+    """
+    entry = ent_reg.async_get(entity_id)
+    if entry is None:
+        return None
+    stored = (entry.options.get(DOMAIN) or {}).get(ALLERGEN_IDENTITY_OPTION)
+    return stored if isinstance(stored, str) and stored.strip() else None
+
+
+def store_allergen_identity(ent_reg, entity_id, latin) -> None:
+    """Record which allergen a registry row is, where a restart keeps it.
+
+    The registry stores a slug, a display name and an icon, and no allergen
+    identity, so for a slug no map can place there has been nothing to check a
+    rename against and a legacy candidate had to be trusted on its name alone.
+    Per-entity options under this integration's own domain are the sanctioned
+    place to keep something of ours: they are written to the registry store
+    and read back at load, unlike state attributes, which are not persisted at
+    all.
+
+    Only this integration's key is written, and the other keys under it are
+    carried over, so nothing else on the row is touched. A row already
+    recorded as this allergen is left alone rather than rewritten, and the
+    comparison is by identity rather than by spelling so that the two paths
+    which can name the same allergen -- the response, which may send a
+    species, and a recreated sensor, which can only name the genus -- do not
+    take turns overwriting each other.
+    """
+    key = allergen_identity_key(latin)
+    if not key or not entity_id:
+        return
+    entry = ent_reg.async_get(entity_id)
+    if entry is None:
+        return
+    options = dict(entry.options.get(DOMAIN) or {})
+    if allergen_identity_key(options.get(ALLERGEN_IDENTITY_OPTION)) == key:
+        return
+    options[ALLERGEN_IDENTITY_OPTION] = latin.strip()
+    ent_reg.async_update_entity_options(entity_id, DOMAIN, options)
 
 
 def migrate_localized_allergen_ids(hass, location_slug, renames) -> None:
@@ -662,6 +726,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             location_title=location_title,
             icon=icon,
             display_name=display_overrides.get(slug_en, poll_title_local),
+            identity_from_response=True,
         )
         entities.append(sensor)
         if sensor.unique_id:
@@ -832,6 +897,7 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
         location_title: str,
         icon: str,
         display_name: str | None = None,
+        identity_from_response: bool = False,
     ) -> None:
         super().__init__(coordinator)
         self.sensor_type = sensor_type
@@ -845,6 +911,10 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
         self._levels_en = levels_en
         self._location_slug = location_slug
         self._location_title = location_title
+        # Whether this response identified the allergen, rather than the slug
+        # in the registry having been read back and turned into a latin name
+        # again. Only the first is evidence about the row.
+        self._identity_from_response = identity_from_response
 
         self._attr_name = self._display_name
         self._attr_unique_id = f"polleninformation_{location_slug}_{allergen_slug}"
@@ -854,6 +924,33 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
             "name": f"Polleninformation ({location_title})",
             "manufacturer": "Austrian Pollen Information Service",
         }
+
+    async def async_added_to_hass(self) -> None:
+        """Record on the registry row which allergen this sensor is.
+
+        Here rather than in setup for two reasons. The row of an entity being
+        created does not exist while setup runs, so setup could only ever
+        record the allergens that already had a sensor; and by this point the
+        entity_id is the migrated one, where writing earlier would stamp the
+        very row the migration is still deciding about, with a latin name
+        taken from the same response that is claiming it. Evidence a rename
+        manufactures for itself is not evidence.
+
+        Every allergen this response identified is recorded, not only a newly
+        created one, so an installation upgrading into this starts accounting
+        for the sensors it already has on the first start rather than only for
+        sensors made afterwards. An allergen the response does not carry is
+        not recorded, which includes every sensor recreated from the registry
+        during an outage: what such a sensor knows about its latin name it
+        derived from its own slug, so recording it would write down the
+        assumption the recording exists to check rather than something the API
+        said. Its row keeps whatever it already had.
+        """
+        await super().async_added_to_hass()
+        if self._identity_from_response:
+            store_allergen_identity(
+                er.async_get(self.hass), self.entity_id, self._allergen_latin
+            )
 
     @property
     def suggested_object_id(self) -> str:

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -855,9 +855,15 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
             if slug is not None and slug != self._allergen_slug:
                 continue
             # The display name through the shared parse, not a third reading
-            # of "the part before the bracket". Every entry here identifies an
-            # allergen, so the parse cannot answer None.
-            name, _ = allergen_names_from_item(item)
+            # of "the part before the bracket". The None cannot happen: the
+            # list was filtered by the same predicate at the top of this
+            # function, not by whoever called it. Handled anyway, so the line
+            # states the invariant instead of depending on a filter four lines
+            # up staying where it is.
+            parsed = allergen_names_from_item(item)
+            if parsed is None:
+                continue
+            name, _ = parsed
             if name.lower() == self._allergen_name.lower():
                 return item
         return None

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -498,9 +498,15 @@ async def async_setup_entry(hass, entry, async_add_entities):
         latin = None
         if "(" in poll_title_full and ")" in poll_title_full:
             latin = poll_title_full.split("(", 1)[1].split(")", 1)[0].strip()
-        if not latin:
+        if not latin and poll_title_local:
+            # A blank never matches a blank, in either direction. The API can
+            # send a title with no name part and no brackets, and the language
+            # map can hold an entry whose name is blank, for an allergen the
+            # API named by its latin name alone. Matching those two would hand
+            # the nameless entry the other one's latin name and make it that
+            # allergen.
             for allergen in language_block_current.get("poll_titles", []):
-                if allergen.get("name") == poll_title_local:
+                if allergen.get("name") and allergen["name"] == poll_title_local:
                     latin = allergen.get("latin")
                     break
         # Resolution order: the static latin map, then the English language

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -283,17 +283,25 @@ def allergen_slug_for_item(item: dict) -> str | None:
     vary with the configured language, so it is what identifies an allergen
     for a sensor that only knows its own slug.
 
+    The title is parsed by the shared helper rather than here. This used to
+    split the brackets itself and read poll_title without a guard, which was
+    safe only because both callers happen to filter the block first: safety by
+    call order, which lasts exactly until someone calls it from somewhere
+    else. An entry the helper cannot read identifies nothing, which is the
+    same answer this gave for a title it could not place.
     """
-    poll_title = item.get("poll_title", "")
-    if "(" in poll_title and ")" in poll_title:
-        latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
+    parsed = allergen_names_from_item(item)
+    if parsed is None:
+        return None
+    name, latin = parsed
+    if latin:
         name_en = english_name_for_latin(latin)
     else:
         # No latin at all: the API sometimes sends the latin name as the
         # display name instead (e.g. "Artemisia"), so the name itself is the
         # last chance to identify the entry. Only tried when no latin was
         # sent, so an entry that carries one is identified by that alone.
-        name_en = english_name_for_display_name(poll_title)
+        name_en = english_name_for_display_name(name)
     return slugify(name_en) if name_en else None
 
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -440,6 +440,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
             # failed and a localized name that is not a latin genus stays
             # unresolved.
             mapped_en = english_name_for_latin(poll_title_local)
+            if mapped_en is not None:
+                # The display name is a latin genus, so report it as one
+                # instead of the empty latin field the API sent.
+                latin = poll_title_local
         if mapped_en is None and allergen_en_obj is None:
             _LOGGER.warning(
                 "Unknown allergen %r (latin %r); its entity_id will follow the "

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -615,7 +615,34 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities(entities, update_before_add=True)
 
 
-class PolleninformationSensor(CoordinatorEntity, SensorEntity):
+class StaleDataMarker:
+    """Tracks which outage the data_stale attributes describe.
+
+    An entity recreated while the API returned nothing carries the timestamp
+    of the outage that was ongoing at setup, and setup does not run again when
+    the API recovers. The transition therefore has to be observed here: the
+    timestamp is taken on the way into an outage and cleared on the way out,
+    so a later outage is dated by itself rather than by the first one. Only
+    the transition assigns it, so the repeated reads Home Assistant makes of
+    an attributes property report the same value throughout one outage.
+    """
+
+    _is_stale: bool
+    _stale_since: str | None
+
+    def _stale_attrs(self, has_data: bool) -> dict[str, Any]:
+        """Return the data_stale pair to publish, empty while data is present."""
+        if has_data:
+            self._is_stale = False
+            self._stale_since = None
+            return {}
+        if not self._is_stale:
+            self._is_stale = True
+            self._stale_since = dt_util.now().isoformat()
+        return {"data_stale": True, "stale_since": self._stale_since}
+
+
+class PolleninformationSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
     """Pollen allergen sensor."""
 
     _attr_has_entity_name = True
@@ -712,11 +739,7 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         if not self.coordinator.data:
-            attrs: dict[str, Any] = {}
-            if self._is_stale:
-                attrs["data_stale"] = True
-                attrs["stale_since"] = self._stale_since
-            return attrs
+            return self._stale_attrs(has_data=False)
 
         contamination = self.coordinator.data.get("contamination", [])
         forecast = []
@@ -765,17 +788,12 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
             if self.coordinator.last_updated
             else None,
         }
-        # Staleness is derived, not remembered: the flag is set once when the
-        # entity is recreated during an empty response, and setup does not run
-        # again when the API recovers. An empty forecast is what "no data for
-        # this allergen" looks like here.
-        if self._is_stale and not forecast:
-            attrs["data_stale"] = True
-            attrs["stale_since"] = self._stale_since
+        # An empty forecast is what "no data for this allergen" looks like.
+        attrs.update(self._stale_attrs(has_data=bool(forecast)))
         return attrs
 
 
-class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
+class AllergyRiskSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
     """Daily allergy risk sensor."""
 
     _attr_has_entity_name = True
@@ -848,9 +866,7 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
                 "location_slug": self._location_slug,
                 "attribution": "Austrian Pollen Information Service",
             }
-            if self._is_stale:
-                attrs["data_stale"] = True
-                attrs["stale_since"] = self._stale_since
+            attrs.update(self._stale_attrs(has_data=False))
             return attrs
 
         forecast = []
@@ -875,7 +891,7 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
             )
         raw_value = allergyrisk.get("allergyrisk_1", None)
         scaled_today = scale_allergy_risk(raw_value) if raw_value is not None else None
-        return {
+        attrs = {
             "named_state": self.native_value,
             "numeric_state": scaled_today,
             "numeric_state_raw": raw_value,
@@ -888,9 +904,11 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
             if self.coordinator.last_updated
             else None,
         }
+        attrs.update(self._stale_attrs(has_data=True))
+        return attrs
 
 
-class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
+class AllergyRiskHourlySensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
     """Hourly allergy risk sensor."""
 
     _attr_has_entity_name = True
@@ -966,9 +984,7 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
                 "location_slug": self._location_slug,
                 "attribution": "Austrian Pollen Information Service",
             }
-            if self._is_stale:
-                attrs["data_stale"] = True
-                attrs["stale_since"] = self._stale_since
+            attrs.update(self._stale_attrs(has_data=False))
             return attrs
 
         base_time = dt_util.now().replace(hour=0, minute=0, second=0, microsecond=0)
@@ -1001,7 +1017,7 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
             if scaled_now is not None and scaled_now < len(self._levels_current)
             else None
         )
-        return {
+        attrs = {
             "named_state": named_now,
             "numeric_state": scaled_now,
             "numeric_state_raw": raw_now,
@@ -1014,3 +1030,5 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
             if self.coordinator.last_updated
             else None,
         }
+        attrs.update(self._stale_attrs(has_data=True))
+        return attrs

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -457,15 +457,15 @@ async def async_setup_entry(hass, entry, async_add_entities):
         )
         legacy_en = allergen_en_obj["name"] if allergen_en_obj else poll_title_local
         mapped_en = english_name_for_latin(latin)
-        if mapped_en is None and allergen_en_obj is None:
+        if not latin:
             # The API sometimes sends the latin genus as the display name and
-            # leaves the latin field empty (e.g. "Artemisia"), which is why no
-            # latin lookup found anything. The static map is keyed by latin
-            # name, so try the display name against it too before giving up:
-            # this keeps the canonical English slug and icon and avoids a
-            # spurious "unknown allergen" warning. The English language block
-            # keeps precedence, so this only runs once both latin lookups have
-            # failed and a localized name that is not a latin genus stays
+            # leaves the latin field empty (e.g. "Artemisia"), so nothing above
+            # had a latin name to look up. The static map is keyed by latin
+            # name, so try the display name against it before giving up: this
+            # keeps the canonical English slug and icon and avoids a spurious
+            # "unknown allergen" warning. A latin name the API did send is
+            # authoritative even when no map knows it, so this never runs then;
+            # a localized display name that is not a latin genus stays
             # unresolved.
             mapped_en = english_name_for_latin(poll_title_local)
             if mapped_en is not None:

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -429,6 +429,15 @@ async def async_setup_entry(hass, entry, async_add_entities):
         )
         legacy_en = allergen_en_obj["name"] if allergen_en_obj else poll_title_local
         mapped_en = english_name_for_latin(latin)
+        if mapped_en is None:
+            # The API sometimes sends the latin genus as the display name and
+            # leaves the latin field empty (e.g. "Artemisia"). The static map
+            # is keyed by latin name, so try the display name against it too
+            # before giving up: this keeps the canonical English slug and icon
+            # and avoids a spurious "unknown allergen" warning. A localized
+            # display name that is not a latin genus stays unresolved here, so
+            # behaviour for a genuinely unknown allergen is unchanged.
+            mapped_en = english_name_for_latin(poll_title_local)
         if mapped_en is None and allergen_en_obj is None:
             _LOGGER.warning(
                 "Unknown allergen %r (latin %r); its entity_id will follow the "

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -77,6 +77,19 @@ LATIN_TO_ENGLISH_NAME = {
     "Urticaceae": "nettle family",
 }
 
+# Spellings the API sends in the latin field that are not latin names, and the
+# name each one stands for. The Slovak response spells ragweed "ambrózia",
+# which is the Slovak word rather than a candidate scientific name, so nothing
+# above matches it and the allergen would be unknown.
+#
+# This is an allow-list on purpose: every entry is a fact about the API's data,
+# added after seeing it. A latin name the API sends that is simply not in the
+# map above is left alone, because it identifies its allergen whatever we can
+# resolve it to. Keys are lowercase; lookups normalize.
+LATIN_NAME_ALIASES = {
+    "ambrózia": "Ambrosia",
+}
+
 # Icons group the allergens by pollen source, which is what makes a list of
 # them scannable: the name next to the icon already says which species it is.
 # Material Design Icons has no species-specific plant icons, so a shared icon
@@ -155,7 +168,20 @@ def _latin_name_index() -> dict[str, str]:
     index = {latin.lower(): name for latin, name in LATIN_TO_ENGLISH_NAME.items()}
     for latin, name in LATIN_TO_ENGLISH_NAME.items():
         index.setdefault(latin.split()[0].lower(), name)
+    for alias, latin in LATIN_NAME_ALIASES.items():
+        index.setdefault(alias, LATIN_TO_ENGLISH_NAME[latin])
     return index
+
+
+def canonical_latin(latin: str | None) -> str | None:
+    """Return the spelling of a latin name the maps use.
+
+    Only a spelling declared in LATIN_NAME_ALIASES is rewritten, so a latin
+    name the API sent that no map knows is returned unchanged.
+    """
+    if not latin:
+        return latin
+    return LATIN_NAME_ALIASES.get(latin.strip().lower(), latin)
 
 
 def english_name_for_latin(latin: str | None) -> str | None:
@@ -472,7 +498,17 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 latin or "",
             )
         allergen_en = mapped_en or legacy_en
-        allergen_la = latin if latin else ""
+        # A spelling the API is known to send in place of a latin name is
+        # reported as the name it stands for, so the attribute carries a latin
+        # name rather than a localized word.
+        allergen_la = canonical_latin(latin) if latin else ""
+        if allergen_la != latin:
+            _LOGGER.debug(
+                "Reporting %r as %r for allergen %r",
+                latin,
+                allergen_la,
+                poll_title_local,
+            )
         slug_en = slugify(allergen_en) if allergen_en else slugify(poll_title_local)
         legacy_slug = slugify(legacy_en) if legacy_en else slug_en
         if legacy_slug and legacy_slug != slug_en:

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -678,6 +678,14 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
         sensor recreated from the registry while the API returned no data
         knows only the English name behind its slug, so it also matches on
         the slug, which holds in every language.
+
+        Both criteria are tested per entry, which is safe because at most one
+        entry can match either way: two entries resolving to one allergen
+        already collide on unique_id at setup, and no localized name in the
+        language map equals another allergen's canonical English name. Were
+        this ever split into two passes, the slug pass belongs first, since
+        the slug comes from the language-invariant latin name while the name
+        compare is the fuzzy one.
         """
         for item in contamination:
             poll_title = item.get("poll_title", "").split("(", 1)[0].strip()

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -595,7 +595,20 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 allergen_en, allergen_la = _slug_index().get(
                     allergen_slug, (allergen_slug.replace("_", " "), "")
                 )
-                allergen_name = capitalize_first(allergen_en)
+                # The API sends poll_title in the configured language, and it
+                # does not always carry the latin name, so the match key has
+                # to be the localized name. It comes from the same language
+                # block the setup path reads it from. An allergen the block
+                # does not carry keeps the English name and stays matchable
+                # through the latin name in poll_title.
+                localized = (
+                    get_allergen_info_by_latin(allergen_la, language_block_current)
+                    if allergen_la
+                    else None
+                )
+                allergen_name = capitalize_first(
+                    (localized or {}).get("name") or allergen_en
+                )
                 icon = ALLERGEN_ICON_MAP.get(
                     allergen_slug, ALLERGEN_ICON_MAP["default"]
                 )

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -620,7 +620,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     entities: list[SensorEntity] = []
     new_unique_ids: set[str] = set()
-    allergen_renames: list[tuple[str, str]] = []
+    allergen_renames: list[tuple[str, str, str]] = []
 
     for item in contamination:
         # Every entry here identifies an allergen: usable_contamination has

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -854,8 +854,11 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
             slug = allergen_slug_for_item(item)
             if slug is not None and slug != self._allergen_slug:
                 continue
-            poll_title = item.get("poll_title", "").split("(", 1)[0].strip()
-            if poll_title.lower() == self._allergen_name.lower():
+            # The display name through the shared parse, not a third reading
+            # of "the part before the bracket". Every entry here identifies an
+            # allergen, so the parse cannot answer None.
+            name, _ = allergen_names_from_item(item)
+            if name.lower() == self._allergen_name.lower():
                 return item
         return None
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -86,6 +86,12 @@ LATIN_TO_ENGLISH_NAME = {
 # added after seeing it. A latin name the API sends that is simply not in the
 # map above is left alone, because it identifies its allergen whatever we can
 # resolve it to. Keys are lowercase; lookups normalize.
+#
+# A key here may not be a latin name the map above already knows, genus keys
+# included: the indexes let the real name win and resolve_latin_alias lets the
+# alias win, so such a key would make the two disagree about the same string
+# with nothing to warn about it. The value must be a key of the map above.
+# Both properties are pinned in tests/test_sensor.py.
 LATIN_NAME_ALIASES = {
     "ambrózia": "Ambrosia",
 }

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -721,24 +721,27 @@ class PolleninformationSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
     def _find_item(self, contamination: list) -> dict | None:
         """Return this allergen's contamination entry, or None.
 
-        The name matches for a sensor built from the current response. A
-        sensor recreated from the registry while the API returned no data
-        knows only the English name behind its slug, so it also matches on
-        the slug, which holds in every language.
+        The slug comes from the language-invariant latin name, so it
+        identifies an entry outright and is searched first, across every
+        entry. The name is only a fallback, for an entry no map can place
+        and for a sensor recreated from the registry.
 
-        Both criteria are tested per entry, which is safe because at most one
-        entry can match either way: two entries resolving to one allergen
-        already collide on unique_id at setup, and no localized name in the
-        language map equals another allergen's canonical English name. Were
-        this ever split into two passes, the slug pass belongs first, since
-        the slug comes from the language-invariant latin name while the name
-        compare is the fuzzy one.
+        Two entries can share a name: poll_title_local drops the
+        parenthesized latin, so "Artemisia (Asteraceae)" and a bare
+        "Artemisia" both leave "Artemisia" as the match key while resolving
+        to different allergens. The name pass therefore skips any entry that
+        identifies as a different allergen, and a name match only ever lands
+        on an entry that nothing else claims.
         """
         for item in contamination:
+            if allergen_slug_for_item(item) == self._allergen_slug:
+                return item
+        for item in contamination:
+            slug = allergen_slug_for_item(item)
+            if slug is not None and slug != self._allergen_slug:
+                continue
             poll_title = item.get("poll_title", "").split("(", 1)[0].strip()
             if poll_title.lower() == self._allergen_name.lower():
-                return item
-            if allergen_slug_for_item(item) == self._allergen_slug:
                 return item
         return None
 

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -536,7 +536,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
             new_unique_ids.add(sensor.unique_id)
 
     # Recreate stale entities from registry when API returns empty data
-    stale_since = dt_util.now().isoformat() if is_data_empty else None
     if is_data_empty and existing_unique_ids:
         _LOGGER.warning(
             "API returned empty data for %s, recreating %d entities as stale",
@@ -556,8 +555,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
                     location_slug=location_slug,
                     location_title=location_title,
                     name=risk_name,
-                    is_stale=True,
-                    stale_since=stale_since,
                 )
             elif allergen_slug == "allergy_risk_hourly":
                 sensor = AllergyRiskHourlySensor(
@@ -566,8 +563,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
                     location_slug=location_slug,
                     location_title=location_title,
                     name=risk_name_hourly,
-                    is_stale=True,
-                    stale_since=stale_since,
                 )
             else:
                 # The slug is all the registry keeps, so the names are
@@ -605,8 +600,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
                     location_title=location_title,
                     icon=icon,
                     display_name=display_overrides.get(allergen_slug, allergen_name),
-                    is_stale=True,
-                    stale_since=stale_since,
                 )
             entities.append(sensor)
             if sensor.unique_id:
@@ -615,34 +608,21 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities(entities, update_before_add=True)
 
 
-class StaleDataMarker:
-    """Tracks which outage the data_stale attributes describe.
+def stale_attrs(coordinator) -> dict[str, Any]:
+    """Return the staleness attributes for a response that carried no data.
 
-    An entity recreated while the API returned nothing carries the timestamp
-    of the outage that was ongoing at setup, and setup does not run again when
-    the API recovers. The transition therefore has to be observed here: the
-    timestamp is taken on the way into an outage and cleared on the way out,
-    so a later outage is dated by itself rather than by the first one. Only
-    the transition assigns it, so the repeated reads Home Assistant makes of
-    an attributes property report the same value throughout one outage.
+    data_stale is response level BY DEFINITION: it says this location's fetch
+    succeeded and returned nothing usable, not that one sensor is missing a
+    reading. A sensor with no reading of its own is unknown and carries no
+    marker. The coordinator owns the timestamp, so every entity of a location
+    reports the same one for the same outage.
     """
-
-    _is_stale: bool
-    _stale_since: str | None
-
-    def _stale_attrs(self, has_data: bool) -> dict[str, Any]:
-        """Return the data_stale pair to publish, empty while data is present."""
-        if has_data:
-            self._is_stale = False
-            self._stale_since = None
-            return {}
-        if not self._is_stale:
-            self._is_stale = True
-            self._stale_since = dt_util.now().isoformat()
-        return {"data_stale": True, "stale_since": self._stale_since}
+    if not coordinator.empty_since:
+        return {}
+    return {"data_stale": True, "stale_since": coordinator.empty_since}
 
 
-class PolleninformationSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
+class PolleninformationSensor(CoordinatorEntity, SensorEntity):
     """Pollen allergen sensor."""
 
     _attr_has_entity_name = True
@@ -661,8 +641,6 @@ class PolleninformationSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
         location_title: str,
         icon: str,
         display_name: str | None = None,
-        is_stale: bool = False,
-        stale_since: str | None = None,
     ) -> None:
         super().__init__(coordinator)
         self.sensor_type = sensor_type
@@ -676,8 +654,6 @@ class PolleninformationSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
         self._levels_en = levels_en
         self._location_slug = location_slug
         self._location_title = location_title
-        self._is_stale = is_stale
-        self._stale_since = stale_since
 
         self._attr_name = self._display_name
         self._attr_unique_id = f"polleninformation_{location_slug}_{allergen_slug}"
@@ -742,7 +718,7 @@ class PolleninformationSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         if not self.coordinator.data:
-            return self._stale_attrs(has_data=False)
+            return stale_attrs(self.coordinator)
 
         contamination = self.coordinator.data.get("contamination", [])
         forecast = []
@@ -794,11 +770,11 @@ class PolleninformationSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
         # Staleness follows the value the sensor reports: a forecast can be
         # built from a level the level names do not cover, and a sensor
         # showing unknown is not fresh whatever else the response held.
-        attrs.update(self._stale_attrs(has_data=self.native_value is not None))
+        attrs.update(stale_attrs(self.coordinator))
         return attrs
 
 
-class AllergyRiskSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
+class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
     """Daily allergy risk sensor."""
 
     _attr_has_entity_name = True
@@ -811,15 +787,11 @@ class AllergyRiskSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
         location_slug: str,
         location_title: str,
         name: str | None = None,
-        is_stale: bool = False,
-        stale_since: str | None = None,
     ) -> None:
         super().__init__(coordinator)
         self._levels_current = levels_current
         self._location_slug = location_slug
         self._location_title = location_title
-        self._is_stale = is_stale
-        self._stale_since = stale_since
 
         # An explicit name wins over the translation key; leaving it unset
         # lets the name follow the Home Assistant UI language.
@@ -871,7 +843,7 @@ class AllergyRiskSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
                 "location_slug": self._location_slug,
                 "attribution": "Austrian Pollen Information Service",
             }
-            attrs.update(self._stale_attrs(has_data=False))
+            attrs.update(stale_attrs(self.coordinator))
             return attrs
 
         forecast = []
@@ -912,11 +884,11 @@ class AllergyRiskSensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
         # The block being present is not a reading: it can carry only a later
         # day, or a null, and leave the sensor unknown. Staleness therefore
         # follows the value, so the two can never disagree.
-        attrs.update(self._stale_attrs(has_data=self.native_value is not None))
+        attrs.update(stale_attrs(self.coordinator))
         return attrs
 
 
-class AllergyRiskHourlySensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
+class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
     """Hourly allergy risk sensor."""
 
     _attr_has_entity_name = True
@@ -929,15 +901,11 @@ class AllergyRiskHourlySensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
         location_slug: str,
         location_title: str,
         name: str | None = None,
-        is_stale: bool = False,
-        stale_since: str | None = None,
     ) -> None:
         super().__init__(coordinator)
         self._levels_current = levels_current
         self._location_slug = location_slug
         self._location_title = location_title
-        self._is_stale = is_stale
-        self._stale_since = stale_since
 
         # An explicit name wins over the translation key; leaving it unset
         # lets the name follow the Home Assistant UI language.
@@ -992,7 +960,7 @@ class AllergyRiskHourlySensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
                 "location_slug": self._location_slug,
                 "attribution": "Austrian Pollen Information Service",
             }
-            attrs.update(self._stale_attrs(has_data=False))
+            attrs.update(stale_attrs(self.coordinator))
             return attrs
 
         base_time = dt_util.now().replace(hour=0, minute=0, second=0, microsecond=0)
@@ -1041,5 +1009,5 @@ class AllergyRiskHourlySensor(StaleDataMarker, CoordinatorEntity, SensorEntity):
         # The block being present is not a reading: it can carry only a later
         # day, or a null, and leave the sensor unknown. Staleness therefore
         # follows the value, so the two can never disagree.
-        attrs.update(self._stale_attrs(has_data=self.native_value is not None))
+        attrs.update(stale_attrs(self.coordinator))
         return attrs

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -359,26 +359,6 @@ async def async_migrate_localized_risk_entity_ids(hass, entry, location_slug) ->
         ent_reg.async_update_entity(reg_entry.entity_id, new_entity_id=new_entity_id)
 
 
-def pollen_forecast_for_allergen(
-    contamination: list, allergen_name: str, levels: list
-) -> list:
-    out = []
-    allergen_name_lower = allergen_name.lower()
-    for item in contamination:
-        poll_title = item.get("poll_title", "").split("(", 1)[0].strip().lower()
-        if poll_title == allergen_name_lower:
-            for day in range(1, 5):
-                val = item.get(f"contamination_{day}", 0)
-                level_name = (
-                    levels[val]
-                    if isinstance(val, int) and val < len(levels)
-                    else str(val)
-                )
-                out.append({"day": day, "level_name": level_name, "level": val})
-            break
-    return out
-
-
 def scale_allergy_risk(value: Any) -> int | None:
     try:
         return int(round(value / 2.5))

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -627,8 +627,26 @@ async def async_setup_entry(hass, entry, async_add_entities):
             slugify(poll_title_local),
         ]
         for legacy_slug in dict.fromkeys(legacy_candidates):
-            if legacy_slug and legacy_slug != slug_en:
-                allergen_renames.append((legacy_slug, slug_en))
+            if not legacy_slug or legacy_slug == slug_en:
+                continue
+            if legacy_slug in KNOWN_ALLERGEN_SLUGS:
+                # The candidate names a DIFFERENT allergen, so renaming would
+                # not recover this allergen's old entity, it would take that
+                # other allergen's row and its history. Both candidates come
+                # from the live response in the end: the display name always,
+                # and the English-block name whenever the block has no entry
+                # for the latin the API sent, which is the case for the ten
+                # allergens the map does not cover. A title like
+                # "Birch (Artemisia)" resolves to mugwort and would otherwise
+                # claim the birch row.
+                _LOGGER.warning(
+                    "Not migrating %r to %r: %r is another allergen's name",
+                    legacy_slug,
+                    slug_en,
+                    legacy_slug,
+                )
+                continue
+            allergen_renames.append((legacy_slug, slug_en))
         icon = ALLERGEN_ICON_MAP.get(slug_en, ALLERGEN_ICON_MAP["default"])
 
         sensor = PolleninformationSensor(

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -382,6 +382,39 @@ def store_allergen_identity(ent_reg, entity_id, latin) -> None:
     ent_reg.async_update_entity_options(entity_id, DOMAIN, options)
 
 
+def record_identified_allergens(hass, location_slug, identified_latins) -> None:
+    """Record the response's allergens on rows this pass will not add.
+
+    An entity disabled in the registry is aborted before it is added -- the
+    platform checks registry_entry.disabled and returns without ever calling
+    add_to_platform_finish -- so async_added_to_hass never runs for it and its
+    row would stay unrecorded for exactly as long as it stayed disabled, which
+    is exactly as long as it stays unprotected. The row is there and the
+    response identifies its allergen; only the entity is absent.
+
+    Called AFTER the migration and never before. A row stamped first would be
+    stamped with the claiming allergen's own latin name, and the guard would
+    then be weighing evidence the rename manufactured for itself. By this
+    point every rename is settled, so the row found under a canonical slug is
+    the row that allergen ended up with.
+
+    Rows created in this pass have no registry entry yet and are not reached
+    here; async_added_to_hass records those. Where the two overlap the second
+    write is a no-op, because a row already recorded as this allergen is left
+    alone.
+    """
+    if not identified_latins:
+        return
+
+    ent_reg = er.async_get(hass)
+    for slug, latin in identified_latins.items():
+        entity_id = ent_reg.async_get_entity_id(
+            "sensor", DOMAIN, f"polleninformation_{location_slug}_{slug}"
+        )
+        if entity_id:
+            store_allergen_identity(ent_reg, entity_id, latin)
+
+
 def migrate_localized_allergen_ids(hass, location_slug, renames) -> None:
     """Rename allergen ids that were derived from a localized allergen name.
 
@@ -621,6 +654,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     entities: list[SensorEntity] = []
     new_unique_ids: set[str] = set()
     allergen_renames: list[tuple[str, str, str]] = []
+    identified_latins: dict[str, str] = {}
 
     for item in contamination:
         # Every entry here identifies an allergen: usable_contamination has
@@ -737,6 +771,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 )
                 continue
             allergen_renames.append((legacy_slug, slug_en, allergen_la))
+        if allergen_la:
+            identified_latins.setdefault(slug_en, allergen_la)
         icon = ALLERGEN_ICON_MAP.get(slug_en, ALLERGEN_ICON_MAP["default"])
 
         sensor = PolleninformationSensor(
@@ -759,6 +795,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             new_unique_ids.add(sensor.unique_id)
 
     migrate_localized_allergen_ids(hass, location_slug, allergen_renames)
+    record_identified_allergens(hass, location_slug, identified_latins)
 
     # The risk sensors are gated on the API having SENT pollen data, not on our
     # having been able to read it. An empty contamination block means the API

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -38,10 +38,12 @@ from .const import (
 )
 from .const_levels import ALLERGEN_DISPLAY_OVERRIDES, LEVELS, RISK_SENSOR_NAMES
 from .utils import (
+    allergen_names_from_item,
     async_get_language_block,
     get_allergen_info_by_latin,
     normalize,
     slugify,
+    usable_contamination,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -443,8 +445,19 @@ async def async_setup_entry(hass, entry, async_add_entities):
     }
 
     has_data = coordinator.data is not None
-    contamination = coordinator.data.get("contamination", []) if has_data else []
+    raw_contamination = coordinator.data.get("contamination", []) if has_data else []
+    # Emptiness is a question about usable allergens, not about how many
+    # entries the API sent. An entry that identifies nothing builds no sensor,
+    # so a block of nothing but those is as empty as a block of none, and
+    # counting the raw list instead would leave the sensors this location
+    # already has absent rather than recreated and marked stale.
+    contamination = usable_contamination(raw_contamination)
     is_data_empty = len(contamination) == 0
+    for item in raw_contamination:
+        if allergen_names_from_item(item) is None:
+            _LOGGER.warning(
+                "Skipping a pollen entry that identifies no allergen: %r", item
+            )
 
     # Options override data (options flow writes to entry.options)
     def _opt(key, default=None):
@@ -493,27 +506,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
     allergen_renames: list[tuple[str, str]] = []
 
     for item in contamination:
-        poll_title_full = item.get("poll_title", "")
-        if not isinstance(poll_title_full, str):
-            poll_title_full = ""
-        poll_title_local = capitalize_first(poll_title_full.split("(", 1)[0].strip())
-        latin = None
-        if "(" in poll_title_full and ")" in poll_title_full:
-            latin = poll_title_full.split("(", 1)[1].split(")", 1)[0].strip()
-        if not poll_title_local and not latin:
-            # The test is what the entry identifies, not whether its title is
-            # readable: "()" is a non-blank title with nothing in either half
-            # of it, and it names an allergen exactly as little as a missing
-            # title does. Building a sensor from one gives an entity with no
-            # name, no latin name and an entity_id ending in nothing at all,
-            # which no later response and no restore can match back to an
-            # allergen. The same rule the language map generator applies: an
-            # allergen we can identify but not classify is kept, one that
-            # identifies nothing is not.
-            _LOGGER.warning(
-                "Skipping a pollen entry that identifies no allergen: %r", item
-            )
-            continue
+        # Every entry here identifies an allergen: usable_contamination has
+        # already dropped the ones that do not, warned about each, and counted
+        # what is left towards is_data_empty above.
+        name, latin = allergen_names_from_item(item)
+        poll_title_local = capitalize_first(name)
         if not latin and poll_title_local:
             # A blank never matches a blank, in either direction: the language
             # map can hold an entry whose name is blank, for an allergen the

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -767,9 +767,6 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
             if self.coordinator.last_updated
             else None,
         }
-        # Staleness follows the value the sensor reports: a forecast can be
-        # built from a level the level names do not cover, and a sensor
-        # showing unknown is not fresh whatever else the response held.
         attrs.update(stale_attrs(self.coordinator))
         return attrs
 
@@ -882,8 +879,8 @@ class AllergyRiskSensor(CoordinatorEntity, SensorEntity):
             else None,
         }
         # The block being present is not a reading: it can carry only a later
-        # day, or a null, and leave the sensor unknown. Staleness therefore
-        # follows the value, so the two can never disagree.
+        # day, or a null, and leave this sensor unknown while the response as
+        # a whole was fine. That is unknown, not stale.
         attrs.update(stale_attrs(self.coordinator))
         return attrs
 
@@ -1007,7 +1004,7 @@ class AllergyRiskHourlySensor(CoordinatorEntity, SensorEntity):
             else None,
         }
         # The block being present is not a reading: it can carry only a later
-        # day, or a null, and leave the sensor unknown. Staleness therefore
-        # follows the value, so the two can never disagree.
+        # day, or a null, and leave this sensor unknown while the response as
+        # a whole was fine. That is unknown, not stale.
         attrs.update(stale_attrs(self.coordinator))
         return attrs

--- a/custom_components/polleninformation/sensor.py
+++ b/custom_components/polleninformation/sensor.py
@@ -753,7 +753,11 @@ class PolleninformationSensor(CoordinatorEntity, SensorEntity):
             if self.coordinator.last_updated
             else None,
         }
-        if self._is_stale:
+        # Staleness is derived, not remembered: the flag is set once when the
+        # entity is recreated during an empty response, and setup does not run
+        # again when the API recovers. An empty forecast is what "no data for
+        # this allergen" looks like here.
+        if self._is_stale and not forecast:
             attrs["data_stale"] = True
             attrs["stale_since"] = self._stale_since
         return attrs

--- a/custom_components/polleninformation/utils.py
+++ b/custom_components/polleninformation/utils.py
@@ -362,6 +362,33 @@ def block_of(data, key):
     return value if isinstance(value, dict) else {}
 
 
+def usable_risk_block(data, key):
+    """Return a risk block that holds a readable forecast, or an empty one.
+
+    block_of answers whether there IS a block; this answers whether there is
+    anything in it to read, which is the question every caller actually has.
+    A non-empty object with no forecast fields carries no more data than an
+    absent one: {"error": "upstream failure"} is what an API sends to say
+    something is wrong, and reading it as fresh data is the worst of the
+    available readings.
+
+    A field counts when it is one of this block's own numbered fields and
+    holds something. A risk of 0 is a real reading and counts; a null, an
+    empty list or an empty string does not.
+    """
+    block = block_of(data, key)
+    prefix = f"{key}_"
+    for field, value in block.items():
+        if not isinstance(field, str) or not field.startswith(prefix):
+            continue
+        if value is None:
+            continue
+        if isinstance(value, (list, dict, str, tuple, set)) and not value:
+            continue
+        return block
+    return {}
+
+
 def usable_contamination(contamination):
     """Return the contamination entries that identify an allergen."""
     if not isinstance(contamination, list):

--- a/custom_components/polleninformation/utils.py
+++ b/custom_components/polleninformation/utils.py
@@ -333,6 +333,20 @@ def allergen_names_from_item(item):
     return name, latin
 
 
+def block_of(data, key):
+    """Return data[key] when it is an object, and an empty one otherwise.
+
+    The API's blocks are read with .get, so a block that arrives as a list or
+    a string raises on the first read and takes the whole entity down with it.
+    A block that is not an object carries nothing this can use, which is what
+    an absent one means too.
+    """
+    if not isinstance(data, dict):
+        return {}
+    value = data.get(key)
+    return value if isinstance(value, dict) else {}
+
+
 def usable_contamination(contamination):
     """Return the contamination entries that identify an allergen."""
     if not isinstance(contamination, list):

--- a/custom_components/polleninformation/utils.py
+++ b/custom_components/polleninformation/utils.py
@@ -304,6 +304,42 @@ def split_location(locationtitle):
     return "", locationtitle
 
 
+def allergen_names_from_item(item):
+    """Return (display name, latin name) for a contamination entry, or None.
+
+    None means the entry identifies no allergen: it is not an object, or its
+    title has neither a display name nor a latin name in it. "(Poaceae)" has
+    one, "Trávy" has the other, "()" has neither and names an allergen exactly
+    as little as a missing title does.
+
+    Shared so that the sensors and the coordinator agree on what counts as an
+    allergen. They ask it for different reasons, one to build a sensor and one
+    to decide whether the response carried anything, and those two answers may
+    not drift apart: a block of entries that build no sensors has to read as
+    empty, or the sensors a location already has go absent instead of being
+    kept and marked stale.
+    """
+    if not isinstance(item, dict):
+        return None
+    poll_title = item.get("poll_title", "")
+    if not isinstance(poll_title, str):
+        poll_title = ""
+    name = poll_title.split("(", 1)[0].strip()
+    latin = None
+    if "(" in poll_title and ")" in poll_title:
+        latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
+    if not name and not latin:
+        return None
+    return name, latin
+
+
+def usable_contamination(contamination):
+    """Return the contamination entries that identify an allergen."""
+    if not isinstance(contamination, list):
+        return []
+    return [item for item in contamination if allergen_names_from_item(item)]
+
+
 def get_language_block_sync(lang_code):
     """
     Get language block for a given ISO code from language_map.json.

--- a/custom_components/polleninformation/utils.py
+++ b/custom_components/polleninformation/utils.py
@@ -392,10 +392,15 @@ async def async_get_language_block(hass, lang_code):
 
 
 def get_allergen_info_by_latin(latin, language_block):
+    """Return the language block's entry for a latin name, or None.
+
+    Reads defensively: the block comes from a file rather than from the
+    response, and it is one of the few inputs nothing type checks on the way
+    in. A row of the wrong shape is passed over rather than raising, because
+    raising here happens inside setup and costs the location every sensor it
+    has, not the one bad row.
     """
-    Get allergen info from a language block by latin name.
-    """
-    for allergen in language_block.get("poll_titles", []):
-        if allergen.get("latin") == latin:
+    for allergen in language_block.get("poll_titles") or []:
+        if isinstance(allergen, dict) and allergen.get("latin") == latin:
             return allergen
     return None

--- a/custom_components/polleninformation/utils.py
+++ b/custom_components/polleninformation/utils.py
@@ -304,13 +304,37 @@ def split_location(locationtitle):
     return "", locationtitle
 
 
+def parse_poll_title(poll_title):
+    """Return (display name, latin name) for a poll_title, or None.
+
+    None means the title identifies no allergen: it has neither a display name
+    nor a latin name in it. "(Poaceae)" has one, "Trávy" has the other, "()"
+    has neither and names an allergen exactly as little as a missing title
+    does. The latin name is None when the API sent no brackets, or only an
+    opening one, and a string otherwise.
+
+    THE one parse. The language map generator and the sensors both call it,
+    through this or through allergen_names_from_item, because two
+    implementations of "what does this title say" drift: they did, on the
+    unmatched bracket, where one read "Artemisia (" as mugwort and the other
+    as nothing.
+    """
+    if not isinstance(poll_title, str):
+        poll_title = ""
+    name = poll_title.split("(", 1)[0].strip()
+    latin = None
+    if "(" in poll_title and ")" in poll_title:
+        latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
+    if not name and not latin:
+        return None
+    return name, latin
+
+
 def allergen_names_from_item(item):
     """Return (display name, latin name) for a contamination entry, or None.
 
     None means the entry identifies no allergen: it is not an object, or its
-    title has neither a display name nor a latin name in it. "(Poaceae)" has
-    one, "Trávy" has the other, "()" has neither and names an allergen exactly
-    as little as a missing title does.
+    title does not name one.
 
     Shared so that the sensors and the coordinator agree on what counts as an
     allergen. They ask it for different reasons, one to build a sensor and one
@@ -321,16 +345,7 @@ def allergen_names_from_item(item):
     """
     if not isinstance(item, dict):
         return None
-    poll_title = item.get("poll_title", "")
-    if not isinstance(poll_title, str):
-        poll_title = ""
-    name = poll_title.split("(", 1)[0].strip()
-    latin = None
-    if "(" in poll_title and ")" in poll_title:
-        latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
-    if not name and not latin:
-        return None
-    return name, latin
+    return parse_poll_title(item.get("poll_title", ""))
 
 
 def block_of(data, key):

--- a/docs/entity_naming.md
+++ b/docs/entity_naming.md
@@ -18,8 +18,8 @@ For an allergen the slug comes from the allergen's latin name, looked up in
 accepts both genus-only and genus-plus-species spellings. When the API sends no
 latin name at all, which happens when it puts the genus in the display name
 instead (`poll_title` "Artemisia"), the display name is looked up in the same
-map. That lookup runs only once the latin lookup and the English language block
-have both come up empty, so it cannot outrank them. If a latin name is not
+map. That lookup is gated on the missing latin name, so a latin name the API
+did send stays authoritative even when no map knows it. If a latin name is not
 in the map, the code falls back to the English language block and then to the
 name the API sent in the configured language. It also logs a warning asking for
 a bug report, so a new allergen surfaces instead of quietly producing a

--- a/docs/entity_naming.md
+++ b/docs/entity_naming.md
@@ -15,7 +15,11 @@ matching properties on `AllergyRiskSensor` and `AllergyRiskHourlySensor`).
 For an allergen the slug comes from the allergen's latin name, looked up in
 `LATIN_TO_ENGLISH_NAME` (`sensor.py`) and slugified: `Fraxinus` becomes `ash`,
 `Poaceae` becomes `grasses`. The map covers all 22 allergens the API returns and
-accepts both genus-only and genus-plus-species spellings. If a latin name is not
+accepts both genus-only and genus-plus-species spellings. When the API sends no
+latin name at all, which happens when it puts the genus in the display name
+instead (`poll_title` "Artemisia"), the display name is looked up in the same
+map. That lookup runs only once the latin lookup and the English language block
+have both come up empty, so it cannot outrank them. If a latin name is not
 in the map, the code falls back to the English language block and then to the
 name the API sent in the configured language. It also logs a warning asking for
 a bug report, so a new allergen surfaces instead of quietly producing a

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -284,6 +284,13 @@ def poll_titles_from_contamination(contamination):
                 f"skipping a contamination entry that is not an object: {poll!r}"
             )
             continue
+        poll_id = poll.get("poll_id")
+        if poll_id is not None and not isinstance(poll_id, (str, int, float)):
+            warnings.append(
+                f"the API sent a poll_id that is not a scalar: {poll_id!r}; "
+                f"recording it as sent, and identifying this allergen by its "
+                f"latin name instead"
+            )
         name, latin = split_poll_title(poll.get("poll_title"))
         if not name and not latin:
             # The test is what the entry identifies, not whether its title is
@@ -347,13 +354,22 @@ def allergen_key(poll):
     would file the corrected spelling as a second allergen rather than as the
     same one. Then the latin name, then the display name, for an entry the API
     sent without an id.
+
+    Every field is type-checked before it is used, because this key goes into
+    a set: an id that arrives as a list or an object is unhashable and would
+    take down the whole run rather than the one entry, and a latin or a name
+    of the wrong type has no .strip(). A field this cannot use is passed over
+    for the next one, so the entry keeps its place in the merge instead of
+    losing its identity along with its id.
     """
     poll_id = poll.get("poll_id")
-    if poll_id is not None:
+    if isinstance(poll_id, (str, int, float)):
         return ("poll_id", poll_id)
-    if latin := poll.get("latin"):
+    latin = poll.get("latin")
+    if isinstance(latin, str) and latin.strip():
         return ("latin", latin.strip().lower())
-    if name := poll.get("name"):
+    name = poll.get("name")
+    if isinstance(name, str) and name.strip():
         return ("name", name.strip().lower())
     return None
 
@@ -530,6 +546,12 @@ def repair_db(db):
                     f"{lang_code}: name or latin is not a string, skipping: {poll!r}"
                 )
                 continue
+            poll_id = poll.get("poll_id")
+            if poll_id is not None and not isinstance(poll_id, (str, int, float)):
+                warnings.append(
+                    f"{lang_code}: poll_id is not a scalar: {poll_id!r}; the "
+                    f"entry is kept and identified by its latin name"
+                )
             resolved, entry_warnings = resolve_latin(name, latin)
             warnings.extend(f"{lang_code}: {w}" for w in entry_warnings)
             if resolved != latin:

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -298,6 +298,24 @@ def needs_fetch(db, lang_code):
     return not isinstance(entry, dict) or "error" in entry
 
 
+def unreadable_entry_warning(db, lang_code):
+    """Warn about a language entry that will be refetched and overwritten.
+
+    needs_fetch treats an entry it cannot read as one to fetch again, which
+    is right: an entry that is not an object holds nothing worth keeping. But
+    it is the one place in this script that destroys something, so it says
+    so first rather than doing it quietly. An entry that is simply absent, or
+    one that records an error, is the ordinary case and says nothing.
+    """
+    entry = db.get(lang_code)
+    if entry is None or isinstance(entry, dict):
+        return None
+    return (
+        f"the file holds {entry!r} for this language, which is not an entry "
+        f"this can read; refetching and overwriting it"
+    )
+
+
 def language_entry_from_response(lang_code, data):
     """Return the db entry for one language's response, plus warnings.
 
@@ -441,6 +459,9 @@ def run_fetch():
         if not needs_fetch(db, lang_code):
             print(f"{lang_code}: Already in db, skipping.")
             continue
+
+        if warning := unreadable_entry_warning(db, lang_code):
+            print(f"{lang_code}: WARNING: {warning}")
 
         params = {
             "country": COUNTRY,

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -419,10 +419,19 @@ def repair_db(db):
 
 
 def run_repair():
-    """Revalidate the whole db offline and save it if anything changed."""
+    """Revalidate the whole db offline and save it if anything changed.
+
+    The only thing decided here is the message for a database that is empty
+    or absent. Everything else goes to repair_db unexamined, because an entry
+    point that judges the data before the validator sees it can silently
+    exclude the very shapes the validator exists to report: `if not db` sent
+    every falsy root, a file holding [] or "" or 0 or false or null, down the
+    "nothing to repair" path, which is the one answer that was certainly
+    wrong.
+    """
     db = load_db()
-    if not db:
-        print(f"No {DB_FILE} to repair.")
+    if isinstance(db, dict) and not db:
+        print(f"No languages in {DB_FILE} to repair.")
         return
 
     changes, warnings = repair_db(db)

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -159,6 +159,10 @@ def resolve_latin(name, latin):
        which is the shape reported in issue #71;
     4. anything else is warned about and recorded exactly as the API sent it.
 
+    An entry whose display name is blank is warned about too, and kept: a
+    title like "(Poaceae)" identifies its allergen, so dropping it would be
+    the mistake, but it leaves the file holding half a pairing.
+
     Rungs 1 to 3 all record a key of LATIN_TO_ENGLISH_NAME, never the string
     the API happened to send, because every consumer of this file matches a
     latin name exactly: an entry recorded as "Ambrosia artemisiifolia" is not
@@ -175,8 +179,17 @@ def resolve_latin(name, latin):
     something to tell us.
     """
     if latin and (canonical := canonical_latin(latin)):
+        # A title like "(Poaceae)" names the allergen but not in this
+        # language, so the entry is kept and the missing half is reported: the
+        # file's whole job is the pairing, and half of one is worth knowing
+        # about even though it identifies its allergen perfectly well.
+        blank_name_warning = (
+            f"the API sent {canonical!r} with no display name; recording the "
+            f"entry, but this language has no name for that allergen"
+        )
+        blank_name = [] if name else [blank_name_warning]
         if canonical == latin:
-            return latin, []
+            return latin, blank_name
         if latin.strip().lower() in LATIN_NAME_ALIASES:
             warning = (
                 f"{name!r}: the API sent {latin!r} where the latin name goes, "
@@ -187,7 +200,7 @@ def resolve_latin(name, latin):
                 f"{name!r}: the API spells the latin name {latin!r}; recording "
                 f"it as {canonical!r}, the spelling every lookup matches on"
             )
-        return canonical, [warning]
+        return canonical, blank_name + [warning]
 
     sent = f"latin name {latin!r}" if latin else "no latin name"
 

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -78,9 +78,16 @@ HEADERS = {
 def load_db():
     """Load the existing language_map.json, or return empty dict.
 
-    A file that is not JSON at all stops the run. Treating it as an empty db
-    would be the destructive reading: the fetch would refetch every language
-    and write over whatever was in there.
+    A file that is not JSON at all stops the run. The rule this follows is
+    not "unreadable stops, readable continues", it is narrower: a run that
+    would REWRITE the file stops, a run that cannot damage it continues. The
+    fetch writes, so it exits on JSON it cannot parse and on a root that is
+    not an object. The repair only ever writes what it has read, so it
+    reports those same roots and leaves the file byte for byte as it was.
+
+    Treating an unreadable file as an empty db would be the destructive
+    reading: the fetch would refetch every language and write over whatever
+    was in there.
     """
     if not os.path.exists(DB_FILE):
         return {}

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -353,7 +353,16 @@ def repair_db(db):
         if not isinstance(entry, dict):
             warnings.append(f"{lang_code}: not an object, skipping: {entry!r}")
             continue
-        poll_titles = entry.get("poll_titles") or []
+        # Every field below is read raw and type-checked before anything is
+        # defaulted. Defaulting first, with `or`, would convert a falsy value
+        # of the wrong type into a valid-looking one and walk it past the
+        # check: a latin of 0 would read as absent, the display name would
+        # then be resolved in its place, and the malformed entry would be
+        # rewritten instead of reported. Only a missing key or an explicit
+        # null is defaulted, and that is a decision rather than a side effect.
+        poll_titles = entry.get("poll_titles")
+        if poll_titles is None:
+            poll_titles = []
         if not isinstance(poll_titles, list):
             warnings.append(
                 f"{lang_code}: poll_titles is not a list, skipping: {poll_titles!r}"
@@ -365,8 +374,12 @@ def repair_db(db):
                     f"{lang_code}: entry is not an object, skipping: {poll!r}"
                 )
                 continue
-            name = poll.get("name") or ""
-            latin = poll.get("latin") or ""
+            name = poll.get("name")
+            latin = poll.get("latin")
+            if name is None:
+                name = ""
+            if latin is None:
+                latin = ""
             if not isinstance(name, str) or not isinstance(latin, str):
                 warnings.append(
                     f"{lang_code}: name or latin is not a string, skipping: {poll!r}"

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -60,7 +60,14 @@ LANG_CODES = [
     "uk",
     "hu",
 ]
-DB_FILE = "custom_components/polleninformation/language_map.json"
+# Anchored to the script rather than to the working directory. Relative, it
+# resolved against wherever the shell happened to be, so a run from any other
+# directory found no file, read no languages, fetched all sixteen and wrote a
+# new map there. A file that is merely absent is indistinguishable from an
+# empty database, so no guard downstream can catch that.
+DB_FILE = str(
+    REPO_ROOT / "custom_components" / "polleninformation" / "language_map.json"
+)
 DELAY_SEC = 2  # Polite delay between requests (adjust if needed)
 HEADERS = {
     "Accept": "application/json, text/plain, */*",

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -117,9 +117,10 @@ def split_poll_title(poll_title):
     brackets comes back as the latin name, and a title without brackets comes
     back with none. resolve_latin decides what that is worth.
 
-    Total over whatever the API sends. A title that is not a string at all
-    reads as an empty one, which resolve_latin then warns about, because one
-    malformed entry may not cost the language its other allergens.
+    Total over whatever it is handed: a title that is not a string reads as an
+    empty one. The caller rejects such an entry before it gets here, since a
+    title that cannot be read names no allergen, but the split itself does not
+    raise on one.
     """
     poll_title = poll_title if isinstance(poll_title, str) else ""
     if "(" in poll_title and ")" in poll_title:
@@ -208,10 +209,18 @@ def resolve_latin(name, latin):
 def poll_titles_from_contamination(contamination):
     """Return the poll_titles entries for a contamination block, plus warnings.
 
-    Every entry in the block produces exactly one entry here, whether or not
-    its allergen is recognized. The one thing that is dropped is an entry that
-    is not an object at all, since there is nothing in it to record, and that
-    is warned about rather than passed over.
+    Every entry the API sends produces exactly one entry here, whether or not
+    its allergen is recognized: an unknown latin name still names a real
+    allergen, and dropping it would hide a new one.
+
+    Two shapes are the exception, and they are the opposite case. An entry
+    that is not an object, and an entry with no readable title, name nothing
+    at all. Recording those would not preserve information, it would
+    manufacture a well-formed record out of nothing, and a block of them would
+    then look like a language that has allergens. Both are warned about rather
+    than passed over, and a block left empty by them is a response with no
+    allergens, which language_entry_from_response records as an error so the
+    language is fetched again.
     """
     poll_titles = []
     warnings = []
@@ -225,7 +234,13 @@ def poll_titles_from_contamination(contamination):
                 f"skipping a contamination entry that is not an object: {poll!r}"
             )
             continue
-        name, latin = split_poll_title(poll.get("poll_title", ""))
+        poll_title = poll.get("poll_title")
+        if not isinstance(poll_title, str) or not poll_title.strip():
+            warnings.append(
+                f"skipping a contamination entry with no readable title: {poll!r}"
+            )
+            continue
+        name, latin = split_poll_title(poll_title)
         latin, entry_warnings = resolve_latin(name, latin)
         warnings.extend(entry_warnings)
         poll_titles.append(

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -116,8 +116,12 @@ def split_poll_title(poll_title):
     This is the transcription step only: whatever the API put between the
     brackets comes back as the latin name, and a title without brackets comes
     back with none. resolve_latin decides what that is worth.
+
+    Total over whatever the API sends. A title that is not a string at all
+    reads as an empty one, which resolve_latin then warns about, because one
+    malformed entry may not cost the language its other allergens.
     """
-    poll_title = poll_title or ""
+    poll_title = poll_title if isinstance(poll_title, str) else ""
     if "(" in poll_title and ")" in poll_title:
         name = poll_title.split("(", 1)[0].strip()
         latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
@@ -205,11 +209,22 @@ def poll_titles_from_contamination(contamination):
     """Return the poll_titles entries for a contamination block, plus warnings.
 
     Every entry in the block produces exactly one entry here, whether or not
-    its allergen is recognized.
+    its allergen is recognized. The one thing that is dropped is an entry that
+    is not an object at all, since there is nothing in it to record, and that
+    is warned about rather than passed over.
     """
     poll_titles = []
     warnings = []
+    if not isinstance(contamination, list):
+        return poll_titles, [
+            f"the API sent a contamination block that is not a list: {contamination!r}"
+        ]
     for poll in contamination:
+        if not isinstance(poll, dict):
+            warnings.append(
+                f"skipping a contamination entry that is not an object: {poll!r}"
+            )
+            continue
         name, latin = split_poll_title(poll.get("poll_title", ""))
         latin, entry_warnings = resolve_latin(name, latin)
         warnings.extend(entry_warnings)
@@ -225,13 +240,31 @@ def repair_db(db):
     Returns (changes, warnings), where a change is one corrected latin name.
     Entries are only ever rewritten, never removed: an allergen no map knows
     keeps what the API sent and is warned about again.
+
+    Total over whatever the file holds. This is the tool you reach for when
+    the file is wrong, so a shape it did not expect is reported with the
+    language it sits in rather than raised as a traceback that names neither.
     """
     changes = []
     warnings = []
     for lang_code, entry in db.items():
-        for poll in entry.get("poll_titles", []):
-            name = poll.get("name", "")
-            latin = poll.get("latin", "")
+        if not isinstance(entry, dict):
+            warnings.append(f"{lang_code}: not an object, skipping: {entry!r}")
+            continue
+        poll_titles = entry.get("poll_titles") or []
+        if not isinstance(poll_titles, list):
+            warnings.append(
+                f"{lang_code}: poll_titles is not a list, skipping: {poll_titles!r}"
+            )
+            continue
+        for poll in poll_titles:
+            if not isinstance(poll, dict):
+                warnings.append(
+                    f"{lang_code}: entry is not an object, skipping: {poll!r}"
+                )
+                continue
+            name = poll.get("name") or ""
+            latin = poll.get("latin") or ""
             resolved, entry_warnings = resolve_latin(name, latin)
             warnings.extend(f"{lang_code}: {w}" for w in entry_warnings)
             if resolved != latin:
@@ -272,7 +305,7 @@ def run_fetch():
     base_url = "https://www.polleninformation.at/api/forecast/public"
 
     for lang_code in LANG_CODES:
-        if lang_code in db:
+        if lang_code in db and "error" not in db[lang_code]:
             print(f"{lang_code}: Already in db, skipping.")
             continue
 
@@ -294,17 +327,13 @@ def run_fetch():
             time.sleep(DELAY_SEC)
             continue
 
-        # Parse forecast block for title/allergens
-        try:
-            poll_titles, warnings = poll_titles_from_contamination(
-                data.get("contamination", [])
-            )
-        except Exception as e:
-            print(f"{lang_code}: [parse error: {e}]")
-            db[lang_code] = {"error": f"parse error: {e}", "lang_code": lang_code}
-            save_db(db)
-            time.sleep(DELAY_SEC)
-            continue
+        # Parse forecast block for title/allergens. Total over anything the
+        # API can send, so there is no parse error to catch: an entry that
+        # cannot be read costs its own line and not the whole language, and a
+        # bug here surfaces as a traceback rather than as an error entry
+        # persisted in a file that is never refetched.
+        contamination = data.get("contamination", []) if isinstance(data, dict) else []
+        poll_titles, warnings = poll_titles_from_contamination(contamination)
 
         for warning in warnings:
             print(f"{lang_code}: WARNING: {warning}")

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -1,10 +1,40 @@
+"""Generate custom_components/polleninformation/language_map.json.
+
+Two modes, both run from the repository root:
+
+    python scripts/generate_language_codes.py           # fetch missing languages
+    python scripts/generate_language_codes.py --repair  # revalidate, offline
+
+The fetch mode asks the API for one forecast per interface language and
+records the localized allergen names it answers with. It needs API_KEY (from
+the environment or from .env) and network access, and it only fetches
+languages the file does not already have.
+
+The repair mode needs neither. It revalidates every latin name already in the
+file with the same rules the fetch mode applies to a fresh response, which is
+what lets an entry recorded before those rules existed correct itself. Run it
+after changing the validation, and review the diff.
+
+Both modes take their authority from LATIN_TO_ENGLISH_NAME in sensor.py, so
+this script imports the integration and therefore needs Home Assistant
+installed (the test venv has it).
+"""
+
+import argparse
 import json
 import os
+import sys
 import time
-import requests
-from dotenv import load_dotenv
+from pathlib import Path
 
-load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), "../.env"))
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from custom_components.polleninformation.sensor import (
+    LATIN_TO_ENGLISH_NAME,
+    english_name_for_display_name,
+    english_name_for_latin,
+)
 
 # ================================
 # CONFIGURATION
@@ -13,7 +43,6 @@ load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), "../.env"))
 LAT = 48.2081743
 LON = 16.3738189
 COUNTRY = "AT"
-API_KEY = os.environ["API_KEY"]
 LANG_CODES = [
     "de",
     "en",
@@ -39,6 +68,14 @@ HEADERS = {
     "User-Agent": "Mozilla/5.0 (compatible; polleninfo-script/1.0)",
 }
 
+# The reverse of LATIN_TO_ENGLISH_NAME. The English names are unique, so this
+# is lossless. It is the last resort for an entry whose display name is the
+# English allergen name rather than a localized one, which is what the API
+# sends for ragweed in some languages.
+ENGLISH_NAME_TO_LATIN = {
+    name.lower(): latin for latin, name in LATIN_TO_ENGLISH_NAME.items()
+}
+
 
 def load_db():
     """Load the existing language_map.json, or return empty dict."""
@@ -52,6 +89,10 @@ def save_db(db):
     """Save the language_map.json file (pretty-printed, UTF-8)."""
     with open(DB_FILE, "w", encoding="utf-8") as f:
         json.dump(db, f, indent=2, ensure_ascii=False)
+        # The file is checked in, so it ends with a newline like every other
+        # source file. Without this every save shows up as a diff on the last
+        # line.
+        f.write("\n")
 
 
 def get_language_name(lang_code):
@@ -78,7 +119,132 @@ def get_language_name(lang_code):
     return names.get(lang_code, lang_code)
 
 
-def main():
+def split_poll_title(poll_title):
+    """Split a poll_title into its display name and its bracketed latin name.
+
+    This is the transcription step only: whatever the API put between the
+    brackets comes back as the latin name, and a title without brackets comes
+    back with none. resolve_latin decides what that is worth.
+    """
+    poll_title = poll_title or ""
+    if "(" in poll_title and ")" in poll_title:
+        name = poll_title.split("(", 1)[0].strip()
+        latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
+    else:
+        name = poll_title.strip()
+        latin = ""
+    return name, latin
+
+
+def resolve_latin(name, latin):
+    """Return the latin name to record for an entry, plus any warnings.
+
+    The API does not always put a latin name between the brackets, and does
+    not always use brackets at all, so a transcribed latin name is checked
+    against LATIN_TO_ENGLISH_NAME before it is trusted. When it fails, the
+    display name is the second chance: it is either a latin name itself, the
+    shape reported in issue #71, or the English allergen name, which is what
+    the API sends for ragweed in some languages.
+
+    An entry no lookup recognizes is warned about and recorded exactly as the
+    API sent it. Dropping it would hide a genuinely new allergen, which is the
+    one case where this file has something to tell us.
+    """
+    if latin and english_name_for_latin(latin):
+        return latin, []
+
+    sent = f"latin name {latin!r}" if latin else "no latin name"
+
+    if english := english_name_for_display_name(name):
+        canonical = ENGLISH_NAME_TO_LATIN[english]
+        warning = (
+            f"{name!r}: the API sent {sent} and a display name that is one; "
+            f"recording {canonical!r}"
+        )
+        return canonical, [warning]
+
+    if canonical := ENGLISH_NAME_TO_LATIN.get(name.strip().lower()):
+        warning = (
+            f"{name!r}: the API sent {sent} and an untranslated English "
+            f"display name; recording {canonical!r}"
+        )
+        return canonical, [warning]
+
+    warning = (
+        f"{name!r}: the API sent {sent} and a display name no map knows. "
+        f"Recording it as sent. If this is a new allergen it needs adding to "
+        f"LATIN_TO_ENGLISH_NAME in sensor.py; please open an issue."
+    )
+    return latin, [warning]
+
+
+def poll_titles_from_contamination(contamination):
+    """Return the poll_titles entries for a contamination block, plus warnings.
+
+    Every entry in the block produces exactly one entry here, whether or not
+    its allergen is recognized.
+    """
+    poll_titles = []
+    warnings = []
+    for poll in contamination:
+        name, latin = split_poll_title(poll.get("poll_title", ""))
+        latin, entry_warnings = resolve_latin(name, latin)
+        warnings.extend(entry_warnings)
+        poll_titles.append(
+            {"name": name, "latin": latin, "poll_id": poll.get("poll_id")}
+        )
+    return poll_titles, warnings
+
+
+def repair_db(db):
+    """Revalidate every latin name already in the db, in place.
+
+    Returns (changes, warnings), where a change is one corrected latin name.
+    Entries are only ever rewritten, never removed: an allergen no map knows
+    keeps what the API sent and is warned about again.
+    """
+    changes = []
+    warnings = []
+    for lang_code, entry in db.items():
+        for poll in entry.get("poll_titles", []):
+            name = poll.get("name", "")
+            latin = poll.get("latin", "")
+            resolved, entry_warnings = resolve_latin(name, latin)
+            warnings.extend(f"{lang_code}: {w}" for w in entry_warnings)
+            if resolved != latin:
+                poll["latin"] = resolved
+                changes.append(f"{lang_code}: {name!r}: {latin!r} -> {resolved!r}")
+    return changes, warnings
+
+
+def run_repair():
+    """Revalidate the whole db offline and save it if anything changed."""
+    db = load_db()
+    if not db:
+        print(f"No {DB_FILE} to repair.")
+        return
+
+    changes, warnings = repair_db(db)
+    for warning in warnings:
+        print(f"WARNING: {warning}")
+    for change in changes:
+        print(f"Repaired {change}")
+
+    if changes:
+        save_db(db)
+        print(f"Done. {len(changes)} latin name(s) repaired in {DB_FILE}")
+    else:
+        print(f"Done. Nothing to repair in {DB_FILE}")
+
+
+def run_fetch():
+    """Fetch every language missing from the db and record its allergen names."""
+    import requests
+    from dotenv import load_dotenv
+
+    load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), "../.env"))
+    api_key = os.environ["API_KEY"]
+
     db = load_db()
     base_url = "https://www.polleninformation.at/api/forecast/public"
 
@@ -92,7 +258,7 @@ def main():
             "lang": lang_code,
             "latitude": LAT,
             "longitude": LON,
-            "apikey": API_KEY,
+            "apikey": api_key,
         }
         try:
             resp = requests.get(base_url, params=params, headers=HEADERS, timeout=20)
@@ -107,26 +273,19 @@ def main():
 
         # Parse forecast block for title/allergens
         try:
-            contamination = data.get("contamination", [])
-            poll_titles = []
-            for poll in contamination:
-                poll_title = poll.get("poll_title", "")
-                # Split "name (Latin)" pattern
-                if "(" in poll_title and ")" in poll_title:
-                    name = poll_title.split("(", 1)[0].strip()
-                    latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
-                else:
-                    name = poll_title.strip()
-                    latin = ""
-                poll_titles.append(
-                    {"name": name, "latin": latin, "poll_id": poll.get("poll_id")}
-                )
+            poll_titles, warnings = poll_titles_from_contamination(
+                data.get("contamination", [])
+            )
         except Exception as e:
             print(f"{lang_code}: [parse error: {e}]")
             db[lang_code] = {"error": f"parse error: {e}", "lang_code": lang_code}
             save_db(db)
             time.sleep(DELAY_SEC)
             continue
+
+        for warning in warnings:
+            print(f"{lang_code}: WARNING: {warning}")
+
         entry = {
             "lang_code": lang_code,
             "lang": get_language_name(lang_code),
@@ -138,6 +297,24 @@ def main():
         time.sleep(DELAY_SEC)
 
     print(f"Done. See {DB_FILE}")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--repair",
+        action="store_true",
+        help=(
+            "revalidate the latin names already in the file instead of "
+            "fetching; needs no API key and no network"
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.repair:
+        run_repair()
+    else:
+        run_fetch()
 
 
 if __name__ == "__main__":

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -335,6 +335,35 @@ def unreadable_entry_warning(db, lang_code):
     )
 
 
+def entry_after_retry(previous, entry):
+    """Return the entry to store, given what the file already held.
+
+    A retry may improve an entry and may not impoverish it. An entry marked
+    incomplete is fetched again, and that retry can fail or come back
+    malformed; storing the error entry it produces would drop allergen names
+    the file already had, which is the trade the incomplete marker exists to
+    refuse. Eleven localized names beside a failure are worth more to a sensor
+    than none, exactly as they were worth more than an error entry.
+
+    So a failure keeps what was there, records that the retry failed, and
+    leaves the language retryable. The stored message says the names are from
+    an earlier fetch, because an entry carrying both names and a failure
+    should not read as a clean partial.
+    """
+    if "error" not in entry:
+        return entry
+    if not isinstance(previous, dict) or not previous.get("poll_titles"):
+        return entry
+
+    kept = dict(previous)
+    kept["incomplete"] = True
+    kept["retry_error"] = (
+        f"the last retry failed ({entry['error']}); the allergen names in this "
+        f"entry are from an earlier fetch"
+    )
+    return kept
+
+
 def language_entry_from_response(lang_code, data):
     """Return the db entry for one language's response, plus warnings.
 
@@ -517,13 +546,16 @@ def run_fetch():
             "longitude": LON,
             "apikey": api_key,
         }
+        previous = db.get(lang_code)
         try:
             resp = requests.get(base_url, params=params, headers=HEADERS, timeout=20)
             resp.raise_for_status()
             data = resp.json()
         except Exception as e:
             print(f"{lang_code}: [request error: {e}]")
-            db[lang_code] = {"error": str(e), "lang_code": lang_code}
+            db[lang_code] = entry_after_retry(
+                previous, {"error": str(e), "lang_code": lang_code}
+            )
             save_db(db)
             time.sleep(DELAY_SEC)
             continue
@@ -538,9 +570,12 @@ def run_fetch():
         for warning in warnings:
             print(f"{lang_code}: WARNING: {warning}")
 
+        entry = entry_after_retry(previous, entry)
         db[lang_code] = entry
         if "error" in entry:
             print(f"{lang_code}: [{entry['error']}]")
+        elif "retry_error" in entry:
+            print(f"{lang_code}: [{entry['retry_error']}]")
         else:
             print(f"{lang_code}: OK, {len(entry['poll_titles'])} allergens")
         save_db(db)

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -69,11 +69,22 @@ HEADERS = {
 
 
 def load_db():
-    """Load the existing language_map.json, or return empty dict."""
+    """Load the existing language_map.json, or return empty dict.
+
+    A file that is not JSON at all stops the run. Treating it as an empty db
+    would be the destructive reading: the fetch would refetch every language
+    and write over whatever was in there.
+    """
     if not os.path.exists(DB_FILE):
         return {}
     with open(DB_FILE, "r", encoding="utf-8") as f:
-        return json.load(f)
+        try:
+            return json.load(f)
+        except json.JSONDecodeError as e:
+            raise SystemExit(
+                f"{DB_FILE} is not valid JSON ({e}). Fix or remove it; this "
+                f"script will not overwrite a file it cannot read."
+            ) from e
 
 
 def save_db(db):
@@ -378,6 +389,12 @@ def run_fetch():
     api_key = os.environ["API_KEY"]
 
     db = load_db()
+    if not isinstance(db, dict):
+        raise SystemExit(
+            f"{DB_FILE} does not hold an object at its root, but a "
+            f"{type(db).__name__}. Fix or remove it; this script will not "
+            f"overwrite a file it cannot read."
+        )
     base_url = "https://www.polleninformation.at/api/forecast/public"
 
     for lang_code in LANG_CODES:

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -234,6 +234,54 @@ def poll_titles_from_contamination(contamination):
     return poll_titles, warnings
 
 
+def needs_fetch(db, lang_code):
+    """Whether a language still has to be fetched.
+
+    An entry that records an error is retried, which is the only reason the
+    error is written to the file at all: a language whose response could not
+    be read has to come back on the next run rather than sit there forever.
+    """
+    entry = db.get(lang_code)
+    return not isinstance(entry, dict) or "error" in entry
+
+
+def language_entry_from_response(lang_code, data):
+    """Return the db entry for one language's response, plus warnings.
+
+    A response this cannot take a single allergen from is recorded as an
+    error, whatever shape caused it: a top level that is not an object, no
+    contamination block, a block that is not a list, an empty block, or a
+    block of entries none of which could be read.
+
+    An empty response and a malformed one are not distinguishable here, and
+    for this file they do not need to be. Both leave a language with no
+    allergen names, which is the one thing the file exists to hold, so both
+    have to be fetched again rather than saved as a language that legitimately
+    has none. Recording either as a success would be permanent: needs_fetch
+    only retries an entry that carries an error.
+    """
+    warnings = []
+    poll_titles = []
+    if not isinstance(data, dict):
+        error = (
+            f"malformed response: the top level is {type(data).__name__}, not an object"
+        )
+    elif "contamination" not in data:
+        error = "malformed response: no contamination block"
+    else:
+        poll_titles, warnings = poll_titles_from_contamination(data["contamination"])
+        error = "the response carries no allergens" if not poll_titles else None
+
+    if error:
+        return {"error": error, "lang_code": lang_code}, warnings
+
+    return {
+        "lang_code": lang_code,
+        "lang": get_language_name(lang_code),
+        "poll_titles": poll_titles,
+    }, warnings
+
+
 def repair_db(db):
     """Revalidate every latin name already in the db, in place.
 
@@ -310,7 +358,7 @@ def run_fetch():
     base_url = "https://www.polleninformation.at/api/forecast/public"
 
     for lang_code in LANG_CODES:
-        if lang_code in db and "error" not in db[lang_code]:
+        if not needs_fetch(db, lang_code):
             print(f"{lang_code}: Already in db, skipping.")
             continue
 
@@ -337,19 +385,16 @@ def run_fetch():
         # cannot be read costs its own line and not the whole language, and a
         # bug here surfaces as a traceback rather than as an error entry
         # persisted in a file that is never refetched.
-        contamination = data.get("contamination", []) if isinstance(data, dict) else []
-        poll_titles, warnings = poll_titles_from_contamination(contamination)
+        entry, warnings = language_entry_from_response(lang_code, data)
 
         for warning in warnings:
             print(f"{lang_code}: WARNING: {warning}")
 
-        entry = {
-            "lang_code": lang_code,
-            "lang": get_language_name(lang_code),
-            "poll_titles": poll_titles,
-        }
         db[lang_code] = entry
-        print(f"{lang_code}: OK, {len(poll_titles)} allergens")
+        if "error" in entry:
+            print(f"{lang_code}: [{entry['error']}]")
+        else:
+            print(f"{lang_code}: OK, {len(entry['poll_titles'])} allergens")
         save_db(db)
         time.sleep(DELAY_SEC)
 

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -335,33 +335,82 @@ def unreadable_entry_warning(db, lang_code):
     )
 
 
+def allergen_key(poll):
+    """Return what identifies an allergen ACROSS two fetches of one language.
+
+    poll_id first, because it is the API's own identifier and the one thing
+    that survives a latin name being corrected: keying on the latin instead
+    would file the corrected spelling as a second allergen rather than as the
+    same one. Then the latin name, then the display name, for an entry the API
+    sent without an id.
+    """
+    poll_id = poll.get("poll_id")
+    if poll_id is not None:
+        return ("poll_id", poll_id)
+    if latin := poll.get("latin"):
+        return ("latin", latin.strip().lower())
+    if name := poll.get("name"):
+        return ("name", name.strip().lower())
+    return None
+
+
 def entry_after_retry(previous, entry):
     """Return the entry to store, given what the file already held.
 
     A retry may improve an entry and may not impoverish it. An entry marked
-    incomplete is fetched again, and that retry can fail or come back
-    malformed; storing the error entry it produces would drop allergen names
-    the file already had, which is the trade the incomplete marker exists to
-    refuse. Eleven localized names beside a failure are worth more to a sensor
-    than none, exactly as they were worth more than an error entry.
+    incomplete is fetched again, and that retry can come back failed, poorer,
+    or clean. Only the last of those may replace what is there.
 
-    So a failure keeps what was there, records that the retry failed, and
-    leaves the language retryable. The stored message says the names are from
-    an earlier fetch, because an entry carrying both names and a failure
-    should not read as a clean partial.
+    A FAILED retry keeps everything and records that it failed. The stored
+    message says the names are from an earlier fetch, because an entry
+    carrying both names and a failure should not read as a clean partial.
+
+    A POORER retry, one that is itself incomplete, is merged per allergen:
+    every name it did read wins, since it is the newer one, and every allergen
+    it did not read keeps the name the file already had. Neither half of a
+    wholesale comparison is right on its own. Keeping the old entry because it
+    has more names would throw away a name the API has just corrected;
+    replacing it because the response is newer would drop ten names to gain
+    one, which is the trade the incomplete marker exists to refuse.
+
+    A CLEAN retry replaces the entry outright, which is what bounds the merge.
+    An allergen that has genuinely left the API for this language disappears
+    from the file on the first response that reads cleanly. Until then the
+    response is one we have admitted we cannot fully read, and in it a missing
+    allergen and an unreadable one are the same observation: the entry we
+    could not read may BE the allergen that looks missing. Dropping it would
+    infer a disappearance from the one response that cannot support the
+    inference.
     """
-    if "error" not in entry:
-        return entry
-    if not isinstance(previous, dict) or not previous.get("poll_titles"):
+    if "error" in entry:
+        if not isinstance(previous, dict) or not previous.get("poll_titles"):
+            return entry
+        kept = dict(previous)
+        kept["incomplete"] = True
+        kept["retry_error"] = (
+            f"the last retry failed ({entry['error']}); the allergen names in "
+            f"this entry are from an earlier fetch"
+        )
+        return kept
+
+    if not entry.get("incomplete") or not isinstance(previous, dict):
         return entry
 
-    kept = dict(previous)
-    kept["incomplete"] = True
-    kept["retry_error"] = (
-        f"the last retry failed ({entry['error']}); the allergen names in this "
-        f"entry are from an earlier fetch"
-    )
-    return kept
+    previous_titles = previous.get("poll_titles")
+    if not isinstance(previous_titles, list):
+        return entry
+
+    fresh_keys = {allergen_key(poll) for poll in entry["poll_titles"]}
+    kept = [
+        poll
+        for poll in previous_titles
+        if isinstance(poll, dict)
+        and (key := allergen_key(poll)) is not None
+        and key not in fresh_keys
+    ]
+    if not kept:
+        return entry
+    return {**entry, "poll_titles": [*entry["poll_titles"], *kept]}
 
 
 def language_entry_from_response(lang_code, data):

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -265,6 +265,11 @@ def repair_db(db):
                 continue
             name = poll.get("name") or ""
             latin = poll.get("latin") or ""
+            if not isinstance(name, str) or not isinstance(latin, str):
+                warnings.append(
+                    f"{lang_code}: name or latin is not a string, skipping: {poll!r}"
+                )
+                continue
             resolved, entry_warnings = resolve_latin(name, latin)
             warnings.extend(f"{lang_code}: {w}" for w in entry_warnings)
             if resolved != latin:

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -31,9 +31,8 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from custom_components.polleninformation.sensor import (
+    LATIN_NAME_ALIASES,
     canonical_latin,
-    english_name_for_display_name,
-    english_name_for_latin,
 )
 
 # ================================
@@ -135,12 +134,20 @@ def resolve_latin(name, latin):
     not always use brackets at all, so a transcribed latin name is checked
     against the integration's own maps before it is trusted:
 
-    1. a latin name LATIN_TO_ENGLISH_NAME knows is recorded as sent;
+    1. a latin name LATIN_TO_ENGLISH_NAME knows is recorded under that map's
+       own key, so "poaceae" and "Ambrosia artemisiifolia" are recorded as
+       "Poaceae" and "Ambrosia";
     2. a spelling LATIN_NAME_ALIASES declares, such as the Slovak "ambrózia",
        is recorded as the latin name it stands for;
     3. the display name is read as a latin name only when the API sent none,
        which is the shape reported in issue #71;
     4. anything else is warned about and recorded exactly as the API sent it.
+
+    Rungs 1 to 3 all record a key of LATIN_TO_ENGLISH_NAME, never the string
+    the API happened to send, because every consumer of this file matches a
+    latin name exactly: an entry recorded as "Ambrosia artemisiifolia" is not
+    found again by the restore path, which holds "Ambrosia". The name field
+    already preserves the API's own wording.
 
     A latin name the API did send is otherwise authoritative even when nothing
     resolves it, exactly as it is for the sensors: "Artemisia (Asteraceae)" is
@@ -151,25 +158,30 @@ def resolve_latin(name, latin):
     hide a genuinely new allergen, which is the one case where this file has
     something to tell us.
     """
-    if latin and english_name_for_latin(latin):
-        canonical = canonical_latin(latin)
-        if canonical != latin:
+    if latin and (canonical := canonical_latin(latin)):
+        if canonical == latin:
+            return latin, []
+        if latin.strip().lower() in LATIN_NAME_ALIASES:
             warning = (
                 f"{name!r}: the API sent {latin!r} where the latin name goes, "
                 f"which is a known spelling of {canonical!r}; recording that"
             )
-            return canonical, [warning]
-        return latin, []
+        else:
+            warning = (
+                f"{name!r}: the API spells the latin name {latin!r}; recording "
+                f"it as {canonical!r}, the spelling every lookup matches on"
+            )
+        return canonical, [warning]
 
     sent = f"latin name {latin!r}" if latin else "no latin name"
 
-    if not latin and english_name_for_display_name(name):
+    if not latin and (canonical := canonical_latin(name)):
         # The display name is itself a latin name, so record it as one.
         warning = (
             f"{name!r}: the API sent {sent} and a display name that is one; "
-            f"recording {name!r}"
+            f"recording {canonical!r}"
         )
-        return name, [warning]
+        return canonical, [warning]
 
     if latin:
         warning = (

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -136,6 +136,27 @@ def split_poll_title(poll_title):
     return name, latin
 
 
+# Everything a scientific name is allowed to be made of. The nomenclature
+# codes require a name to be written in Latin letters, so a name never carries
+# a diacritic or a non-Latin script; the multiplication sign is the one
+# exception, since it marks a hybrid ("Ambrosia x helenae" is also written
+# with it).
+SCIENTIFIC_NAME_CHARACTERS = set(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ .-'×"
+)
+
+
+def could_be_a_scientific_name(latin):
+    """Return whether a string could be a scientific name at all.
+
+    This does not say the name exists, only that nothing rules it out. A
+    string carrying a diacritic or a non-Latin script cannot be one, which is
+    how a localized word the API put between the brackets is told apart from
+    a genuine latin name the static map happens not to know.
+    """
+    return bool(latin) and set(latin) <= SCIENTIFIC_NAME_CHARACTERS
+
+
 def resolve_latin(name, latin):
     """Return the latin name to record for an entry, plus any warnings.
 
@@ -146,6 +167,14 @@ def resolve_latin(name, latin):
     shape reported in issue #71, or the English allergen name, which is what
     the API sends for ragweed in some languages.
 
+    A latin name the API did send is authoritative even when nothing resolves
+    it, exactly as it is for the sensors: "Artemisia (Asteraceae)" is the
+    composite family, not mugwort, and reading its display name as a latin
+    name would record it as a different allergen. So the display name is only
+    read as a latin name when the API sent none, and it is only read as an
+    English allergen name when the API sent none or sent something that could
+    not be a scientific name whatever it names.
+
     An entry no lookup recognizes is warned about and recorded exactly as the
     API sent it. Dropping it would hide a genuinely new allergen, which is the
     one case where this file has something to tell us.
@@ -155,7 +184,7 @@ def resolve_latin(name, latin):
 
     sent = f"latin name {latin!r}" if latin else "no latin name"
 
-    if english := english_name_for_display_name(name):
+    if not latin and (english := english_name_for_display_name(name)):
         canonical = ENGLISH_NAME_TO_LATIN[english]
         warning = (
             f"{name!r}: the API sent {sent} and a display name that is one; "
@@ -163,18 +192,28 @@ def resolve_latin(name, latin):
         )
         return canonical, [warning]
 
-    if canonical := ENGLISH_NAME_TO_LATIN.get(name.strip().lower()):
+    if not could_be_a_scientific_name(latin) and (
+        canonical := ENGLISH_NAME_TO_LATIN.get(name.strip().lower())
+    ):
         warning = (
             f"{name!r}: the API sent {sent} and an untranslated English "
             f"display name; recording {canonical!r}"
         )
         return canonical, [warning]
 
-    warning = (
-        f"{name!r}: the API sent {sent} and a display name no map knows. "
-        f"Recording it as sent. If this is a new allergen it needs adding to "
-        f"LATIN_TO_ENGLISH_NAME in sensor.py; please open an issue."
-    )
+    if latin:
+        warning = (
+            f"{name!r}: the API sent {sent}, which no map knows. Keeping it: "
+            f"a latin name the API sent identifies the allergen even when "
+            f"nothing resolves it. If this is a new allergen it needs adding "
+            f"to LATIN_TO_ENGLISH_NAME in sensor.py; please open an issue."
+        )
+    else:
+        warning = (
+            f"{name!r}: the API sent {sent} and a display name no map knows. "
+            f"Recording it as sent. If this is a new allergen it needs adding "
+            f"to LATIN_TO_ENGLISH_NAME in sensor.py; please open an issue."
+        )
     return latin, [warning]
 
 

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -35,6 +35,7 @@ from custom_components.polleninformation.sensor import (
     canonical_latin,
     canonical_latin_for_display_name,
 )
+from custom_components.polleninformation.utils import parse_poll_title
 
 # ================================
 # CONFIGURATION
@@ -143,19 +144,22 @@ def split_poll_title(poll_title):
     brackets comes back as the latin name, and a title without brackets comes
     back with none. resolve_latin decides what that is worth.
 
-    Total over whatever it is handed: a title that is not a string reads as an
-    empty one. The caller rejects such an entry before it gets here, since a
-    title that cannot be read names no allergen, but the split itself does not
-    raise on one.
+    Delegates to the integration's own parse, so that the file and the sensors
+    read a title the same way rather than nearly the same way. They differed
+    on the unmatched bracket: this kept "Artemisia (" whole and recorded
+    nothing, while the sensors split at the bracket and read mugwort.
+
+    The seam is the return shape. The shared parse answers None for a title
+    that identifies nothing and None for an absent latin name; this answers a
+    pair either way, with "" where there is no latin name, because resolve_latin
+    is written against strings and the caller decides what to do with a title
+    that names nothing.
     """
-    poll_title = poll_title if isinstance(poll_title, str) else ""
-    if "(" in poll_title and ")" in poll_title:
-        name = poll_title.split("(", 1)[0].strip()
-        latin = poll_title.split("(", 1)[1].split(")", 1)[0].strip()
-    else:
-        name = poll_title.strip()
-        latin = ""
-    return name, latin
+    parsed = parse_poll_title(poll_title)
+    if parsed is None:
+        return "", ""
+    name, latin = parsed
+    return name, latin or ""
 
 
 def resolve_latin(name, latin):

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -304,12 +304,20 @@ def repair_db(db):
     Entries are only ever rewritten, never removed: an allergen no map knows
     keeps what the API sent and is warned about again.
 
-    Total over whatever the file holds. This is the tool you reach for when
-    the file is wrong, so a shape it did not expect is reported with the
-    language it sits in rather than raised as a traceback that names neither.
+    Total over whatever the file holds, from the root down. This is the tool
+    you reach for when the file is wrong, so a shape it did not expect is
+    reported, with the language it sits in where there is one, rather than
+    raised as a traceback that names neither. Nothing is rewritten on the way:
+    a file this cannot read is left exactly as it is.
     """
     changes = []
     warnings = []
+    if not isinstance(db, dict):
+        warning = (
+            f"the file does not hold an object at its root, but a "
+            f"{type(db).__name__}; nothing to repair"
+        )
+        return changes, [warning]
     for lang_code, entry in db.items():
         if not isinstance(entry, dict):
             warnings.append(f"{lang_code}: not an object, skipping: {entry!r}")

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -15,7 +15,7 @@ file with the same rules the fetch mode applies to a fresh response, which is
 what lets an entry recorded before those rules existed correct itself. Run it
 after changing the validation, and review the diff.
 
-Both modes take their authority from LATIN_TO_ENGLISH_NAME in sensor.py, so
+Both modes take their authority from the allergen maps in sensor.py, so
 this script imports the integration and therefore needs Home Assistant
 installed (the test venv has it).
 """
@@ -31,7 +31,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from custom_components.polleninformation.sensor import (
-    LATIN_TO_ENGLISH_NAME,
+    canonical_latin,
     english_name_for_display_name,
     english_name_for_latin,
 )
@@ -66,14 +66,6 @@ DELAY_SEC = 2  # Polite delay between requests (adjust if needed)
 HEADERS = {
     "Accept": "application/json, text/plain, */*",
     "User-Agent": "Mozilla/5.0 (compatible; polleninfo-script/1.0)",
-}
-
-# The reverse of LATIN_TO_ENGLISH_NAME. The English names are unique, so this
-# is lossless. It is the last resort for an entry whose display name is the
-# English allergen name rather than a localized one, which is what the API
-# sends for ragweed in some languages.
-ENGLISH_NAME_TO_LATIN = {
-    name.lower(): latin for latin, name in LATIN_TO_ENGLISH_NAME.items()
 }
 
 
@@ -136,77 +128,57 @@ def split_poll_title(poll_title):
     return name, latin
 
 
-# Everything a scientific name is allowed to be made of. The nomenclature
-# codes require a name to be written in Latin letters, so a name never carries
-# a diacritic or a non-Latin script; the multiplication sign is the one
-# exception, since it marks a hybrid ("Ambrosia x helenae" is also written
-# with it).
-SCIENTIFIC_NAME_CHARACTERS = set(
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ .-'×"
-)
-
-
-def could_be_a_scientific_name(latin):
-    """Return whether a string could be a scientific name at all.
-
-    This does not say the name exists, only that nothing rules it out. A
-    string carrying a diacritic or a non-Latin script cannot be one, which is
-    how a localized word the API put between the brackets is told apart from
-    a genuine latin name the static map happens not to know.
-    """
-    return bool(latin) and set(latin) <= SCIENTIFIC_NAME_CHARACTERS
-
-
 def resolve_latin(name, latin):
     """Return the latin name to record for an entry, plus any warnings.
 
     The API does not always put a latin name between the brackets, and does
     not always use brackets at all, so a transcribed latin name is checked
-    against LATIN_TO_ENGLISH_NAME before it is trusted. When it fails, the
-    display name is the second chance: it is either a latin name itself, the
-    shape reported in issue #71, or the English allergen name, which is what
-    the API sends for ragweed in some languages.
+    against the integration's own maps before it is trusted:
 
-    A latin name the API did send is authoritative even when nothing resolves
-    it, exactly as it is for the sensors: "Artemisia (Asteraceae)" is the
-    composite family, not mugwort, and reading its display name as a latin
-    name would record it as a different allergen. So the display name is only
-    read as a latin name when the API sent none, and it is only read as an
-    English allergen name when the API sent none or sent something that could
-    not be a scientific name whatever it names.
+    1. a latin name LATIN_TO_ENGLISH_NAME knows is recorded as sent;
+    2. a spelling LATIN_NAME_ALIASES declares, such as the Slovak "ambrózia",
+       is recorded as the latin name it stands for;
+    3. the display name is read as a latin name only when the API sent none,
+       which is the shape reported in issue #71;
+    4. anything else is warned about and recorded exactly as the API sent it.
 
-    An entry no lookup recognizes is warned about and recorded exactly as the
-    API sent it. Dropping it would hide a genuinely new allergen, which is the
-    one case where this file has something to tell us.
+    A latin name the API did send is otherwise authoritative even when nothing
+    resolves it, exactly as it is for the sensors: "Artemisia (Asteraceae)" is
+    the composite family, not mugwort, and reading its display name as a latin
+    name would record it as a different allergen. Only a spelling declared in
+    the alias table overrides what the API sent, so an unknown latin name is
+    never guessed at, and dropping it is never an option either: that would
+    hide a genuinely new allergen, which is the one case where this file has
+    something to tell us.
     """
     if latin and english_name_for_latin(latin):
+        canonical = canonical_latin(latin)
+        if canonical != latin:
+            warning = (
+                f"{name!r}: the API sent {latin!r} where the latin name goes, "
+                f"which is a known spelling of {canonical!r}; recording that"
+            )
+            return canonical, [warning]
         return latin, []
 
     sent = f"latin name {latin!r}" if latin else "no latin name"
 
-    if not latin and (english := english_name_for_display_name(name)):
-        canonical = ENGLISH_NAME_TO_LATIN[english]
+    if not latin and english_name_for_display_name(name):
+        # The display name is itself a latin name, so record it as one.
         warning = (
             f"{name!r}: the API sent {sent} and a display name that is one; "
-            f"recording {canonical!r}"
+            f"recording {name!r}"
         )
-        return canonical, [warning]
-
-    if not could_be_a_scientific_name(latin) and (
-        canonical := ENGLISH_NAME_TO_LATIN.get(name.strip().lower())
-    ):
-        warning = (
-            f"{name!r}: the API sent {sent} and an untranslated English "
-            f"display name; recording {canonical!r}"
-        )
-        return canonical, [warning]
+        return name, [warning]
 
     if latin:
         warning = (
             f"{name!r}: the API sent {sent}, which no map knows. Keeping it: "
             f"a latin name the API sent identifies the allergen even when "
             f"nothing resolves it. If this is a new allergen it needs adding "
-            f"to LATIN_TO_ENGLISH_NAME in sensor.py; please open an issue."
+            f"to LATIN_TO_ENGLISH_NAME in sensor.py, and a spelling that is "
+            f"not a latin name at all to LATIN_NAME_ALIASES; please open an "
+            f"issue."
         )
     else:
         warning = (

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -299,9 +299,17 @@ def needs_fetch(db, lang_code):
     An entry that records an error is retried, which is the only reason the
     error is written to the file at all: a language whose response could not
     be read has to come back on the next run rather than sit there forever.
+
+    So is an entry that is incomplete. A response can be readable and still
+    have lost an allergen to a malformed entry, and nothing else would ever
+    revisit it: this skips a saved language, and --repair cannot invent an
+    entry that was never recorded. Left alone it would be permanently missing
+    one allergen with nothing to say so.
     """
     entry = db.get(lang_code)
-    return not isinstance(entry, dict) or "error" in entry
+    if not isinstance(entry, dict):
+        return True
+    return "error" in entry or bool(entry.get("incomplete"))
 
 
 def unreadable_entry_warning(db, lang_code):
@@ -335,10 +343,18 @@ def language_entry_from_response(lang_code, data):
     allergen names, which is the one thing the file exists to hold, so both
     have to be fetched again rather than saved as a language that legitimately
     has none. Recording either as a success would be permanent: needs_fetch
-    only retries an entry that carries an error.
+    only retries an entry that carries an error or is marked incomplete.
+
+    A response that lost SOME of its entries is marked incomplete and keeps
+    the ones it had. The entry is worth keeping, because eleven names are
+    worth more to a sensor than none, and it may not be treated as finished,
+    because nothing else would ever come back for the twelfth: this file is
+    only fetched for languages it lacks, and --repair cannot invent an entry
+    that was never recorded.
     """
     warnings = []
     poll_titles = []
+    dropped = 0
     if not isinstance(data, dict):
         error = (
             f"malformed response: the top level is {type(data).__name__}, not an object"
@@ -346,17 +362,28 @@ def language_entry_from_response(lang_code, data):
     elif "contamination" not in data:
         error = "malformed response: no contamination block"
     else:
-        poll_titles, warnings = poll_titles_from_contamination(data["contamination"])
+        contamination = data["contamination"]
+        poll_titles, warnings = poll_titles_from_contamination(contamination)
         error = "the response carries no allergens" if not poll_titles else None
+        if isinstance(contamination, list):
+            dropped = len(contamination) - len(poll_titles)
 
     if error:
         return {"error": error, "lang_code": lang_code}, warnings
 
-    return {
+    entry = {
         "lang_code": lang_code,
         "lang": get_language_name(lang_code),
         "poll_titles": poll_titles,
-    }, warnings
+    }
+    if dropped:
+        entry["incomplete"] = True
+        incomplete_warning = (
+            f"{dropped} entry(ies) could not be read, so this language is "
+            f"recorded as incomplete and will be fetched again"
+        )
+        warnings = [*warnings, incomplete_warning]
+    return entry, warnings
 
 
 def repair_db(db):

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -33,6 +33,7 @@ sys.path.insert(0, str(REPO_ROOT))
 from custom_components.polleninformation.sensor import (
     LATIN_NAME_ALIASES,
     canonical_latin,
+    canonical_latin_for_display_name,
 )
 
 # ================================
@@ -170,7 +171,8 @@ def resolve_latin(name, latin):
     2. a spelling LATIN_NAME_ALIASES declares, such as the Slovak "ambrózia",
        is recorded as the latin name it stands for;
     3. the display name is read as a latin name only when the API sent none,
-       which is the shape reported in issue #71;
+       which is the shape reported in issue #71, and only on an exact match,
+       because prose that begins with a genus is not an identity;
     4. anything else is warned about and recorded exactly as the API sent it.
 
     An entry whose display name is blank is warned about too, and kept: a
@@ -218,8 +220,11 @@ def resolve_latin(name, latin):
 
     sent = f"latin name {latin!r}" if latin else "no latin name"
 
-    if not latin and (canonical := canonical_latin(name)):
-        # The display name is itself a latin name, so record it as one.
+    if not latin and (canonical := canonical_latin_for_display_name(name)):
+        # The display name is itself a latin name, so record it as one. The
+        # lookup is exact, with no genus fallback: "Ambrosia hojas" is prose
+        # that begins with a genus, and recording it as Ambrosia would file
+        # the entry under an allergen the sensors refuse to read it as.
         warning = (
             f"{name!r}: the API sent {sent} and a display name that is one; "
             f"recording {canonical!r}"

--- a/scripts/generate_language_codes.py
+++ b/scripts/generate_language_codes.py
@@ -252,13 +252,16 @@ def poll_titles_from_contamination(contamination):
     allergen, and dropping it would hide a new one.
 
     Two shapes are the exception, and they are the opposite case. An entry
-    that is not an object, and an entry with no readable title, name nothing
-    at all. Recording those would not preserve information, it would
-    manufacture a well-formed record out of nothing, and a block of them would
-    then look like a language that has allergens. Both are warned about rather
-    than passed over, and a block left empty by them is a response with no
-    allergens, which language_entry_from_response records as an error so the
-    language is fetched again.
+    that is not an object, and an entry that identifies no allergen, name
+    nothing at all. The second is the parsed test rather than a test on the
+    raw title: a title is kept when it has a display name or a latin name,
+    so "(Poaceae)" is kept for its latin name and "()" is not, any more than
+    a missing title is. Recording those would not preserve information, it
+    would manufacture a well-formed record out of nothing, and a block of
+    them would then look like a language that has allergens. Both are warned
+    about rather than passed over, and a block left empty by them is a
+    response with no allergens, which language_entry_from_response records as
+    an error so the language is fetched again.
     """
     poll_titles = []
     warnings = []
@@ -272,13 +275,16 @@ def poll_titles_from_contamination(contamination):
                 f"skipping a contamination entry that is not an object: {poll!r}"
             )
             continue
-        poll_title = poll.get("poll_title")
-        if not isinstance(poll_title, str) or not poll_title.strip():
+        name, latin = split_poll_title(poll.get("poll_title"))
+        if not name and not latin:
+            # The test is what the entry identifies, not whether its title is
+            # readable. "()" and "( )" are non-blank titles with nothing in
+            # either half, and they name an allergen exactly as little as a
+            # missing title does.
             warnings.append(
-                f"skipping a contamination entry with no readable title: {poll!r}"
+                f"skipping a contamination entry that identifies no allergen: {poll!r}"
             )
             continue
-        name, latin = split_poll_title(poll_title)
         latin, entry_warnings = resolve_latin(name, latin)
         warnings.extend(entry_warnings)
         poll_titles.append(

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -68,13 +68,17 @@ class TestResolveLatin:
         assert latin == "Ambrosia artemisiifolia"
         assert warnings == []
 
-    def test_localized_word_in_brackets_is_replaced_from_the_display_name(self, script):
-        # The sk shape: the API put a Slovak word where the latin name goes,
-        # and left the display name in English.
+    def test_a_declared_alias_is_recorded_as_the_name_it_stands_for(self, script):
+        # The sk shape: the API put the Slovak word for ragweed where the
+        # latin name goes. That spelling is declared in LATIN_NAME_ALIASES,
+        # which is the only thing that may override what the API sent.
         latin, warnings = script.resolve_latin("Ragweed", "ambrózia")
         assert latin == "Ambrosia"
         assert len(warnings) == 1
         assert "ambrózia" in warnings[0]
+
+    def test_an_alias_is_matched_case_insensitively(self, script):
+        assert script.resolve_latin("Ragweed", "Ambrózia")[0] == "Ambrosia"
 
     def test_display_name_that_is_a_latin_name_supplies_the_missing_latin(self, script):
         # The es shape, and the shape reported in issue #71.
@@ -92,18 +96,14 @@ class TestResolveLatin:
         assert len(warnings) == 1
         assert "Keeping it" in warnings[0]
 
-    def test_a_latin_the_api_sent_outranks_an_english_display_name(self, script):
-        # The same rule for the English-name lookup: "Asteraceae" could be a
-        # scientific name, so it identifies the allergen whatever the display
-        # name says.
+    def test_an_english_display_name_never_overrides_a_latin_one(self, script):
+        # "Ragweed (Asteraceae)" is the case that ruled out inferring a latin
+        # name from the display name. Asteraceae is not a declared alias, so
+        # nothing touches it.
         latin, warnings = script.resolve_latin("Ragweed", "Asteraceae")
         assert latin == "Asteraceae"
         assert len(warnings) == 1
         assert "Keeping it" in warnings[0]
-
-    def test_a_hybrid_name_the_map_does_not_know_is_kept(self, script):
-        latin, _ = script.resolve_latin("Ragweed", "Asteraceae × nova")
-        assert latin == "Asteraceae × nova"
 
     def test_unknown_latin_is_kept_as_sent_and_warned_about(self, script):
         latin, warnings = script.resolve_latin("Nässlor", "Nonexistentia")
@@ -116,26 +116,6 @@ class TestResolveLatin:
         assert latin == ""
         assert len(warnings) == 1
         assert "no latin name" in warnings[0]
-
-
-class TestCouldBeAScientificName:
-    """What tells a latin name the map does not know from a localized word.
-
-    This is the whole safety argument for the English-name lookup: it may
-    only override what the API put between the brackets when that string
-    cannot be a scientific name whatever it names.
-    """
-
-    @pytest.mark.parametrize(
-        "latin",
-        ["Asteraceae", "Ambrosia artemisiifolia", "Ambrosia × helenae", "Poaceae"],
-    )
-    def test_latin_names_could_be_one(self, script, latin):
-        assert script.could_be_a_scientific_name(latin)
-
-    @pytest.mark.parametrize("latin", ["ambrózia", "Амброзия", "パセリ", "", "räven"])
-    def test_a_localized_word_could_not(self, script, latin):
-        assert not script.could_be_a_scientific_name(latin)
 
 
 class TestPollTitlesFromContamination:

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -310,7 +310,30 @@ class TestRepairDb:
 
 
 class TestShippedLanguageMap:
-    """The file itself, as shipped."""
+    """The file itself, as shipped.
+
+    The map may not carry an allergen the integration does not know. That is
+    deliberate, and it is why these two fail rather than pass when the API
+    adds one: the generator writes an unknown allergen through on purpose, so
+    that it reaches a human. The fix when they go red is to add the allergen
+    to LATIN_TO_ENGLISH_NAME in sensor.py, or its spelling to
+    LATIN_NAME_ALIASES if that is what it turns out to be. It is never to
+    relax the assertion, and never to delete the entry from the file.
+    """
+
+    def test_no_recorded_latin_name_is_a_known_bad_spelling(self, script):
+        # The narrow half of the tripwire: whatever else the file holds, it
+        # may not hold a spelling we have already established is not a latin
+        # name, nor an entry with no latin name at all. This one stays true
+        # even for an allergen the integration does not know yet.
+        db = json.loads(LANGUAGE_MAP.read_text(encoding="utf-8"))
+        bad = [
+            (lang_code, entry["name"], entry["latin"])
+            for lang_code, block in db.items()
+            for entry in block.get("poll_titles", [])
+            if not entry["latin"] or entry["latin"].lower() in script.LATIN_NAME_ALIASES
+        ]
+        assert bad == []
 
     def test_every_recorded_latin_name_is_recognized(self, script):
         db = json.loads(LANGUAGE_MAP.read_text(encoding="utf-8"))

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -185,6 +185,94 @@ class TestPollTitlesFromContamination:
         assert poll_titles[0]["name"] == "Ragweed"
 
 
+class TestLanguageEntryFromResponse:
+    """What one language's response is worth, before it reaches the file.
+
+    A response no allergen can be read from is recorded as an error rather
+    than as a language that has none, because only an error entry is fetched
+    again. An empty response and a malformed one are not told apart here: for
+    this file they are the same defect, a language with no allergen names.
+    """
+
+    def test_a_good_response_records_its_allergens(self, script):
+        entry, warnings = script.language_entry_from_response(
+            "sk",
+            {"contamination": [{"poll_title": "Trávy (Poaceae)", "poll_id": 5}]},
+        )
+
+        assert entry["lang_code"] == "sk"
+        assert entry["lang"] == "Slovak"
+        assert entry["poll_titles"] == [
+            {"name": "Trávy", "latin": "Poaceae", "poll_id": 5}
+        ]
+        assert warnings == []
+
+    def test_a_top_level_that_is_not_an_object_is_an_error_entry(self, script):
+        # An array is what an upstream error looks like, and recording it as a
+        # language with no allergens would be permanent.
+        entry, _ = script.language_entry_from_response("sk", [])
+        assert "error" in entry
+        assert "top level" in entry["error"]
+
+    @pytest.mark.parametrize("data", [[], "oops", None, 42])
+    def test_no_malformed_top_level_is_recorded_as_a_success(self, script, data):
+        entry, _ = script.language_entry_from_response("sk", data)
+        assert "error" in entry
+        assert "poll_titles" not in entry
+
+    def test_a_missing_contamination_block_is_an_error_entry(self, script):
+        entry, _ = script.language_entry_from_response("sk", {"allergyrisk": {}})
+        assert "error" in entry
+
+    def test_an_empty_contamination_block_is_an_error_entry(self, script):
+        entry, _ = script.language_entry_from_response("sk", {"contamination": []})
+        assert "error" in entry
+
+    def test_a_block_of_unreadable_entries_is_an_error_entry(self, script):
+        entry, warnings = script.language_entry_from_response(
+            "sk", {"contamination": ["oops", "also oops"]}
+        )
+        assert "error" in entry
+        assert len(warnings) == 2
+
+    def test_a_readable_entry_beside_an_unreadable_one_is_kept(self, script):
+        entry, warnings = script.language_entry_from_response(
+            "sk",
+            {
+                "contamination": [
+                    "oops",
+                    {"poll_title": "Trávy (Poaceae)", "poll_id": 5},
+                ]
+            },
+        )
+        assert [poll["latin"] for poll in entry["poll_titles"]] == ["Poaceae"]
+        assert len(warnings) == 1
+
+
+class TestNeedsFetch:
+    """Which languages the next run goes back for."""
+
+    def test_a_language_that_is_not_there_is_fetched(self, script):
+        assert script.needs_fetch({}, "sk")
+
+    def test_a_recorded_language_is_not_refetched(self, script):
+        db = {"sk": {"lang_code": "sk", "poll_titles": []}}
+        assert not script.needs_fetch(db, "sk")
+
+    def test_an_error_entry_is_retried(self, script):
+        db = {"sk": {"lang_code": "sk", "error": "request error: timeout"}}
+        assert script.needs_fetch(db, "sk")
+
+    def test_a_malformed_response_is_retried_on_the_next_run(self, script):
+        # The two halves together: a response that cannot be read is recorded
+        # as an error, and an error is what the next run comes back for.
+        entry, _ = script.language_entry_from_response("sk", [])
+        assert script.needs_fetch({"sk": entry}, "sk")
+
+    def test_a_language_that_is_not_an_object_is_refetched(self, script):
+        assert script.needs_fetch({"sk": "oops"}, "sk")
+
+
 class TestRepairDb:
     """The offline pass that lets an already recorded entry correct itself."""
 

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -119,6 +119,22 @@ class TestResolveLatin:
         assert len(warnings) == 1
         assert "Keeping it" in warnings[0]
 
+    def test_a_blank_display_name_is_kept_and_warned_about(self, script):
+        # "(Poaceae)" names its allergen, so dropping it would be the mistake,
+        # but the file holds half a pairing and that is worth reporting.
+        latin, warnings = script.resolve_latin("", "Poaceae")
+
+        assert latin == "Poaceae"
+        assert len(warnings) == 1
+        assert "no display name" in warnings[0]
+        assert "Poaceae" in warnings[0]
+
+    def test_a_blank_name_beside_a_spelling_fix_warns_about_both(self, script):
+        latin, warnings = script.resolve_latin("", "poaceae")
+
+        assert latin == "Poaceae"
+        assert len(warnings) == 2
+
     def test_unknown_latin_is_kept_as_sent_and_warned_about(self, script):
         latin, warnings = script.resolve_latin("Nässlor", "Nonexistentia")
         assert latin == "Nonexistentia"
@@ -193,6 +209,15 @@ class TestPollTitlesFromContamination:
         )
         assert len(poll_titles) == 1
         assert len(warnings) == 1
+
+    def test_a_title_that_is_only_a_latin_name_is_kept(self, script):
+        poll_titles, warnings = script.poll_titles_from_contamination(
+            [{"poll_title": "(Poaceae)", "poll_id": 5}]
+        )
+
+        assert poll_titles == [{"name": "", "latin": "Poaceae", "poll_id": 5}]
+        assert len(warnings) == 1
+        assert "no display name" in warnings[0]
 
     def test_display_names_are_kept_as_the_api_sent_them(self, script):
         poll_titles, _ = script.poll_titles_from_contamination(

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -228,6 +228,13 @@ class TestLanguageEntryFromResponse:
         entry, _ = script.language_entry_from_response("sk", {"contamination": []})
         assert "error" in entry
 
+    def test_a_contamination_block_that_is_not_a_list_is_an_error_entry(self, script):
+        entry, warnings = script.language_entry_from_response(
+            "sk", {"contamination": "oops"}
+        )
+        assert "error" in entry
+        assert len(warnings) == 1
+
     def test_a_block_of_unreadable_entries_is_an_error_entry(self, script):
         entry, warnings = script.language_entry_from_response(
             "sk", {"contamination": ["oops", "also oops"]}

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -1090,6 +1090,11 @@ class TestTheFileAndTheRuntimeAgree:
             # read the empty brackets as a latin name it could not place and
             # resolve to nothing, while the file recorded Artemisia.
             "Artemisia ()",
+            # An opening bracket and no closing one. The two parses differed
+            # on exactly this: the runtime split at the bracket and read
+            # mugwort, the generator kept the title whole and read nothing.
+            "Artemisia (",
+            "Artemisia (   )",
         ],
     )
     def test_both_sides_resolve_the_same_input_the_same_way(self, script, poll_title):
@@ -1118,6 +1123,12 @@ class TestTheFileAndTheRuntimeAgree:
     def test_empty_brackets_resolve_to_the_display_name_on_both_sides(self, script):
         assert self._runtime_allergen("Artemisia ()") == "mugwort"
         assert self._recorded_allergen(script, "Artemisia ()") == "mugwort"
+
+    def test_an_unmatched_bracket_resolves_to_the_display_name_on_both_sides(
+        self, script
+    ):
+        assert self._runtime_allergen("Artemisia (") == "mugwort"
+        assert self._recorded_allergen(script, "Artemisia (") == "mugwort"
 
 
 class TestShippedLanguageMap:

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -226,6 +226,30 @@ class TestPollTitlesFromContamination:
         assert poll_titles[0]["name"] == "Ragweed"
 
 
+class TestUnreadableEntryWarning:
+    """The one path in this script that destroys something says so first."""
+
+    @pytest.mark.parametrize("entry", ["oops", 42, ["sk"], True])
+    def test_an_entry_that_cannot_be_read_is_announced(self, script, entry):
+        warning = script.unreadable_entry_warning({"sk": entry}, "sk")
+
+        assert warning is not None
+        assert "overwriting" in warning
+        # It is refetched, which is the behaviour being announced.
+        assert script.needs_fetch({"sk": entry}, "sk")
+
+    def test_a_language_that_is_absent_says_nothing(self, script):
+        assert script.unreadable_entry_warning({}, "sk") is None
+
+    def test_an_error_entry_says_nothing(self, script):
+        db = {"sk": {"lang_code": "sk", "error": "request error: timeout"}}
+        assert script.unreadable_entry_warning(db, "sk") is None
+
+    def test_a_good_entry_says_nothing(self, script):
+        db = {"sk": {"lang_code": "sk", "poll_titles": []}}
+        assert script.unreadable_entry_warning(db, "sk") is None
+
+
 class TestLanguageEntryFromResponse:
     """What one language's response is worth, before it reaches the file.
 

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -581,6 +581,30 @@ class TestRunFetchWritesThroughTheRetryRule:
         assert "retry_error" not in db["sk"]
         assert not script.needs_fetch(db, "sk")
 
+    def test_a_poorer_retry_keeps_the_names_it_did_not_read(
+        self, script, monkeypatch, tmp_path
+    ):
+        # Codex's case, driven through the write: three allergens on disk, a
+        # retry that reads one and loses another to a malformed entry.
+        payload = {
+            "contamination": [
+                {"poll_title": "Traviny (Poaceae)", "poll_id": 5},
+                {"poll_title": "()", "poll_id": 2},
+            ]
+        }
+        db = self._run(
+            script,
+            monkeypatch,
+            tmp_path,
+            {"sk": RICHER_PREVIOUS},
+            self._answer(payload),
+        )
+        by_id = {poll["poll_id"]: poll["name"] for poll in db["sk"]["poll_titles"]}
+
+        assert by_id == {5: "Traviny", 2: "Breza", 1: "Jelša"}
+        assert db["sk"]["incomplete"] is True
+        assert script.needs_fetch(db, "sk")
+
     def test_a_language_with_nothing_to_lose_records_the_error(
         self, script, monkeypatch, tmp_path
     ):
@@ -591,6 +615,111 @@ class TestRunFetchWritesThroughTheRetryRule:
 
         assert "error" in db["sk"]
         assert "poll_titles" not in db["sk"]
+
+
+# The same language after a retry that read one allergen and lost another.
+RICHER_PREVIOUS = {
+    "lang_code": "sk",
+    "lang": "Slovak",
+    "poll_titles": [
+        {"name": "Trávy", "latin": "Poaceae", "poll_id": 5},
+        {"name": "Breza", "latin": "Betula", "poll_id": 2},
+        {"name": "Jelša", "latin": "Alnus", "poll_id": 1},
+    ],
+    "incomplete": True,
+}
+
+
+POORER_RETRY = {
+    "lang_code": "sk",
+    "lang": "Slovak",
+    "poll_titles": [{"name": "Traviny", "latin": "Poaceae", "poll_id": 5}],
+    "incomplete": True,
+}
+
+
+class TestAPoorerRetryIsMergedPerAllergen:
+    """The success-but-poorer path, which is the same invariant as the failure.
+
+    A retry that is itself incomplete has read some allergens and lost
+    others. Every name it read is the newer one and wins; every allergen it
+    did not read keeps the name the file already had. Wholesale comparison is
+    wrong in both directions: keeping the old entry for having more names
+    throws away a name the API has just corrected, and taking the new one for
+    being newer drops ten names to gain one.
+    """
+
+    def test_the_names_the_retry_lost_are_kept(self, script):
+        got = script.entry_after_retry(RICHER_PREVIOUS, POORER_RETRY)
+
+        assert {poll["poll_id"] for poll in got["poll_titles"]} == {5, 2, 1}
+
+    def test_the_name_the_retry_read_is_the_new_one(self, script):
+        got = script.entry_after_retry(RICHER_PREVIOUS, POORER_RETRY)
+        by_id = {poll["poll_id"]: poll["name"] for poll in got["poll_titles"]}
+
+        # Fresher for the allergen it read, kept for the two it did not.
+        assert by_id[5] == "Traviny"
+        assert by_id[2] == "Breza"
+        assert by_id[1] == "Jelša"
+
+    def test_no_allergen_is_recorded_twice(self, script):
+        got = script.entry_after_retry(RICHER_PREVIOUS, POORER_RETRY)
+        keys = [poll["poll_id"] for poll in got["poll_titles"]]
+
+        assert len(keys) == len(set(keys))
+
+    def test_a_corrected_latin_name_replaces_rather_than_duplicates(self, script):
+        # Keyed on poll_id, so the same allergen under a corrected spelling is
+        # the same allergen. Keying on the latin name would file it twice.
+        poorer = {
+            "lang_code": "sk",
+            "lang": "Slovak",
+            "poll_titles": [{"name": "Trávy", "latin": "Poaceae", "poll_id": 5}],
+            "incomplete": True,
+        }
+        previous = {
+            "lang_code": "sk",
+            "poll_titles": [{"name": "Trávy", "latin": "poaceae", "poll_id": 5}],
+            "incomplete": True,
+        }
+        got = script.entry_after_retry(previous, poorer)
+
+        assert got["poll_titles"] == poorer["poll_titles"]
+
+    def test_the_merged_entry_stays_retryable(self, script):
+        got = script.entry_after_retry(RICHER_PREVIOUS, POORER_RETRY)
+
+        assert got["incomplete"] is True
+        assert script.needs_fetch({"sk": got}, "sk")
+
+    def test_a_clean_retry_replaces_the_entry_outright(self, script):
+        # What bounds the merge: an allergen that has genuinely left the API
+        # for this language is gone from the file on the first response that
+        # reads cleanly, and only then.
+        clean = {
+            "lang_code": "sk",
+            "lang": "Slovak",
+            "poll_titles": [{"name": "Traviny", "latin": "Poaceae", "poll_id": 5}],
+        }
+        got = script.entry_after_retry(RICHER_PREVIOUS, clean)
+
+        assert got == clean
+        assert not script.needs_fetch({"sk": got}, "sk")
+
+    def test_an_entry_without_a_poll_id_is_kept_by_its_latin_name(self, script):
+        previous = {
+            "lang_code": "sk",
+            "poll_titles": [{"name": "Breza", "latin": "Betula", "poll_id": None}],
+            "incomplete": True,
+        }
+        got = script.entry_after_retry(previous, POORER_RETRY)
+
+        assert {poll["latin"] for poll in got["poll_titles"]} == {"Poaceae", "Betula"}
+
+    def test_a_first_fetch_has_nothing_to_merge(self, script):
+        assert script.entry_after_retry(None, POORER_RETRY) == POORER_RETRY
+        assert script.entry_after_retry({"error": "x"}, POORER_RETRY) == POORER_RETRY
 
 
 class TestNeedsFetch:

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -56,6 +56,11 @@ class TestSplitPollTitle:
     def test_empty_title(self, script):
         assert script.split_poll_title("") == ("", "")
 
+    @pytest.mark.parametrize("poll_title", [None, 123, ["Ragweed"], {"a": 1}])
+    def test_a_title_that_is_not_a_string_reads_as_empty(self, script, poll_title):
+        # Raising here would cost the language its other allergens.
+        assert script.split_poll_title(poll_title) == ("", "")
+
 
 class TestResolveLatin:
     """The validation step, over the shapes the API actually sends."""
@@ -147,6 +152,31 @@ class TestPollTitlesFromContamination:
         ]
         # One warning each for the two repairs and the unknown allergen.
         assert len(warnings) == 3
+
+    def test_one_malformed_entry_does_not_cost_the_others(self, script):
+        contamination = [
+            {"poll_title": "Trávy (Poaceae)", "poll_id": 5},
+            {"poll_title": 123, "poll_id": 6},
+            {"poll_title": "Breza (Betula)", "poll_id": 2},
+        ]
+        poll_titles, warnings = script.poll_titles_from_contamination(contamination)
+
+        assert [entry["poll_id"] for entry in poll_titles] == [5, 6, 2]
+        assert [entry["latin"] for entry in poll_titles] == ["Poaceae", "", "Betula"]
+        assert len(warnings) == 1
+
+    @pytest.mark.parametrize("contamination", ["oops", None, {"poll_title": "x"}])
+    def test_a_block_that_is_not_a_list_is_reported(self, script, contamination):
+        poll_titles, warnings = script.poll_titles_from_contamination(contamination)
+        assert poll_titles == []
+        assert len(warnings) == 1
+
+    def test_an_entry_that_is_not_an_object_is_reported(self, script):
+        poll_titles, warnings = script.poll_titles_from_contamination(
+            [{"poll_title": "Trávy (Poaceae)", "poll_id": 5}, "oops"]
+        )
+        assert len(poll_titles) == 1
+        assert len(warnings) == 1
 
     def test_display_names_are_kept_as_the_api_sent_them(self, script):
         poll_titles, _ = script.poll_titles_from_contamination(
@@ -258,6 +288,25 @@ class TestRepairDb:
     def test_tolerates_an_error_entry(self, script):
         db = {"tr": {"lang_code": "tr", "error": "request error: timeout"}}
         assert script.repair_db(db) == ([], [])
+
+    @pytest.mark.parametrize(
+        "db",
+        [
+            {"x": {"poll_titles": [{"name": None, "latin": "Nonexistentia"}]}},
+            {"x": {"poll_titles": [{"name": "Trávy", "latin": None}]}},
+            {"x": {"poll_titles": ["oops"]}},
+            {"x": {"poll_titles": "oops"}},
+            {"x": "oops"},
+        ],
+    )
+    def test_reports_a_shape_it_did_not_expect_instead_of_raising(self, script, db):
+        # --repair is the tool you reach for when the file is wrong, so a
+        # wrong file has to come back as a warning naming the language.
+        changes, warnings = script.repair_db(db)
+
+        assert changes == []
+        assert len(warnings) == 1
+        assert warnings[0].startswith("x: ")
 
 
 class TestShippedLanguageMap:

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -361,7 +361,48 @@ class TestLanguageEntryFromResponse:
             },
         )
         assert [poll["latin"] for poll in entry["poll_titles"]] == ["Poaceae"]
-        assert len(warnings) == 1
+        # One for the entry that was dropped, one for the language being left
+        # incomplete because of it.
+        assert len(warnings) == 2
+
+    def test_a_response_that_lost_an_entry_is_marked_incomplete(self, script):
+        entry, warnings = script.language_entry_from_response(
+            "sk",
+            {
+                "contamination": [
+                    {"poll_title": "Trávy (Poaceae)", "poll_id": 5},
+                    {"poll_title": "()", "poll_id": 6},
+                ]
+            },
+        )
+
+        assert entry["incomplete"] is True
+        assert [poll["latin"] for poll in entry["poll_titles"]] == ["Poaceae"]
+        assert any("incomplete" in w for w in warnings)
+
+    def test_an_incomplete_language_is_fetched_again(self, script):
+        # The property that matters: nothing else would ever come back for the
+        # entry that was lost, since a saved language is skipped and --repair
+        # cannot invent an entry that was never recorded.
+        entry, _ = script.language_entry_from_response(
+            "sk",
+            {
+                "contamination": [
+                    {"poll_title": "Trávy (Poaceae)", "poll_id": 5},
+                    {"poll_title": "()", "poll_id": 6},
+                ]
+            },
+        )
+
+        assert script.needs_fetch({"sk": entry}, "sk")
+
+    def test_a_complete_response_is_not_marked(self, script):
+        entry, _ = script.language_entry_from_response(
+            "sk", {"contamination": [{"poll_title": "Trávy (Poaceae)", "poll_id": 5}]}
+        )
+
+        assert "incomplete" not in entry
+        assert not script.needs_fetch({"sk": entry}, "sk")
 
 
 class TestNeedsFetch:
@@ -373,6 +414,10 @@ class TestNeedsFetch:
     def test_a_recorded_language_is_not_refetched(self, script):
         db = {"sk": {"lang_code": "sk", "poll_titles": []}}
         assert not script.needs_fetch(db, "sk")
+
+    def test_an_incomplete_entry_is_retried(self, script):
+        db = {"sk": {"lang_code": "sk", "poll_titles": [], "incomplete": True}}
+        assert script.needs_fetch(db, "sk")
 
     def test_an_error_entry_is_retried(self, script):
         db = {"sk": {"lang_code": "sk", "error": "request error: timeout"}}

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -1,0 +1,213 @@
+"""Tests for scripts/generate_language_codes.py.
+
+The script is not importable as a module (scripts/ is not a package and the
+file name is not an identifier we import anywhere), so it is loaded from its
+path. Loading it must stay free of side effects: it may not read API_KEY or
+import requests at import time, which is why those live inside run_fetch.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "generate_language_codes.py"
+LANGUAGE_MAP = (
+    REPO_ROOT / "custom_components" / "polleninformation" / "language_map.json"
+)
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location(
+        "generate_language_codes", SCRIPT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def script():
+    """The generator, loaded from its path."""
+    return _load_script()
+
+
+class TestSplitPollTitle:
+    """The transcription step: what the API sent, split in two."""
+
+    def test_name_with_latin_in_brackets(self, script):
+        assert script.split_poll_title("Ragweed (Ambrosia)") == (
+            "Ragweed",
+            "Ambrosia",
+        )
+
+    def test_localized_word_in_brackets_is_transcribed_as_sent(self, script):
+        # The split does not judge; resolve_latin does.
+        assert script.split_poll_title("Ragweed (ambrózia)") == (
+            "Ragweed",
+            "ambrózia",
+        )
+
+    def test_bare_name_has_no_latin(self, script):
+        assert script.split_poll_title("Artemisia") == ("Artemisia", "")
+
+    def test_empty_title(self, script):
+        assert script.split_poll_title("") == ("", "")
+
+
+class TestResolveLatin:
+    """The validation step, over the shapes the API actually sends."""
+
+    def test_known_latin_is_kept_without_a_warning(self, script):
+        assert script.resolve_latin("Trávy", "Poaceae") == ("Poaceae", [])
+
+    def test_genus_and_species_is_kept(self, script):
+        latin, warnings = script.resolve_latin("Ambrosia", "Ambrosia artemisiifolia")
+        assert latin == "Ambrosia artemisiifolia"
+        assert warnings == []
+
+    def test_localized_word_in_brackets_is_replaced_from_the_display_name(self, script):
+        # The sk shape: the API put a Slovak word where the latin name goes,
+        # and left the display name in English.
+        latin, warnings = script.resolve_latin("Ragweed", "ambrózia")
+        assert latin == "Ambrosia"
+        assert len(warnings) == 1
+        assert "ambrózia" in warnings[0]
+
+    def test_display_name_that_is_a_latin_name_supplies_the_missing_latin(self, script):
+        # The es shape, and the shape reported in issue #71.
+        latin, warnings = script.resolve_latin("Artemisia", "")
+        assert latin == "Artemisia"
+        assert len(warnings) == 1
+        assert "Artemisia" in warnings[0]
+
+    def test_unknown_latin_is_kept_as_sent_and_warned_about(self, script):
+        latin, warnings = script.resolve_latin("Nässlor", "Nonexistentia")
+        assert latin == "Nonexistentia"
+        assert len(warnings) == 1
+        assert "please open an issue" in warnings[0]
+
+    def test_unknown_allergen_without_a_latin_is_warned_about(self, script):
+        latin, warnings = script.resolve_latin("Något nytt", "")
+        assert latin == ""
+        assert len(warnings) == 1
+        assert "no latin name" in warnings[0]
+
+
+class TestPollTitlesFromContamination:
+    """Nothing the API sends is ever dropped."""
+
+    def test_every_entry_is_recorded(self, script):
+        contamination = [
+            {"poll_title": "Trávy (Poaceae)", "poll_id": 5},
+            {"poll_title": "Ragweed (ambrózia)", "poll_id": 6},
+            {"poll_title": "Artemisia", "poll_id": 7},
+            {"poll_title": "Något nytt (Nonexistentia)", "poll_id": 999},
+        ]
+        poll_titles, warnings = script.poll_titles_from_contamination(contamination)
+
+        assert [entry["poll_id"] for entry in poll_titles] == [5, 6, 7, 999]
+        assert [entry["latin"] for entry in poll_titles] == [
+            "Poaceae",
+            "Ambrosia",
+            "Artemisia",
+            "Nonexistentia",
+        ]
+        # One warning each for the two repairs and the unknown allergen.
+        assert len(warnings) == 3
+
+    def test_display_names_are_kept_as_the_api_sent_them(self, script):
+        poll_titles, _ = script.poll_titles_from_contamination(
+            [{"poll_title": "Ragweed (ambrózia)", "poll_id": 6}]
+        )
+        assert poll_titles[0]["name"] == "Ragweed"
+
+
+class TestRepairDb:
+    """The offline pass that lets an already recorded entry correct itself."""
+
+    def test_repairs_the_two_shipped_shapes(self, script):
+        db = {
+            "sk": {
+                "lang_code": "sk",
+                "poll_titles": [
+                    {"name": "Trávy", "latin": "Poaceae", "poll_id": 5},
+                    {"name": "Ragweed", "latin": "ambrózia", "poll_id": 6},
+                ],
+            },
+            "es": {
+                "lang_code": "es",
+                "poll_titles": [
+                    {"name": "Artemisia", "latin": "", "poll_id": 7},
+                ],
+            },
+        }
+        changes, warnings = script.repair_db(db)
+
+        assert db["sk"]["poll_titles"][1]["latin"] == "Ambrosia"
+        assert db["es"]["poll_titles"][0]["latin"] == "Artemisia"
+        assert len(changes) == 2
+        assert len(warnings) == 2
+
+    def test_leaves_a_clean_db_untouched(self, script):
+        db = {
+            "en": {
+                "lang_code": "en",
+                "poll_titles": [{"name": "grasses", "latin": "Poaceae", "poll_id": 5}],
+            }
+        }
+        changes, warnings = script.repair_db(db)
+
+        assert changes == []
+        assert warnings == []
+        assert db["en"]["poll_titles"][0]["latin"] == "Poaceae"
+
+    def test_is_idempotent(self, script):
+        db = {
+            "sk": {
+                "lang_code": "sk",
+                "poll_titles": [{"name": "Ragweed", "latin": "ambrózia"}],
+            }
+        }
+        script.repair_db(db)
+        changes, _ = script.repair_db(db)
+
+        assert changes == []
+
+    def test_keeps_an_unknown_allergen_and_warns_again(self, script):
+        db = {
+            "sv": {
+                "lang_code": "sv",
+                "poll_titles": [{"name": "Något nytt", "latin": "Nonexistentia"}],
+            }
+        }
+        changes, warnings = script.repair_db(db)
+
+        assert changes == []
+        assert len(warnings) == 1
+        assert db["sv"]["poll_titles"][0]["latin"] == "Nonexistentia"
+
+    def test_tolerates_an_error_entry(self, script):
+        db = {"tr": {"lang_code": "tr", "error": "request error: timeout"}}
+        assert script.repair_db(db) == ([], [])
+
+
+class TestShippedLanguageMap:
+    """The file itself, as shipped."""
+
+    def test_every_recorded_latin_name_is_recognized(self, script):
+        db = json.loads(LANGUAGE_MAP.read_text(encoding="utf-8"))
+        unrecognized = [
+            (lang_code, entry["name"], entry["latin"])
+            for lang_code, block in db.items()
+            for entry in block.get("poll_titles", [])
+            if not script.english_name_for_latin(entry["latin"])
+        ]
+        assert unrecognized == []
+
+    def test_needs_no_repair(self, script):
+        db = json.loads(LANGUAGE_MAP.read_text(encoding="utf-8"))
+        changes, warnings = script.repair_db(db)
+        assert (changes, warnings) == ([], [])

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -83,6 +83,28 @@ class TestResolveLatin:
         assert len(warnings) == 1
         assert "Artemisia" in warnings[0]
 
+    def test_a_latin_the_api_sent_outranks_a_latin_display_name(self, script):
+        # "Artemisia (Asteraceae)" is the composite family, not mugwort. The
+        # display name may only be read as a latin name when the API sent
+        # none, exactly as the setup path in sensor.py has it.
+        latin, warnings = script.resolve_latin("Artemisia", "Asteraceae")
+        assert latin == "Asteraceae"
+        assert len(warnings) == 1
+        assert "Keeping it" in warnings[0]
+
+    def test_a_latin_the_api_sent_outranks_an_english_display_name(self, script):
+        # The same rule for the English-name lookup: "Asteraceae" could be a
+        # scientific name, so it identifies the allergen whatever the display
+        # name says.
+        latin, warnings = script.resolve_latin("Ragweed", "Asteraceae")
+        assert latin == "Asteraceae"
+        assert len(warnings) == 1
+        assert "Keeping it" in warnings[0]
+
+    def test_a_hybrid_name_the_map_does_not_know_is_kept(self, script):
+        latin, _ = script.resolve_latin("Ragweed", "Asteraceae × nova")
+        assert latin == "Asteraceae × nova"
+
     def test_unknown_latin_is_kept_as_sent_and_warned_about(self, script):
         latin, warnings = script.resolve_latin("Nässlor", "Nonexistentia")
         assert latin == "Nonexistentia"
@@ -94,6 +116,26 @@ class TestResolveLatin:
         assert latin == ""
         assert len(warnings) == 1
         assert "no latin name" in warnings[0]
+
+
+class TestCouldBeAScientificName:
+    """What tells a latin name the map does not know from a localized word.
+
+    This is the whole safety argument for the English-name lookup: it may
+    only override what the API put between the brackets when that string
+    cannot be a scientific name whatever it names.
+    """
+
+    @pytest.mark.parametrize(
+        "latin",
+        ["Asteraceae", "Ambrosia artemisiifolia", "Ambrosia × helenae", "Poaceae"],
+    )
+    def test_latin_names_could_be_one(self, script, latin):
+        assert script.could_be_a_scientific_name(latin)
+
+    @pytest.mark.parametrize("latin", ["ambrózia", "Амброзия", "パセリ", "", "räven"])
+    def test_a_localized_word_could_not(self, script, latin):
+        assert not script.could_be_a_scientific_name(latin)
 
 
 class TestPollTitlesFromContamination:
@@ -188,6 +230,42 @@ class TestRepairDb:
         assert changes == []
         assert len(warnings) == 1
         assert db["sv"]["poll_titles"][0]["latin"] == "Nonexistentia"
+
+    def test_keeps_a_latin_the_api_sent_that_no_map_knows(self, script):
+        # The repair rewrites a file we ship, so an entry the API recorded
+        # correctly must survive it. Reading "Artemisia" as the latin name
+        # here would record the composite family as mugwort, and the next
+        # repair run would then confirm that as correct.
+        db = {
+            "de": {
+                "lang_code": "de",
+                "poll_titles": [
+                    {"name": "Artemisia", "latin": "Asteraceae", "poll_id": 300}
+                ],
+            }
+        }
+        changes, warnings = script.repair_db(db)
+
+        assert changes == []
+        assert db["de"]["poll_titles"][0]["latin"] == "Asteraceae"
+        assert len(warnings) == 1
+
+    def test_a_correctly_recorded_entry_survives_a_round_trip(self, script):
+        db = {
+            "de": {
+                "lang_code": "de",
+                "poll_titles": [
+                    {"name": "Gräser", "latin": "Poaceae", "poll_id": 5},
+                    {"name": "Artemisia", "latin": "Asteraceae", "poll_id": 300},
+                ],
+            }
+        }
+        before = json.dumps(db, sort_keys=True)
+
+        script.repair_db(db)
+        script.repair_db(db)
+
+        assert json.dumps(db, sort_keys=True) == before
 
     def test_tolerates_an_error_entry(self, script):
         db = {"tr": {"lang_code": "tr", "error": "request error: timeout"}}

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -184,18 +184,49 @@ class TestPollTitlesFromContamination:
 
     @pytest.mark.parametrize(
         "poll",
-        [{"poll_id": 6}, {"poll_title": 123}, {"poll_title": ""}, {"poll_title": "  "}],
+        [
+            # Nothing to read at all.
+            {"poll_id": 6},
+            {"poll_title": 123},
+            {"poll_title": ""},
+            {"poll_title": "  "},
+            # A non-blank title with nothing in either half of it, which
+            # identifies an allergen exactly as little as the four above.
+            {"poll_title": "()"},
+            {"poll_title": "( )"},
+            {"poll_title": "  (  )  "},
+            {"poll_title": "()extra"},
+        ],
     )
-    def test_an_entry_with_no_readable_title_is_skipped(self, script, poll):
-        # An unknown latin name still names a real allergen and is kept. A
-        # title that cannot be read names nothing, so recording it would
-        # manufacture a blank allergen and make an unreadable block look like
-        # a language that has some.
+    def test_an_entry_that_identifies_nothing_is_skipped(self, script, poll):
+        # An unknown latin name still names a real allergen and is kept. An
+        # entry with neither a display name nor a latin name names nothing, so
+        # recording it would manufacture a blank allergen and make a block of
+        # them look like a language that has some.
         poll_titles, warnings = script.poll_titles_from_contamination([poll])
 
         assert poll_titles == []
         assert len(warnings) == 1
-        assert "no readable title" in warnings[0]
+        assert "identifies no allergen" in warnings[0]
+
+    @pytest.mark.parametrize(
+        ("poll_title", "expected"),
+        [
+            ("(Poaceae)", {"name": "", "latin": "Poaceae"}),
+            ("Trávy", {"name": "Trávy", "latin": ""}),
+            ("Trávy (Poaceae)", {"name": "Trávy", "latin": "Poaceae"}),
+        ],
+    )
+    def test_either_half_alone_is_enough_to_be_kept(self, script, poll_title, expected):
+        # The rule is what the entry identifies, so one half is enough: a
+        # latin name with no display name is an allergen this language has no
+        # word for, and a display name with no latin name is one we may not be
+        # able to classify. Both are kept.
+        poll_titles, _ = script.poll_titles_from_contamination(
+            [{"poll_title": poll_title, "poll_id": 5}]
+        )
+
+        assert poll_titles == [{**expected, "poll_id": 5}]
 
     @pytest.mark.parametrize("contamination", ["oops", None, {"poll_title": "x"}])
     def test_a_block_that_is_not_a_list_is_reported(self, script, contamination):
@@ -308,7 +339,7 @@ class TestLanguageEntryFromResponse:
         assert len(warnings) == 2
 
     def test_a_block_of_title_less_entries_is_an_error_entry(self, script):
-        # The chain end to end: every entry is skipped for want of a title,
+        # The chain end to end: every entry is skipped for naming nothing,
         # which leaves no allergens, which is an error entry, which
         # needs_fetch comes back for.
         entry, warnings = script.language_entry_from_response(

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -307,6 +307,21 @@ class TestNeedsFetch:
         assert script.needs_fetch({"sk": "oops"}, "sk")
 
 
+class TestRepairDbRoot:
+    """The level above the per-language checks: the file's own root."""
+
+    @pytest.mark.parametrize("db", [["sk"], "oops", 42, True])
+    def test_a_root_that_is_not_an_object_is_reported(self, script, db):
+        changes, warnings = script.repair_db(db)
+
+        assert changes == []
+        assert len(warnings) == 1
+        assert "root" in warnings[0]
+
+    def test_an_empty_root_is_not_a_complaint(self, script):
+        assert script.repair_db({}) == ([], [])
+
+
 class TestRepairDb:
     """The offline pass that lets an already recorded entry correct itself."""
 

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -290,6 +290,27 @@ class TestRepairDb:
         assert script.repair_db(db) == ([], [])
 
     @pytest.mark.parametrize(
+        "poll",
+        [
+            {"name": "Trávy", "latin": 5},
+            {"name": 5, "latin": ""},
+            {"name": ["Trávy"], "latin": "Poaceae"},
+        ],
+    )
+    def test_a_scalar_that_is_not_a_string_does_not_abort_the_run(self, script, poll):
+        # canonical_latin strips, so a truthy non-string used to raise and
+        # take every remaining language with it.
+        db = {"x": {"poll_titles": [poll, {"name": "Breza", "latin": "Betula"}]}}
+        changes, warnings = script.repair_db(db)
+
+        assert changes == []
+        assert len(warnings) == 1
+        assert warnings[0].startswith("x: ")
+        # The entry is left exactly as it was: a defect is reported, never
+        # quietly rewritten into a well-formed record.
+        assert db["x"]["poll_titles"][0] == poll
+
+    @pytest.mark.parametrize(
         "db",
         [
             {"x": {"poll_titles": [{"name": None, "latin": "Nonexistentia"}]}},

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -161,9 +161,24 @@ class TestPollTitlesFromContamination:
         ]
         poll_titles, warnings = script.poll_titles_from_contamination(contamination)
 
-        assert [entry["poll_id"] for entry in poll_titles] == [5, 6, 2]
-        assert [entry["latin"] for entry in poll_titles] == ["Poaceae", "", "Betula"]
+        assert [entry["poll_id"] for entry in poll_titles] == [5, 2]
+        assert [entry["latin"] for entry in poll_titles] == ["Poaceae", "Betula"]
         assert len(warnings) == 1
+
+    @pytest.mark.parametrize(
+        "poll",
+        [{"poll_id": 6}, {"poll_title": 123}, {"poll_title": ""}, {"poll_title": "  "}],
+    )
+    def test_an_entry_with_no_readable_title_is_skipped(self, script, poll):
+        # An unknown latin name still names a real allergen and is kept. A
+        # title that cannot be read names nothing, so recording it would
+        # manufacture a blank allergen and make an unreadable block look like
+        # a language that has some.
+        poll_titles, warnings = script.poll_titles_from_contamination([poll])
+
+        assert poll_titles == []
+        assert len(warnings) == 1
+        assert "no readable title" in warnings[0]
 
     @pytest.mark.parametrize("contamination", ["oops", None, {"poll_title": "x"}])
     def test_a_block_that_is_not_a_list_is_reported(self, script, contamination):
@@ -241,6 +256,18 @@ class TestLanguageEntryFromResponse:
         )
         assert "error" in entry
         assert len(warnings) == 2
+
+    def test_a_block_of_title_less_entries_is_an_error_entry(self, script):
+        # The chain end to end: every entry is skipped for want of a title,
+        # which leaves no allergens, which is an error entry, which
+        # needs_fetch comes back for.
+        entry, warnings = script.language_entry_from_response(
+            "sk", {"contamination": [{"poll_id": 5}, {"poll_id": 6}]}
+        )
+
+        assert "error" in entry
+        assert len(warnings) == 2
+        assert script.needs_fetch({"sk": entry}, "sk")
 
     def test_a_readable_entry_beside_an_unreadable_one_is_kept(self, script):
         entry, warnings = script.language_entry_from_response(

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -63,10 +63,18 @@ class TestResolveLatin:
     def test_known_latin_is_kept_without_a_warning(self, script):
         assert script.resolve_latin("Trávy", "Poaceae") == ("Poaceae", [])
 
-    def test_genus_and_species_is_kept(self, script):
+    def test_genus_and_species_is_recorded_as_the_genus(self, script):
+        # Every consumer of this file matches a latin name exactly, and the
+        # one the restore path holds is the map's own key.
         latin, warnings = script.resolve_latin("Ambrosia", "Ambrosia artemisiifolia")
-        assert latin == "Ambrosia artemisiifolia"
-        assert warnings == []
+        assert latin == "Ambrosia"
+        assert len(warnings) == 1
+
+    @pytest.mark.parametrize("sent", ["poaceae", " Poaceae ", "POACEAE"])
+    def test_a_recognized_latin_is_recorded_under_the_map_key(self, script, sent):
+        latin, warnings = script.resolve_latin("Trávy", sent)
+        assert latin == "Poaceae"
+        assert len(warnings) == 1
 
     def test_a_declared_alias_is_recorded_as_the_name_it_stands_for(self, script):
         # The sk shape: the API put the Slovak word for ragweed where the
@@ -261,7 +269,7 @@ class TestShippedLanguageMap:
             (lang_code, entry["name"], entry["latin"])
             for lang_code, block in db.items()
             for entry in block.get("poll_titles", [])
-            if not script.english_name_for_latin(entry["latin"])
+            if not script.canonical_latin(entry["latin"])
         ]
         assert unrecognized == []
 

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -8,6 +8,8 @@ import requests at import time, which is why those live inside run_fetch.
 
 import importlib.util
 import json
+import sys
+import types
 from pathlib import Path
 from unittest.mock import patch
 
@@ -409,6 +411,186 @@ class TestLanguageEntryFromResponse:
 
         assert "incomplete" not in entry
         assert not script.needs_fetch({"sk": entry}, "sk")
+
+
+# A language the file already holds names for, marked for another try. What a
+# failed retry must not be allowed to take away.
+PARTIAL_ENTRY = {
+    "lang_code": "sk",
+    "lang": "Slovak",
+    "poll_titles": [{"name": "Trávy", "latin": "Poaceae", "poll_id": 5}],
+    "incomplete": True,
+}
+
+PARTIAL_DB = {"sk": PARTIAL_ENTRY}
+
+
+class TestARetryNeverImpoverishesAnEntry:
+    """A retry may improve what the file holds and may not take from it.
+
+    The incomplete marker exists because eleven localized names are worth
+    more to a sensor than none. The retry it schedules must not then do the
+    thing the marker refused: a failed or malformed retry that replaced the
+    entry with an error object would drop those names and send every allergen
+    in that language back to its English name.
+    """
+
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            {"error": "request error: timeout", "lang_code": "sk"},
+            {"error": "malformed response: no contamination block", "lang_code": "sk"},
+            {"error": "the response carries no allergens", "lang_code": "sk"},
+        ],
+    )
+    def test_a_failed_retry_keeps_the_names(self, script, failure):
+        kept = script.entry_after_retry(PARTIAL_ENTRY, failure)
+
+        assert kept["poll_titles"] == PARTIAL_ENTRY["poll_titles"]
+
+    def test_a_failed_retry_says_the_names_are_old(self, script):
+        # The record may not read as a clean partial when it is a partial
+        # plus a failure.
+        kept = script.entry_after_retry(
+            PARTIAL_ENTRY, {"error": "request error: timeout", "lang_code": "sk"}
+        )
+
+        assert "earlier fetch" in kept["retry_error"]
+        assert "request error: timeout" in kept["retry_error"]
+
+    def test_a_failed_retry_stays_retryable(self, script):
+        kept = script.entry_after_retry(
+            PARTIAL_ENTRY, {"error": "request error: timeout", "lang_code": "sk"}
+        )
+
+        assert script.needs_fetch({"sk": kept}, "sk")
+
+    def test_a_clean_retry_replaces_the_entry(self, script):
+        fresh = {
+            "lang_code": "sk",
+            "lang": "Slovak",
+            "poll_titles": [
+                {"name": "Trávy", "latin": "Poaceae", "poll_id": 5},
+                {"name": "Breza", "latin": "Betula", "poll_id": 2},
+            ],
+        }
+        got = script.entry_after_retry(PARTIAL_ENTRY, fresh)
+
+        assert got == fresh
+        assert "incomplete" not in got
+        assert "retry_error" not in got
+        assert not script.needs_fetch({"sk": got}, "sk")
+
+    @pytest.mark.parametrize(
+        "previous",
+        [
+            None,
+            "oops",
+            {"lang_code": "sk", "error": "request error: timeout"},
+            {"lang_code": "sk", "poll_titles": []},
+        ],
+    )
+    def test_nothing_to_keep_records_the_error_as_before(self, script, previous):
+        failure = {"error": "request error: timeout", "lang_code": "sk"}
+        assert script.entry_after_retry(previous, failure) == failure
+
+    def test_a_complete_entry_is_never_retried_and_so_never_clobbered(self, script):
+        # The answer to whether a transient failure can cost a COMPLETE
+        # language its names: it is not reachable, because such an entry is
+        # never fetched again. Pinned both ways, so neither half can drift.
+        complete = {
+            "lang_code": "sk",
+            "lang": "Slovak",
+            "poll_titles": [{"name": "Trávy", "latin": "Poaceae", "poll_id": 5}],
+        }
+        assert not script.needs_fetch({"sk": complete}, "sk")
+        kept = script.entry_after_retry(
+            complete, {"error": "request error: timeout", "lang_code": "sk"}
+        )
+        assert kept["poll_titles"] == complete["poll_titles"]
+
+
+class TestRunFetchWritesThroughTheRetryRule:
+    """The rule where it actually lands: the two lines that write the file.
+
+    Both failure paths in run_fetch assign to db[lang_code], and either one
+    could drop an entry's allergen names. Exercised end to end, with the
+    network and the environment stubbed, because a helper that gets this
+    right is worth nothing if the caller writes past it.
+    """
+
+    @staticmethod
+    def _run(script, monkeypatch, tmp_path, existing, responder):
+        db_file = tmp_path / "language_map.json"
+        db_file.write_text(json.dumps(existing), encoding="utf-8")
+        monkeypatch.setattr(script, "DB_FILE", str(db_file))
+        monkeypatch.setattr(script, "LANG_CODES", ["sk"])
+        monkeypatch.setattr(script, "DELAY_SEC", 0)
+        monkeypatch.setenv("API_KEY", "test-key")
+        monkeypatch.setitem(
+            sys.modules, "requests", types.SimpleNamespace(get=responder)
+        )
+        monkeypatch.setitem(
+            sys.modules, "dotenv", types.SimpleNamespace(load_dotenv=lambda **kw: None)
+        )
+        script.run_fetch()
+        return json.loads(db_file.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _answer(payload):
+        def responder(*args, **kwargs):
+            return types.SimpleNamespace(
+                raise_for_status=lambda: None, json=lambda: payload
+            )
+
+        return responder
+
+    def test_a_request_failure_keeps_the_names_on_disk(
+        self, script, monkeypatch, tmp_path
+    ):
+        def boom(*args, **kwargs):
+            raise RuntimeError("timeout")
+
+        db = self._run(script, monkeypatch, tmp_path, PARTIAL_DB, boom)
+
+        assert db["sk"]["poll_titles"] == PARTIAL_ENTRY["poll_titles"]
+        assert "earlier fetch" in db["sk"]["retry_error"]
+        assert script.needs_fetch(db, "sk")
+
+    def test_a_malformed_response_keeps_the_names_on_disk(
+        self, script, monkeypatch, tmp_path
+    ):
+        db = self._run(
+            script, monkeypatch, tmp_path, PARTIAL_DB, self._answer({"nope": 1})
+        )
+
+        assert db["sk"]["poll_titles"] == PARTIAL_ENTRY["poll_titles"]
+        assert "earlier fetch" in db["sk"]["retry_error"]
+
+    def test_a_clean_retry_replaces_what_was_there(self, script, monkeypatch, tmp_path):
+        payload = {
+            "contamination": [
+                {"poll_title": "Trávy (Poaceae)", "poll_id": 5},
+                {"poll_title": "Breza (Betula)", "poll_id": 2},
+            ]
+        }
+        db = self._run(script, monkeypatch, tmp_path, PARTIAL_DB, self._answer(payload))
+
+        assert len(db["sk"]["poll_titles"]) == 2
+        assert "incomplete" not in db["sk"]
+        assert "retry_error" not in db["sk"]
+        assert not script.needs_fetch(db, "sk")
+
+    def test_a_language_with_nothing_to_lose_records_the_error(
+        self, script, monkeypatch, tmp_path
+    ):
+        def boom(*args, **kwargs):
+            raise RuntimeError("timeout")
+
+        db = self._run(script, monkeypatch, tmp_path, {}, boom)
+
+        assert "error" in db["sk"]
+        assert "poll_titles" not in db["sk"]
 
 
 class TestNeedsFetch:

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -9,6 +9,7 @@ import requests at import time, which is why those live inside run_fetch.
 import importlib.util
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -305,6 +306,26 @@ class TestNeedsFetch:
 
     def test_a_language_that_is_not_an_object_is_refetched(self, script):
         assert script.needs_fetch({"sk": "oops"}, "sk")
+
+
+class TestLoadDb:
+    """The level above the root: the file may not be JSON at all."""
+
+    def test_a_missing_file_is_an_empty_db(self, script, tmp_path):
+        with patch.object(script, "DB_FILE", str(tmp_path / "nothing.json")):
+            assert script.load_db() == {}
+
+    def test_a_file_that_is_not_json_stops_the_run(self, script, tmp_path):
+        # Reading it as an empty db would be the destructive answer: the fetch
+        # would refetch every language and write over whatever is in there.
+        broken = tmp_path / "language_map.json"
+        broken.write_text('{"sk": ', encoding="utf-8")
+        with (
+            patch.object(script, "DB_FILE", str(broken)),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            script.load_db()
+        assert "not valid JSON" in str(excinfo.value)
 
 
 class TestRepairDbRoot:

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -490,6 +490,28 @@ class TestRepairDb:
 
         assert json.dumps(db, sort_keys=True) == before
 
+    @pytest.mark.parametrize("poll_titles", [0, False, "", {}])
+    def test_a_falsy_poll_titles_of_the_wrong_type_is_reported(
+        self, script, poll_titles
+    ):
+        # The third `or` default, found in the same sweep: these read as an
+        # empty list and were skipped in silence.
+        db = {"x": {"lang_code": "x", "poll_titles": poll_titles}}
+        changes, warnings = script.repair_db(db)
+
+        assert changes == []
+        assert len(warnings) == 1
+        assert warnings[0].startswith("x: ")
+        assert db["x"]["poll_titles"] == poll_titles
+
+    def test_a_missing_poll_titles_is_not_a_complaint(self, script):
+        # The one default that is deliberate: an error entry has no allergens
+        # and never had any.
+        assert script.repair_db({"x": {"lang_code": "x"}}) == ([], [])
+
+    def test_a_null_poll_titles_is_not_a_complaint(self, script):
+        assert script.repair_db({"x": {"poll_titles": None}}) == ([], [])
+
     def test_tolerates_an_error_entry(self, script):
         db = {"tr": {"lang_code": "tr", "error": "request error: timeout"}}
         assert script.repair_db(db) == ([], [])
@@ -497,9 +519,20 @@ class TestRepairDb:
     @pytest.mark.parametrize(
         "poll",
         [
+            # Truthy non-strings: these reached canonical_latin and raised.
             {"name": "Trávy", "latin": 5},
             {"name": 5, "latin": ""},
             {"name": ["Trávy"], "latin": "Poaceae"},
+            # Falsy non-strings: these walked past the type check, because
+            # `or ""` had already turned them into a valid-looking empty
+            # string. The latin ones were then REWRITTEN from the display
+            # name, which is the malformed entry being turned into a
+            # well-formed record rather than reported.
+            {"name": "Artemisia", "latin": 0},
+            {"name": "Artemisia", "latin": False},
+            {"name": "Artemisia", "latin": []},
+            {"name": 0, "latin": "Poaceae"},
+            {"name": False, "latin": ""},
         ],
     )
     def test_a_scalar_that_is_not_a_string_does_not_abort_the_run(self, script, poll):
@@ -511,6 +544,9 @@ class TestRepairDb:
         assert changes == []
         assert len(warnings) == 1
         assert warnings[0].startswith("x: ")
+        # Reported AS a type error, not as some downstream consequence of a
+        # value that was quietly defaulted before the check could see it.
+        assert "not a string" in warnings[0]
         # The entry is left exactly as it was: a defect is reported, never
         # quietly rewritten into a well-formed record.
         assert db["x"]["poll_titles"][0] == poll

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -1130,6 +1130,29 @@ class TestTheFileAndTheRuntimeAgree:
         assert self._runtime_allergen("Artemisia (") == "mugwort"
         assert self._recorded_allergen(script, "Artemisia (") == "mugwort"
 
+    @pytest.mark.parametrize(
+        "name",
+        ["Artemisia", "Ambrosia hojas", "Ailanthus altissima", "Trávy", "Ragweed", ""],
+    )
+    @pytest.mark.parametrize(
+        "brackets",
+        ["", " ()", " (   )", " (", " )", " (Poaceae)", " (ambrózia)", " (Asteraceae)"],
+    )
+    def test_the_two_sides_agree_on_every_generated_title(self, script, name, brackets):
+        """The differential, generated rather than listed.
+
+        The named rows above are the cases we thought of, and the drift this
+        class exists to catch has twice been a case nobody thought of: it was
+        invisible here until a row happened to carry the shape. Crossing the
+        display names that have caused trouble with every bracket shape the
+        API has been seen to send, or could, covers the combinations rather
+        than the instances.
+        """
+        poll_title = name + brackets
+        assert self._recorded_allergen(script, poll_title) == self._runtime_allergen(
+            poll_title
+        )
+
 
 class TestShippedLanguageMap:
     """The file itself, as shipped.

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -399,10 +399,60 @@ class TestLoadDb:
         assert "not valid JSON" in str(excinfo.value)
 
 
+class TestRunRepairReachesTheValidator:
+    """The entry point may not decide what the validator gets to see.
+
+    `if not db` sent every falsy root down the "nothing to repair" path: a
+    file holding [], "", 0, false or null was reported as an empty database,
+    which is the one answer that is certainly wrong for the mode whose job is
+    to diagnose a malformed file.
+    """
+
+    @staticmethod
+    def _run(script, monkeypatch, capsys, db):
+        monkeypatch.setattr(script, "load_db", lambda: db)
+        script.run_repair()
+        return capsys.readouterr().out
+
+    @pytest.mark.parametrize("db", [[], "", 0, False, None, ["sk"], "oops", 42])
+    def test_a_non_dict_root_reaches_the_validator(
+        self, script, monkeypatch, capsys, db
+    ):
+        out = self._run(script, monkeypatch, capsys, db)
+
+        assert "root" in out
+        assert "No languages" not in out
+
+    def test_an_empty_database_is_not_a_malformed_one(
+        self, script, monkeypatch, capsys
+    ):
+        # A missing file reads as {} too, and that is the ordinary first run.
+        out = self._run(script, monkeypatch, capsys, {})
+
+        assert "No languages" in out
+        assert "root" not in out
+
+    def test_a_good_database_is_repaired_as_before(self, script, monkeypatch, capsys):
+        db = {
+            "sk": {
+                "lang_code": "sk",
+                "poll_titles": [{"name": "Trávy", "latin": "Poaceae"}],
+            }
+        }
+        out = self._run(script, monkeypatch, capsys, db)
+
+        assert "Nothing to repair" in out
+
+
 class TestRepairDbRoot:
     """The level above the per-language checks: the file's own root."""
 
-    @pytest.mark.parametrize("db", [["sk"], "oops", 42, True])
+    @pytest.mark.parametrize(
+        "db",
+        # Truthy and falsy alike: the validator never saw the falsy ones,
+        # because the entry point above returned before calling it.
+        [["sk"], "oops", 42, True, [], "", 0, False, None],
+    )
     def test_a_root_that_is_not_an_object_is_reported(self, script, db):
         changes, warnings = script.repair_db(db)
 

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -333,6 +333,28 @@ class TestNeedsFetch:
         assert script.needs_fetch({"sk": "oops"}, "sk")
 
 
+class TestDbFilePath:
+    """The map's path is a property of the repo, not of the shell.
+
+    Relative, it resolved against the working directory, so a run from
+    anywhere else read no file, found no languages, fetched all sixteen and
+    wrote a new map into that directory. Nothing downstream can catch it: a
+    file that is merely absent looks exactly like an empty database.
+    """
+
+    def test_the_path_is_absolute(self, script):
+        assert Path(script.DB_FILE).is_absolute()
+
+    def test_it_points_at_the_map_in_this_repo(self, script):
+        assert Path(script.DB_FILE) == LANGUAGE_MAP
+
+    def test_the_map_is_found_from_another_directory(
+        self, script, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        assert len(script.load_db()) == 16
+
+
 class TestLoadDb:
     """The level above the root: the file may not be JSON at all."""
 

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -13,6 +13,12 @@ from unittest.mock import patch
 
 import pytest
 
+from custom_components.polleninformation.sensor import (
+    allergen_slug_for_item,
+    english_name_for_latin,
+)
+from custom_components.polleninformation.utils import slugify
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT_PATH = REPO_ROOT / "scripts" / "generate_language_codes.py"
 LANGUAGE_MAP = (
@@ -719,6 +725,71 @@ class TestRepairDb:
         assert changes == []
         assert len(warnings) == 1
         assert warnings[0].startswith("x: ")
+
+
+class TestTheFileAndTheRuntimeAgree:
+    """The invariant the individual fixes keep failing to hold.
+
+    An entry the generator records and the same entry as the API sends it
+    must identify the SAME allergen, or nothing, in the same cases. When they
+    disagree the file files an allergen under an identity the sensors refuse
+    to read it as, and the restore path then attaches the wrong localized
+    name to it during an outage.
+
+    "Ambrosia hojas" is the input that has caused this three times, from
+    three different directions: the setup path read it as ragweed, then a
+    reverse English-name lookup would have, then the generator's genus
+    fallback did. It is prose that begins with a genus, and neither side may
+    treat that as an identity.
+    """
+
+    @staticmethod
+    def _runtime_allergen(poll_title):
+        """The allergen the sensors read this title as, or None."""
+        return allergen_slug_for_item({"poll_title": poll_title})
+
+    @staticmethod
+    def _recorded_allergen(script, poll_title):
+        """The allergen the map entry for this title identifies, or None."""
+        poll_titles, _ = script.poll_titles_from_contamination(
+            [{"poll_title": poll_title, "poll_id": 1}]
+        )
+        if not poll_titles:
+            return None
+        name_en = english_name_for_latin(poll_titles[0]["latin"])
+        return slugify(name_en) if name_en else None
+
+    @pytest.mark.parametrize(
+        "poll_title",
+        [
+            "Ambrosia hojas",
+            "Artemisia",
+            "Ailanthus altissima",
+            "Ambrosia artemisiifolia",
+            "Ragweed (Ambrosia artemisiifolia)",
+            "Ragweed (Ambrosia)",
+            "Artemisia (Asteraceae)",
+            "(Poaceae)",
+            "Trávy (Poaceae)",
+            "Ragweed (ambrózia)",
+            "Nässlor (Nonexistentia)",
+            "Något nytt",
+        ],
+    )
+    def test_both_sides_resolve_the_same_input_the_same_way(self, script, poll_title):
+        assert self._recorded_allergen(script, poll_title) == self._runtime_allergen(
+            poll_title
+        )
+
+    def test_the_prose_case_resolves_to_nothing_on_both_sides(self, script):
+        # Stated separately from the parametrize above, because "they agree"
+        # would also be satisfied by both being wrong in the same way.
+        assert self._runtime_allergen("Ambrosia hojas") is None
+        assert self._recorded_allergen(script, "Ambrosia hojas") is None
+
+    def test_a_display_name_that_is_a_latin_name_resolves_on_both_sides(self, script):
+        assert self._runtime_allergen("Artemisia") == "mugwort"
+        assert self._recorded_allergen(script, "Artemisia") == "mugwort"
 
 
 class TestShippedLanguageMap:

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -638,6 +638,81 @@ POORER_RETRY = {
 }
 
 
+class TestTheMergeKeyIsTotal:
+    """The key goes into a set, so every field it reads is type-checked.
+
+    An id that arrives as a list or an object is unhashable. Building the set
+    would raise, and the raise lands in run_fetch: not one bad entry, but the
+    partial result unsaved and every language after it in the loop unfetched.
+    The two fallbacks had the same hole one step down, since a latin or a name
+    of the wrong type has no .strip().
+    """
+
+    @pytest.mark.parametrize("junk", [["x"], {"a": 1}, ("x",), set()])
+    def test_an_unhashable_id_falls_back_rather_than_raising(self, script, junk):
+        key = script.allergen_key(
+            {"name": "Trávy", "latin": "Poaceae", "poll_id": junk}
+        )
+
+        assert key == ("latin", "poaceae")
+        hash(key)
+
+    @pytest.mark.parametrize("junk", [["x"], {"a": 1}, 5, 5.0, True])
+    def test_a_latin_of_the_wrong_type_falls_back_to_the_name(self, script, junk):
+        key = script.allergen_key({"name": "Trávy", "latin": junk, "poll_id": None})
+
+        assert key == ("name", "trávy")
+        hash(key)
+
+    @pytest.mark.parametrize("junk", [["x"], {"a": 1}, 5, 5.0, True])
+    def test_an_entry_with_no_usable_field_has_no_key(self, script, junk):
+        assert script.allergen_key({"name": junk, "latin": "", "poll_id": None}) is None
+
+    @pytest.mark.parametrize("poll_id", ["6", 6, 6.0, True])
+    def test_a_scalar_id_is_still_the_identity(self, script, poll_id):
+        key = script.allergen_key(
+            {"name": "Trávy", "latin": "Poaceae", "poll_id": poll_id}
+        )
+
+        assert key == ("poll_id", poll_id)
+
+    def test_the_merge_survives_an_unhashable_id(self, script):
+        # The failure Codex describes, at the level where it aborts the run.
+        previous = {
+            "lang_code": "sk",
+            "poll_titles": [{"name": "Breza", "latin": "Betula", "poll_id": 2}],
+            "incomplete": True,
+        }
+        fresh = {
+            "lang_code": "sk",
+            "poll_titles": [{"name": "Traviny", "latin": "Poaceae", "poll_id": ["x"]}],
+            "incomplete": True,
+        }
+        got = script.entry_after_retry(previous, fresh)
+
+        assert [poll["name"] for poll in got["poll_titles"]] == ["Traviny", "Breza"]
+
+    def test_a_junk_id_is_reported_when_it_is_recorded(self, script):
+        _, warnings = script.poll_titles_from_contamination(
+            [{"poll_title": "Trávy (Poaceae)", "poll_id": ["x"]}]
+        )
+
+        assert len(warnings) == 1
+        assert "not a scalar" in warnings[0]
+
+    def test_a_junk_id_already_in_the_file_is_reported_by_repair(self, script):
+        db = {
+            "sk": {
+                "poll_titles": [{"name": "Trávy", "latin": "Poaceae", "poll_id": {}}]
+            }
+        }
+        changes, warnings = script.repair_db(db)
+
+        assert changes == []
+        assert any("not a scalar" in w for w in warnings)
+        assert db["sk"]["poll_titles"][0]["poll_id"] == {}
+
+
 class TestAPoorerRetryIsMergedPerAllergen:
     """The success-but-poorer path, which is the same invariant as the failure.
 

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -956,6 +956,11 @@ class TestTheFileAndTheRuntimeAgree:
             "Ragweed (ambrózia)",
             "Nässlor (Nonexistentia)",
             "Något nytt",
+            # Brackets with nothing in them: the API sent no latin name, so
+            # both sides fall back to the display name. The runtime used to
+            # read the empty brackets as a latin name it could not place and
+            # resolve to nothing, while the file recorded Artemisia.
+            "Artemisia ()",
         ],
     )
     def test_both_sides_resolve_the_same_input_the_same_way(self, script, poll_title):
@@ -972,6 +977,10 @@ class TestTheFileAndTheRuntimeAgree:
     def test_a_display_name_that_is_a_latin_name_resolves_on_both_sides(self, script):
         assert self._runtime_allergen("Artemisia") == "mugwort"
         assert self._recorded_allergen(script, "Artemisia") == "mugwort"
+
+    def test_empty_brackets_resolve_to_the_display_name_on_both_sides(self, script):
+        assert self._runtime_allergen("Artemisia ()") == "mugwort"
+        assert self._recorded_allergen(script, "Artemisia ()") == "mugwort"
 
 
 class TestShippedLanguageMap:

--- a/tests/test_generate_language_codes.py
+++ b/tests/test_generate_language_codes.py
@@ -978,6 +978,14 @@ class TestTheFileAndTheRuntimeAgree:
         assert self._runtime_allergen("Artemisia") == "mugwort"
         assert self._recorded_allergen(script, "Artemisia") == "mugwort"
 
+    def test_the_alias_resolves_to_ragweed_on_both_sides(self, script):
+        # Named rather than compared, for the same reason as the two above:
+        # emptying LATIN_NAME_ALIASES makes both sides resolve this to
+        # nothing, and "they agree" would still hold while the allergen had
+        # quietly stopped being identifiable.
+        assert self._runtime_allergen("Ragweed (ambrózia)") == "ragweed"
+        assert self._recorded_allergen(script, "Ragweed (ambrózia)") == "ragweed"
+
     def test_empty_brackets_resolve_to_the_display_name_on_both_sides(self, script):
         assert self._runtime_allergen("Artemisia ()") == "mugwort"
         assert self._recorded_allergen(script, "Artemisia ()") == "mugwort"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -215,6 +215,21 @@ MALFORMED_RISK_WITH_POLLEN_PAYLOAD = {
     "allergyrisk_hourly": "x",
 }
 
+# A risk block that is a non-empty object with nothing readable in it. This is
+# what an API sends to say something went wrong, so reading it as fresh data is
+# the worst of the available readings.
+UNREADABLE_RISK_PAYLOAD = {
+    "contamination": [{"poll_title": "()"}],
+    "allergyrisk": {"error": "upstream failure"},
+    "allergyrisk_hourly": {},
+}
+
+READABLE_RISK_PAYLOAD = {
+    "contamination": [{"poll_title": "()"}],
+    "allergyrisk": {"allergyrisk_1": 7.0},
+    "allergyrisk_hourly": {},
+}
+
 RISK_ONLY_PAYLOAD = {
     "contamination": [],
     "allergyrisk": {"allergyrisk_1": 7.5},
@@ -297,6 +312,29 @@ class TestEmptySince:
         # reports unknown without a marker.
         coordinator = self._make_coordinator(hass)
         await self._fetch(coordinator, MALFORMED_RISK_WITH_POLLEN_PAYLOAD, E1)
+        assert coordinator.empty_since is None
+
+    async def test_a_risk_block_with_nothing_readable_stamps_it(self, hass):
+        # Nonempty is not usable, three levels down: the entries, then the
+        # block being an object, now the fields inside it.
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, UNREADABLE_RISK_PAYLOAD, E1)
+        assert coordinator.empty_since == E1.isoformat()
+
+    async def test_a_real_reading_beside_unusable_pollen_is_not_an_outage(self, hass):
+        # The case ORDER #21 restored, which this must not undo: the API sent
+        # a forecast we can read, so the response carried data.
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, READABLE_RISK_PAYLOAD, E1)
+        assert coordinator.empty_since is None
+
+    async def test_a_risk_of_zero_is_a_reading(self, hass):
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(
+            coordinator,
+            {**READABLE_RISK_PAYLOAD, "allergyrisk": {"allergyrisk_1": 0}},
+            E1,
+        )
         assert coordinator.empty_since is None
 
     async def test_it_holds_for_the_duration_of_one_outage(self, hass):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -188,6 +188,11 @@ class TestOptionsReloadConsistency:
 
 EMPTY_PAYLOAD = {"contamination": []}
 FULL_PAYLOAD = {"contamination": [{"poll_title": "Birch (Betula)"}]}
+RISK_ONLY_PAYLOAD = {
+    "contamination": [],
+    "allergyrisk": {"allergyrisk_1": 7.5},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [7.5] * 24},
+}
 
 E1 = datetime(2026, 8, 18, 6, 0, tzinfo=timezone.utc)
 E2 = datetime(2026, 8, 18, 18, 0, tzinfo=timezone.utc)
@@ -253,6 +258,33 @@ class TestEmptySince:
         await self._fetch(coordinator, FULL_PAYLOAD, E1)
         await self._fetch(coordinator, EMPTY_PAYLOAD, E2)
         assert coordinator.empty_since == E2.isoformat()
+
+    async def test_a_risk_only_response_is_not_empty(self, hass):
+        """A response with risk data carried data, whatever contamination says.
+
+        The risk sensors would otherwise report a current value while the
+        whole location advertised itself stale.
+        """
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, RISK_ONLY_PAYLOAD, E1)
+        assert coordinator.empty_since is None
+
+    async def test_a_risk_only_response_ends_an_outage(self, hass):
+        """The other side of it: such a response clears an existing mark."""
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, EMPTY_PAYLOAD, E1)
+        await self._fetch(coordinator, RISK_ONLY_PAYLOAD, E2)
+        assert coordinator.empty_since is None
+
+    async def test_every_block_empty_is_an_outage(self, hass):
+        """Only a response with nothing in any block is stale."""
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(
+            coordinator,
+            {"contamination": [], "allergyrisk": {}, "allergyrisk_hourly": {}},
+            E1,
+        )
+        assert coordinator.empty_since == E1.isoformat()
 
     async def test_a_failed_fetch_does_not_stamp_it(self, hass):
         """A fetch that never returned says nothing about the response."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -188,6 +188,18 @@ class TestOptionsReloadConsistency:
 
 EMPTY_PAYLOAD = {"contamination": []}
 FULL_PAYLOAD = {"contamination": [{"poll_title": "Birch (Betula)"}]}
+# Entries in the block, none of which identify an allergen. No sensor is built
+# from any of them, so the response carried no pollen data whatever its length.
+ALL_UNUSABLE_PAYLOAD = {
+    "contamination": [{"poll_title": "()"}, {"poll_title": ""}, {}],
+}
+
+ALL_UNUSABLE_WITH_RISK_PAYLOAD = {
+    "contamination": [{"poll_title": "()"}],
+    "allergyrisk": {"allergyrisk_1": 7.5},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [7.5] * 24},
+}
+
 RISK_ONLY_PAYLOAD = {
     "contamination": [],
     "allergyrisk": {"allergyrisk_1": 7.5},
@@ -239,6 +251,23 @@ class TestEmptySince:
         coordinator = self._make_coordinator(hass)
         await self._fetch(coordinator, EMPTY_PAYLOAD, E1)
         assert coordinator.empty_since == E1.isoformat()
+
+    async def test_a_block_of_unusable_entries_stamps_it(self, hass):
+        # The block is not empty, but nothing in it identifies an allergen, so
+        # it carried no more data than an empty one. Counting the raw length
+        # here would call this a response with data while the sensors were
+        # being recreated as stale for want of any.
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, ALL_UNUSABLE_PAYLOAD, E1)
+        assert coordinator.empty_since == E1.isoformat()
+
+    async def test_risk_data_beside_unusable_entries_is_still_data(self, hass):
+        # Deliberately not the same answer as the sensors give: the pollen
+        # block carried nothing usable, so those sensors are recreated, while
+        # the risk sensors report real readings and nothing is stale.
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, ALL_UNUSABLE_WITH_RISK_PAYLOAD, E1)
+        assert coordinator.empty_since is None
 
     async def test_it_holds_for_the_duration_of_one_outage(self, hass):
         coordinator = self._make_coordinator(hass)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -263,7 +263,7 @@ class TestEmptySince:
                 AsyncMock(return_value={"nonsense": True}),
             ),
             _frozen(E1),
+            pytest.raises(UpdateFailed),
         ):
-            with pytest.raises(UpdateFailed):
-                await coordinator._async_update_data()
+            await coordinator._async_update_data()
         assert coordinator.empty_since is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,9 +1,11 @@
 """Tests for integration setup and coordinator."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.polleninformation import (
@@ -182,3 +184,86 @@ class TestOptionsReloadConsistency:
         assert coordinator.lon == 18.0
         assert coordinator.apikey == "new-key"
         assert coordinator.update_interval == timedelta(hours=4)
+
+
+EMPTY_PAYLOAD = {"contamination": []}
+FULL_PAYLOAD = {"contamination": [{"poll_title": "Birch (Betula)"}]}
+
+E1 = datetime(2026, 8, 18, 6, 0, tzinfo=timezone.utc)
+E2 = datetime(2026, 8, 18, 18, 0, tzinfo=timezone.utc)
+
+
+def _frozen(moment):
+    return patch("custom_components.polleninformation.dt_util.now", return_value=moment)
+
+
+class TestEmptySince:
+    """The coordinator owns response-level staleness.
+
+    data_stale describes the response, not a sensor: it means the fetch
+    succeeded and carried nothing usable. Tracking it here gives every entity
+    of a location the same timestamp for the same outage.
+    """
+
+    def _make_coordinator(self, hass):
+        entry = MockConfigEntry(domain=DOMAIN, title="Test", data={})
+        entry.add_to_hass(hass)
+        return PollenInformationDataUpdateCoordinator(
+            hass, entry, 53.5, 10.0, "DE", "en", "key", timedelta(hours=8)
+        )
+
+    async def _fetch(self, coordinator, payload, moment):
+        with (
+            patch(
+                "custom_components.polleninformation.async_get_pollenat_data",
+                AsyncMock(return_value=payload),
+            ),
+            _frozen(moment),
+        ):
+            await coordinator._async_update_data()
+
+    async def test_unset_before_any_fetch(self, hass):
+        assert self._make_coordinator(hass).empty_since is None
+
+    async def test_data_leaves_it_unset(self, hass):
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, FULL_PAYLOAD, E1)
+        assert coordinator.empty_since is None
+
+    async def test_an_empty_response_stamps_it(self, hass):
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, EMPTY_PAYLOAD, E1)
+        assert coordinator.empty_since == E1.isoformat()
+
+    async def test_it_holds_for_the_duration_of_one_outage(self, hass):
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, EMPTY_PAYLOAD, E1)
+        await self._fetch(coordinator, EMPTY_PAYLOAD, E2)
+        assert coordinator.empty_since == E1.isoformat()
+
+    async def test_recovery_clears_it(self, hass):
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, EMPTY_PAYLOAD, E1)
+        await self._fetch(coordinator, FULL_PAYLOAD, E2)
+        assert coordinator.empty_since is None
+
+    async def test_a_later_outage_is_stamped_afresh(self, hass):
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, EMPTY_PAYLOAD, E1)
+        await self._fetch(coordinator, FULL_PAYLOAD, E1)
+        await self._fetch(coordinator, EMPTY_PAYLOAD, E2)
+        assert coordinator.empty_since == E2.isoformat()
+
+    async def test_a_failed_fetch_does_not_stamp_it(self, hass):
+        """A fetch that never returned says nothing about the response."""
+        coordinator = self._make_coordinator(hass)
+        with (
+            patch(
+                "custom_components.polleninformation.async_get_pollenat_data",
+                AsyncMock(return_value={"nonsense": True}),
+            ),
+            _frozen(E1),
+        ):
+            with pytest.raises(UpdateFailed):
+                await coordinator._async_update_data()
+        assert coordinator.empty_since is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -200,6 +200,21 @@ ALL_UNUSABLE_WITH_RISK_PAYLOAD = {
     "allergyrisk_hourly": {"allergyrisk_hourly_1": [7.5] * 24},
 }
 
+# Blocks that are present but not objects. The sensors read them as absent and
+# report unknown, so counting them as data here would leave a response nothing
+# can be read from without an outage for its sensors to point at.
+MALFORMED_RISK_PAYLOAD = {
+    "contamination": [],
+    "allergyrisk": ["oops"],
+    "allergyrisk_hourly": "x",
+}
+
+MALFORMED_RISK_WITH_POLLEN_PAYLOAD = {
+    "contamination": [{"poll_title": "Birch (Betula)"}],
+    "allergyrisk": ["oops"],
+    "allergyrisk_hourly": "x",
+}
+
 RISK_ONLY_PAYLOAD = {
     "contamination": [],
     "allergyrisk": {"allergyrisk_1": 7.5},
@@ -267,6 +282,21 @@ class TestEmptySince:
         # the risk sensors report real readings and nothing is stale.
         coordinator = self._make_coordinator(hass)
         await self._fetch(coordinator, ALL_UNUSABLE_WITH_RISK_PAYLOAD, E1)
+        assert coordinator.empty_since is None
+
+    async def test_risk_blocks_that_are_not_objects_stamp_it(self, hass):
+        # Nothing in this response can be read, so it is an outage even though
+        # two of its three blocks are non-empty.
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, MALFORMED_RISK_PAYLOAD, E1)
+        assert coordinator.empty_since == E1.isoformat()
+
+    async def test_a_malformed_risk_block_alone_is_not_an_outage(self, hass):
+        # The pollen block carried data, so the response did. A risk sensor
+        # with nothing to read is a missing reading, not an outage, and
+        # reports unknown without a marker.
+        coordinator = self._make_coordinator(hass)
+        await self._fetch(coordinator, MALFORMED_RISK_WITH_POLLEN_PAYLOAD, E1)
         assert coordinator.empty_since is None
 
     async def test_it_holds_for_the_duration_of_one_outage(self, hass):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1691,49 +1691,51 @@ BINOMIAL_NAME_RESPONSE = {
 }
 
 
+async def _recreate_stale(hass, lang, unique_id, language_block=None):
+    """Run setup against an empty response so a registry entity is recreated."""
+    entry = _make_entry(lang)
+    entry.add_to_hass(hass)
+    ent_reg = er.async_get(hass)
+    ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        unique_id,
+        suggested_object_id=unique_id,
+        config_entry=entry,
+    )
+    entities = await _setup_entities(
+        hass,
+        lang,
+        entry=entry,
+        response=EMPTY_RESPONSE,
+        language_block=language_block or EMPTY_LANGUAGE_BLOCK,
+    )
+    return _by_type(entities, PolleninformationSensor)
+
+
 class TestStaleSensorRecovery:
     """A sensor recreated during an empty response must recover on any language."""
 
-    async def _recreate(self, hass, lang, unique_id):
-        entry = _make_entry(lang)
-        entry.add_to_hass(hass)
-        ent_reg = er.async_get(hass)
-        ent_reg.async_get_or_create(
-            "sensor",
-            DOMAIN,
-            unique_id,
-            suggested_object_id=unique_id,
-            config_entry=entry,
-        )
-        entities = await _setup_entities(
-            hass,
-            lang,
-            entry=entry,
-            response=EMPTY_RESPONSE,
-            language_block=EMPTY_LANGUAGE_BLOCK,
-        )
-        return _by_type(entities, PolleninformationSensor)
-
     async def test_german_sensor_recovers_on_localized_poll_title(self, hass):
-        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor = await _recreate_stale(hass, "de", "polleninformation_hamburg_birch")
         sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
         assert sensor.native_value == "hoch"
 
     async def test_german_forecast_recovers(self, hass):
-        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor = await _recreate_stale(hass, "de", "polleninformation_hamburg_birch")
         sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
         forecast = sensor.extra_state_attributes["forecast"]
         assert [day["level"] for day in forecast] == [3, 2, 1, 0]
 
     async def test_english_dock_sorrel_recovers(self, hass):
-        sensor = await self._recreate(
+        sensor = await _recreate_stale(
             hass, "en", "polleninformation_hamburg_dock_sorrel"
         )
         sensor.coordinator.data = ENGLISH_DOCK_SORREL_RESPONSE
         assert sensor.native_value == "moderate"
 
     async def test_latin_name_is_derived_from_the_slug(self, hass):
-        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor = await _recreate_stale(hass, "de", "polleninformation_hamburg_birch")
         sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
         assert sensor.extra_state_attributes["name_la"] == "Betula"
 
@@ -1744,7 +1746,7 @@ class TestStaleSensorRecovery:
         whole poll_title; its own name is "Mugwort", so only the map lookup on
         the display name itself can identify the entry.
         """
-        sensor = await self._recreate(hass, "es", "polleninformation_hamburg_mugwort")
+        sensor = await _recreate_stale(hass, "es", "polleninformation_hamburg_mugwort")
         sensor.coordinator.data = LATIN_GENUS_AS_NAME_RESPONSE
         assert sensor.native_value == "bajo"
 
@@ -1755,7 +1757,7 @@ class TestStaleSensorRecovery:
         again when the API recovers, so it has to be derived from whether the
         allergen was actually found.
         """
-        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor = await _recreate_stale(hass, "de", "polleninformation_hamburg_birch")
         sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
         attrs = sensor.extra_state_attributes
         assert "data_stale" not in attrs
@@ -1763,7 +1765,7 @@ class TestStaleSensorRecovery:
 
     async def test_stale_flag_stays_while_the_allergen_is_missing(self, hass):
         """Data for other allergens only is still no data for this one."""
-        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor = await _recreate_stale(hass, "de", "polleninformation_hamburg_birch")
         sensor.coordinator.data = LATIN_GENUS_AS_NAME_RESPONSE
         attrs = sensor.extra_state_attributes
         assert attrs["data_stale"] is True
@@ -1775,7 +1777,7 @@ class TestStaleSensorRecovery:
         Counting words would reject it, but it is a latin name the map knows,
         so a stale tree of heaven sensor must pick it up like any other.
         """
-        sensor = await self._recreate(
+        sensor = await _recreate_stale(
             hass, "de", "polleninformation_hamburg_tree_of_heaven"
         )
         sensor.coordinator.data = BINOMIAL_NAME_RESPONSE
@@ -1788,7 +1790,7 @@ class TestStaleSensorRecovery:
         matching it to the ragweed sensor would be a guess, not an
         identification.
         """
-        sensor = await self._recreate(hass, "es", "polleninformation_hamburg_ragweed")
+        sensor = await _recreate_stale(hass, "es", "polleninformation_hamburg_ragweed")
         sensor.coordinator.data = GENUS_PREFIXED_NAME_RESPONSE
         assert sensor.native_value is None
 
@@ -2056,3 +2058,4 @@ class TestPartialDataIsNotFreshData:
         assert attrs["forecast"]
         assert attrs["data_stale"] is True
         assert attrs["stale_since"] == T1.isoformat()
+

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1661,6 +1661,21 @@ ENGLISH_DOCK_SORREL_RESPONSE = {
 }
 
 
+GENUS_PREFIXED_NAME_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Ambrosia hojas",
+            "contamination_1": 2,
+            "contamination_2": 2,
+            "contamination_3": 1,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {},
+    "allergyrisk_hourly": {},
+}
+
+
 class TestStaleSensorRecovery:
     """A sensor recreated during an empty response must recover on any language."""
 
@@ -1739,3 +1754,13 @@ class TestStaleSensorRecovery:
         assert attrs["data_stale"] is True
         assert attrs["stale_since"] is not None
 
+    async def test_a_two_word_name_starting_with_a_genus_does_not_match(self, hass):
+        """The display-name lookup holds only for a name that IS the genus.
+
+        "Ambrosia hojas" is prose that happens to start with a latin genus, so
+        matching it to the ragweed sensor would be a guess, not an
+        identification.
+        """
+        sensor = await self._recreate(hass, "es", "polleninformation_hamburg_ragweed")
+        sensor.coordinator.data = GENUS_PREFIXED_NAME_RESPONSE
+        assert sensor.native_value is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1764,6 +1764,9 @@ class TestStaleSensorRecovery:
         sensor.coordinator.empty_since = None
         attrs = sensor.extra_state_attributes
         assert sensor.native_value is None
+        # No value means no value: nothing of an earlier reading is kept, so
+        # the empty forecast is what says the sensor has nothing to show.
+        assert attrs["forecast"] == []
         assert "data_stale" not in attrs
         assert "stale_since" not in attrs
 
@@ -1796,8 +1799,8 @@ class TestEveryEntityReportsTheSameOutage:
 
     The per-outage semantics themselves are the coordinator's, and are tested
     in test_init.py. What matters here is that an entity reports the
-    coordinator's value rather than one of its own: a card reading
-    stale_since off whichever entity it reaches first must get one answer.
+    coordinator's value rather than one of its own: anything reading
+    stale_since off an arbitrary entity of the location gets one answer.
     """
 
     async def _entities_during_an_outage(self, hass):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2240,6 +2240,52 @@ class TestANonObjectEntryCostsOnlyItself:
         assert len(sensor.extra_state_attributes["forecast"]) == 4
 
 
+class TestFindItemIsSafeWithoutItsCallers:
+    """The block is filtered by _find_item itself, not by its callers.
+
+    These pass today and are meant to: they document the invariant rather
+    than fix a reachable bug. _find_item filters the block through the shared
+    predicate before either pass, so handing it the raw block directly is
+    already safe, and the unpack below that filter cannot meet a None. What
+    they pin is that the filter stays inside the function, where it does not
+    depend on who calls it.
+    """
+
+    @staticmethod
+    def _sensor(hass_coordinator):
+        return PolleninformationSensor(
+            coordinator=hass_coordinator,
+            sensor_type="pollen",
+            allergen_name="Birke",
+            allergen_en="birch",
+            allergen_slug="birch",
+            allergen_latin="Betula",
+            levels_current=["none", "low", "moderate", "high", "very high"],
+            levels_en=["none", "low", "moderate", "high", "very high"],
+            location_slug="hamburg",
+            location_title="Hamburg",
+            icon="mdi:tree-outline",
+        )
+
+    def test_an_unusable_entry_handed_straight_to_it_is_skipped(self):
+        sensor = self._sensor(_make_coordinator({"contamination": []}))
+        block = [
+            "oops",
+            {"poll_title": "()"},
+            {"poll_title": 5},
+            {},
+            {"poll_title": "Birke (Betula)", "contamination_1": 2},
+        ]
+
+        # The raw block, unfiltered by any caller.
+        assert sensor._find_item(block) == block[-1]
+
+    def test_a_block_of_nothing_usable_finds_nothing(self):
+        sensor = self._sensor(_make_coordinator({"contamination": []}))
+
+        assert sensor._find_item(["oops", {"poll_title": "()"}, {}]) is None
+
+
 class TestABlockThatIsNotAnObject:
     """The same assumption one level up, over the risk blocks.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2159,6 +2159,87 @@ class TestABlockOfUnusableEntriesReadsAsEmpty:
         assert "data_stale" not in sensor.extra_state_attributes
 
 
+# One non-object element beside a good one. The coordinator validates that
+# contamination is a list and says nothing about what is in it.
+NON_OBJECT_ELEMENT_RESPONSE = {
+    "contamination": [
+        "oops",
+        123,
+        None,
+        ["x"],
+        {
+            "poll_title": "Birke (Betula)",
+            "contamination_1": 3,
+            "contamination_2": 2,
+            "contamination_3": 1,
+            "contamination_4": 0,
+        },
+    ],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+
+class TestANonObjectEntryCostsOnlyItself:
+    """One junk element may not take the whole location down with it.
+
+    Everything else on this branch degrades a single sensor. This one raised
+    inside setup, which fails the config entry: every sensor for the location
+    disappears, risk sensors included. It raised again on every read, so
+    fixing setup alone would not have been enough.
+    """
+
+    async def test_setup_survives_and_keeps_the_good_entry(self, hass):
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=NON_OBJECT_ELEMENT_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_birch" in unique_ids
+
+    async def test_the_risk_sensors_survive_too(self, hass):
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=NON_OBJECT_ELEMENT_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_allergy_risk" in unique_ids
+
+    async def test_the_junk_is_warned_about(self, hass, caplog):
+        with caplog.at_level(logging.WARNING):
+            await _setup_entities(
+                hass,
+                "de",
+                response=NON_OBJECT_ELEMENT_RESPONSE,
+                language_block=EMPTY_LANGUAGE_BLOCK,
+            )
+        skipped = [
+            r for r in caplog.records if "identifies no allergen" in r.getMessage()
+        ]
+        assert len(skipped) == 4
+
+    async def test_reading_the_sensor_survives_it(self, hass):
+        # The read path matters as much as setup: the response is re-read on
+        # every refresh, so a fix in setup alone would leave the sensor
+        # raising for as long as the API sends that element.
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=NON_OBJECT_ELEMENT_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        sensor = _by_type(entities, PolleninformationSensor)
+
+        assert sensor.native_value == "hoch"
+        assert len(sensor.extra_state_attributes["forecast"]) == 4
+
+
 class TestEveryEntityReportsTheSameOutage:
     """The timestamp belongs to the response, so siblings must agree on it.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1712,6 +1712,37 @@ class TestARenameThatContradictsWhatTheRowRecords:
         assert migrated is not None
         assert migrated.id == foo_id
 
+    async def test_an_unknown_name_does_not_contradict_its_own_genus(self, hass):
+        # The counterpart of the test above for a name no map carries, which
+        # is the whole population this guard exists for. The API sends the
+        # genus in one language and the genus with a species in another, and
+        # one allergen must not read as two, or the migration is refused
+        # naming the allergen it actually is.
+        entry, ent_reg, foo_id = self._register(
+            hass, "foo", latin="Nonexistentia vulgaris"
+        )
+
+        migrate_localized_allergen_ids(
+            hass, "hamburg", [("foo", "birch", "Nonexistentia")]
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert migrated is not None
+        assert migrated.id == foo_id
+        assert entry.entry_id
+
+    async def test_two_unmapped_allergens_are_still_told_apart(self, hass):
+        # The price of folding, pinned so it stays a price and not a surprise:
+        # only a shared FIRST word folds. Two unmapped names that merely
+        # resemble each other still contradict.
+        _, ent_reg, foo_id = self._register(hass, "foo", latin="Nonexistentia")
+
+        migrate_localized_allergen_ids(hass, "hamburg", [("foo", "birch", "Alia")])
+
+        kept = ent_reg.async_get("sensor.polleninformation_hamburg_foo")
+        assert kept is not None
+        assert kept.id == foo_id
+
     async def test_a_claim_that_names_no_allergen_is_not_a_contradiction(self, hass):
         # Unknown on the claiming side is unknown too, never mismatch. Setup
         # cannot currently queue such a rename -- an entry with no latin name

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1764,3 +1764,104 @@ class TestStaleSensorRecovery:
         sensor = await self._recreate(hass, "es", "polleninformation_hamburg_ragweed")
         sensor.coordinator.data = GENUS_PREFIXED_NAME_RESPONSE
         assert sensor.native_value is None
+
+
+T1 = datetime(2026, 8, 18, 6, 0, tzinfo=timezone.utc)
+T2 = datetime(2026, 8, 18, 18, 0, tzinfo=timezone.utc)
+
+
+def _frozen(moment):
+    """Patch the sensor module's clock to a fixed moment."""
+    return patch(
+        "custom_components.polleninformation.sensor.dt_util.now",
+        return_value=moment,
+    )
+
+
+class TestStaleSinceFollowsTheCurrentOutage:
+    """stale_since must date the outage being reported, not the first one.
+
+    The timestamp is a constructor value, and setup does not run again when
+    the API recovers, so a second outage would otherwise republish the first
+    outage's timestamp and appear to have lasted for the whole gap.
+    """
+
+    async def _recreated_at(self, hass, moment):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_birch",
+            suggested_object_id="polleninformation_hamburg_birch",
+            config_entry=entry,
+        )
+        with _frozen(moment):
+            entities = await _setup_entities(
+                hass,
+                "de",
+                entry=entry,
+                response=EMPTY_RESPONSE,
+                language_block=EMPTY_LANGUAGE_BLOCK,
+            )
+        return _by_type(entities, PolleninformationSensor)
+
+    async def test_second_outage_gets_a_fresh_timestamp(self, hass):
+        sensor = await self._recreated_at(hass, T1)
+        with _frozen(T1):
+            assert sensor.extra_state_attributes["stale_since"] == T1.isoformat()
+
+        sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
+        with _frozen(T1):
+            assert "stale_since" not in sensor.extra_state_attributes
+
+        sensor.coordinator.data = EMPTY_RESPONSE
+        with _frozen(T2):
+            attrs = sensor.extra_state_attributes
+        assert attrs["data_stale"] is True
+        assert attrs["stale_since"] == T2.isoformat()
+
+    async def test_the_timestamp_does_not_drift_across_reads(self, hass):
+        """The property is read more than once per update."""
+        sensor = await self._recreated_at(hass, T1)
+        with _frozen(T1):
+            first = sensor.extra_state_attributes["stale_since"]
+        with _frozen(T2):
+            second = sensor.extra_state_attributes["stale_since"]
+        assert first == second == T1.isoformat()
+
+    @pytest.mark.parametrize(
+        ("cls", "key", "payload"),
+        [
+            (AllergyRiskSensor, "allergyrisk", {"allergyrisk_1": 5.0}),
+            (
+                AllergyRiskHourlySensor,
+                "allergyrisk_hourly",
+                {"allergyrisk_hourly_1": [5.0] * 24},
+            ),
+        ],
+    )
+    async def test_risk_sensors_date_the_current_outage(self, cls, key, payload):
+        """The risk sensors froze the same timestamp for the same reason."""
+        coordinator = _make_coordinator({key: {}})
+        sensor = cls(
+            coordinator=coordinator,
+            levels_current=["none", "low", "moderate", "high", "very high"],
+            location_slug="hamburg",
+            location_title="Hamburg",
+            is_stale=True,
+            stale_since=T1.isoformat(),
+        )
+        with _frozen(T1):
+            assert sensor.extra_state_attributes["stale_since"] == T1.isoformat()
+
+        coordinator.data = {key: payload}
+        with _frozen(T1):
+            assert "stale_since" not in sensor.extra_state_attributes
+
+        coordinator.data = {key: {}}
+        with _frozen(T2):
+            attrs = sensor.extra_state_attributes
+        assert attrs["data_stale"] is True
+        assert attrs["stale_since"] == T2.isoformat()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1301,6 +1301,109 @@ ITALIAN_RAGWEED_RESPONSE = {
 }
 
 
+class TestALegacyCandidateFromTheLiveResponse:
+    """The candidate comes from the RESPONSE, so no test over the map binds it.
+
+    poll_title_local is whatever the API sent, and the English-block name
+    falls back to it whenever the block has no entry for the latin, which is
+    the case for the ten allergens the map does not cover. A title like
+    "Birch (Artemisia)" resolves to mugwort while its display name slugs to
+    birch, so the candidate would have renamed the birch row, taking that
+    allergen's history with it. Nothing creates a duplicate here and nothing
+    reverses it afterwards.
+    """
+
+    @staticmethod
+    def _response(poll_title):
+        return {
+            "contamination": [{"poll_title": poll_title, "contamination_1": 2}],
+            "allergyrisk": {},
+            "allergyrisk_hourly": {},
+        }
+
+    @staticmethod
+    def _register(hass, slug):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        registered = ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            f"polleninformation_hamburg_{slug}",
+            suggested_object_id=f"polleninformation_hamburg_{slug}",
+            config_entry=entry,
+        )
+        return entry, ent_reg, registered.id
+
+    async def test_the_other_allergens_row_is_left_alone(self, hass):
+        entry, ent_reg, birch_id = self._register(hass, "birch")
+
+        await _setup_with_shipped_blocks(
+            hass, "de", self._response("Birch (Artemisia)"), entry=entry
+        )
+
+        kept = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert kept is not None
+        assert kept.id == birch_id
+        assert kept.unique_id == "polleninformation_hamburg_birch"
+
+    async def test_no_mugwort_row_is_manufactured_from_it(self, hass):
+        entry, ent_reg, _ = self._register(hass, "birch")
+
+        await _setup_with_shipped_blocks(
+            hass, "de", self._response("Birch (Artemisia)"), entry=entry
+        )
+
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_mugwort"
+            )
+            is None
+        )
+
+    async def test_the_refusal_is_logged(self, hass, caplog):
+        entry, _, _ = self._register(hass, "birch")
+
+        with caplog.at_level(logging.WARNING):
+            await _setup_with_shipped_blocks(
+                hass, "de", self._response("Birch (Artemisia)"), entry=entry
+            )
+
+        assert [
+            r
+            for r in caplog.records
+            if "another allergen" in r.getMessage() and "birch" in r.getMessage()
+        ]
+
+    async def test_the_same_holds_for_an_allergen_the_map_does_not_cover(self, hass):
+        # The English-block candidate, which falls back to the display name
+        # when the block has no entry for the latin. Quercus is one of ten
+        # such allergens, so this shape reaches the same line by the other
+        # route, and it did so before the display-name candidate existed.
+        entry, ent_reg, birch_id = self._register(hass, "birch")
+
+        await _setup_with_shipped_blocks(
+            hass, "de", self._response("Birch (Quercus)"), entry=entry
+        )
+
+        kept = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert kept is not None
+        assert kept.id == birch_id
+
+    async def test_an_ordinary_localized_name_is_still_migrated(self, hass):
+        # The guard may not cost the migration its actual job: "Beifuß" is
+        # nobody else's canonical slug, so it is still a candidate.
+        entry, ent_reg, original_id = self._register(hass, "beifuss")
+
+        await _setup_with_shipped_blocks(
+            hass, "de", self._response("Beifuß (Artemisia)"), entry=entry
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_mugwort")
+        assert migrated is not None
+        assert migrated.id == original_id
+
+
 class TestNoLegacyCandidateCanClaimAnotherAllergen:
     """A rename candidate that does not exist is free; one that collides is not.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1638,3 +1638,14 @@ class TestStaleSensorRecovery:
         sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
         sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
         assert sensor.extra_state_attributes["name_la"] == "Betula"
+
+    async def test_recovers_when_the_latin_genus_is_the_display_name(self, hass):
+        """Issue #71 arrives without parentheses, so there is no latin to read.
+
+        A stale mugwort sensor on a Spanish install sees "Artemisia" as the
+        whole poll_title; its own name is "Mugwort", so only the map lookup on
+        the display name itself can identify the entry.
+        """
+        sensor = await self._recreate(hass, "es", "polleninformation_hamburg_mugwort")
+        sensor.coordinator.data = LATIN_GENUS_AS_NAME_RESPONSE
+        assert sensor.native_value is not None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -16,12 +16,14 @@ from custom_components.polleninformation.const import DOMAIN
 from custom_components.polleninformation.sensor import (
     ALLERGEN_ICON_MAP,
     KNOWN_ALLERGEN_SLUGS,
+    LATIN_NAME_ALIASES,
     LATIN_TO_ENGLISH_NAME,
     RISK_SLUGS,
     AllergyRiskHourlySensor,
     AllergyRiskSensor,
     PolleninformationSensor,
     async_setup_entry,
+    canonical_latin,
     capitalize_first,
     english_name_for_latin,
     entity_id_available,
@@ -1358,6 +1360,70 @@ class TestPresentLatinIsAuthoritative:
             )
             is None
         )
+
+
+# The Slovak response spells ragweed's latin name "ambrózia", which is the
+# Slovak word rather than a candidate scientific name. Nothing in the static
+# map matches it, so before it was declared an alias the allergen was unknown.
+SLOVAK_RAGWEED_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Ragweed (ambrózia)",
+            "contamination_1": 1,
+            "contamination_2": 0,
+            "contamination_3": 0,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+
+class TestDeclaredLatinNameAliases:
+    """A spelling declared in LATIN_NAME_ALIASES resolves like the name itself.
+
+    The alias table is an allow-list: only a spelling we have seen the API
+    send is rewritten, so an unknown latin name is never guessed at.
+    """
+
+    def test_the_alias_resolves_to_its_allergen(self):
+        assert english_name_for_latin("ambrózia") == "ragweed"
+
+    def test_the_alias_is_matched_case_insensitively(self):
+        assert english_name_for_latin("Ambrózia") == "ragweed"
+
+    def test_canonical_latin_rewrites_only_a_declared_alias(self):
+        assert canonical_latin("ambrózia") == "Ambrosia"
+        assert canonical_latin("Asteraceae") == "Asteraceae"
+        assert canonical_latin("") == ""
+        assert canonical_latin(None) is None
+
+    def test_every_alias_names_an_allergen_the_map_knows(self):
+        assert set(LATIN_NAME_ALIASES.values()) <= set(LATIN_TO_ENGLISH_NAME)
+
+    async def _setup(self, hass):
+        return await _setup_entities(
+            hass,
+            "sk",
+            response=SLOVAK_RAGWEED_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+
+    async def test_a_slovak_install_gets_the_canonical_slug(self, hass):
+        entities = await self._setup(hass)
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+        assert "polleninformation_hamburg_ragweed" in unique_ids
+
+    async def test_the_latin_name_is_reported_canonically(self, hass):
+        entities = await self._setup(hass)
+        sensor = _by_type(entities, PolleninformationSensor)
+        assert sensor.extra_state_attributes["name_la"] == "Ambrosia"
+
+    async def test_no_unknown_allergen_warning(self, hass, caplog):
+        with caplog.at_level(logging.WARNING):
+            await self._setup(hass)
+        assert not [r for r in caplog.records if "Unknown allergen" in r.getMessage()]
 
 
 # The canonical slug for every allergen, pinned. These slugs are a public

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1945,3 +1945,114 @@ class TestGenusPrefixedNameOnTheSetupPath:
             )
             is None
         )
+
+
+class TestPartialDataIsNotFreshData:
+    """A sensor with no readable value must not report itself fresh.
+
+    A risk block that is present but carries nothing usable for right now,
+    only a later day, a null, or an empty hourly list, left native_value
+    unknown while clearing the stale marker.
+    """
+
+    LEVELS = ["none", "low", "moderate", "high", "very high"]
+
+    def _risk(self, cls, data, is_stale=True):
+        return cls(
+            coordinator=_make_coordinator(data),
+            levels_current=self.LEVELS,
+            location_slug="hamburg",
+            location_title="Hamburg",
+            is_stale=is_stale,
+            stale_since=T1.isoformat(),
+        )
+
+    @pytest.mark.parametrize(
+        ("cls", "data"),
+        [
+            (AllergyRiskSensor, {"allergyrisk": {"allergyrisk_2": 5.0}}),
+            (AllergyRiskSensor, {"allergyrisk": {"allergyrisk_1": None}}),
+            (
+                AllergyRiskHourlySensor,
+                {"allergyrisk_hourly": {"allergyrisk_hourly_2": [5.0] * 24}},
+            ),
+            (AllergyRiskHourlySensor, {"allergyrisk_hourly": {}}),
+            (
+                AllergyRiskHourlySensor,
+                {"allergyrisk_hourly": {"allergyrisk_hourly_1": []}},
+            ),
+        ],
+    )
+    def test_partial_risk_data_stays_stale(self, cls, data):
+        sensor = self._risk(cls, data)
+        with _frozen(T2):
+            attrs = sensor.extra_state_attributes
+        assert sensor.native_value is None
+        assert attrs["data_stale"] is True
+        assert attrs["stale_since"] == T1.isoformat()
+
+    @pytest.mark.parametrize(
+        ("cls", "data"),
+        [
+            (AllergyRiskSensor, {"allergyrisk": {"allergyrisk_1": 0.0}}),
+            (
+                AllergyRiskHourlySensor,
+                {"allergyrisk_hourly": {"allergyrisk_hourly_1": [0.0] * 24}},
+            ),
+        ],
+    )
+    def test_a_zero_reading_is_a_reading(self, cls, data):
+        """No risk at all is a real value, not a missing one."""
+        sensor = self._risk(cls, data)
+        with _frozen(T2):
+            attrs = sensor.extra_state_attributes
+        assert sensor.native_value == "none"
+        assert "data_stale" not in attrs
+        assert "stale_since" not in attrs
+
+    def test_repeated_partial_responses_keep_the_first_timestamp(self):
+        """Flickering between partial shapes is one outage, not several."""
+        sensor = self._risk(
+            AllergyRiskSensor, {"allergyrisk": {"allergyrisk_2": 5.0}}, is_stale=False
+        )
+        with _frozen(T1):
+            first = sensor.extra_state_attributes["stale_since"]
+        sensor.coordinator.data = {"allergyrisk": {"allergyrisk_1": None}}
+        with _frozen(T2):
+            second = sensor.extra_state_attributes["stale_since"]
+        assert first == second == T1.isoformat()
+
+    def test_an_unusable_pollen_level_is_not_fresh(self):
+        """The pollen sensor answers the same question the same way.
+
+        A level outside the level names leaves native_value unknown while the
+        forecast is still built, so a forecast alone cannot stand for a
+        reading.
+        """
+        sensor = PolleninformationSensor(
+            coordinator=_make_coordinator(
+                {
+                    "contamination": [
+                        {"poll_title": "Birke (Betula)", "contamination_1": 9}
+                    ]
+                }
+            ),
+            sensor_type="pollen",
+            allergen_name="Birke",
+            allergen_en="birch",
+            allergen_slug="birch",
+            allergen_latin="Betula",
+            levels_current=self.LEVELS,
+            levels_en=self.LEVELS,
+            location_slug="hamburg",
+            location_title="Hamburg",
+            icon="mdi:tree-outline",
+            is_stale=True,
+            stale_since=T1.isoformat(),
+        )
+        with _frozen(T2):
+            attrs = sensor.extra_state_attributes
+        assert sensor.native_value is None
+        assert attrs["forecast"]
+        assert attrs["data_stale"] is True
+        assert attrs["stale_since"] == T1.isoformat()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1633,3 +1633,8 @@ class TestStaleSensorRecovery:
         )
         sensor.coordinator.data = ENGLISH_DOCK_SORREL_RESPONSE
         assert sensor.native_value == "moderate"
+
+    async def test_latin_name_is_derived_from_the_slug(self, hass):
+        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
+        assert sensor.extra_state_attributes["name_la"] == "Betula"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1731,10 +1731,29 @@ class TestARenameThatContradictsWhatTheRowRecords:
         assert migrated.id == foo_id
         assert entry.entry_id
 
-    async def test_two_unmapped_allergens_are_still_told_apart(self, hass):
-        # The price of folding, pinned so it stays a price and not a surprise:
-        # only a shared FIRST word folds. Two unmapped names that merely
-        # resemble each other still contradict.
+    async def test_two_unmapped_names_sharing_a_first_word_fold_together(self, hass):
+        # THE PRICE of folding, and the only test that charges it. Two
+        # DIFFERENT unmapped allergens whose latin names share a genus are one
+        # allergen to this integration, so a rename the old rule refused now
+        # goes through. That is the trade taken deliberately: a genus is what
+        # this integration means by an allergen everywhere else, and the
+        # alternative made every unmapped allergen contradict itself whenever
+        # the API varied its spelling.
+        _, ent_reg, foo_id = self._register(hass, "foo", latin="Nonexistentia bar")
+
+        migrate_localized_allergen_ids(
+            hass, "hamburg", [("foo", "birch", "Nonexistentia baz")]
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert migrated is not None
+        assert migrated.id == foo_id
+
+    async def test_two_unmapped_names_sharing_nothing_still_contradict(self, hass):
+        # The limit of the fold: only the FIRST word folds, so names that do
+        # not share one are still two allergens. This held before the fold as
+        # well, and it is here to catch a future widening of the rule rather
+        # than to charge its price.
         _, ent_reg, foo_id = self._register(hass, "foo", latin="Nonexistentia")
 
         migrate_localized_allergen_ids(hass, "hamburg", [("foo", "birch", "Alia")])

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1746,6 +1746,20 @@ class TestStateMachineCollision:
 
 EMPTY_RESPONSE = {"contamination": [], "allergyrisk": {}, "allergyrisk_hourly": {}}
 
+GERMAN_BIRCH_RESPONSE_WITHOUT_LATIN = {
+    "contamination": [
+        {
+            "poll_title": "Birke",
+            "contamination_1": 3,
+            "contamination_2": 2,
+            "contamination_3": 1,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {},
+    "allergyrisk_hourly": {},
+}
+
 GERMAN_BIRCH_RESPONSE = {
     "contamination": [
         {
@@ -1912,6 +1926,65 @@ class TestStaleSensorRecovery:
         sensor = await _recreate_stale(hass, "es", "polleninformation_hamburg_ragweed")
         sensor.coordinator.data = GENUS_PREFIXED_NAME_RESPONSE
         assert sensor.native_value is None
+
+
+# A title with no name part and no brackets, beside a language map entry whose
+# name is blank. The map can hold one for an allergen the API named by its
+# latin name alone, which is the "(Poaceae)" shape the generator records.
+NAMELESS_TITLE_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "",
+            "contamination_1": 1,
+            "contamination_2": 0,
+            "contamination_3": 0,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+BLANK_NAMED_LANGUAGE_BLOCK = {"poll_titles": [{"name": "", "latin": "Poaceae"}]}
+
+
+class TestABlankNameNeverMatchesABlankName:
+    """The backfill matches an API title against the language map by name.
+
+    Both sides can be blank: the API sends a title with no name part and no
+    brackets, and the map can hold an entry whose name is blank. Letting those
+    match would hand the nameless entry the other one's latin name and make it
+    that allergen, with nothing in the response saying so.
+    """
+
+    async def _setup(self, hass):
+        return await _setup_entities(
+            hass,
+            "de",
+            response=NAMELESS_TITLE_RESPONSE,
+            language_block=BLANK_NAMED_LANGUAGE_BLOCK,
+        )
+
+    async def test_the_nameless_entry_does_not_become_that_allergen(self, hass):
+        entities = await self._setup(hass)
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+        assert "polleninformation_hamburg_grasses" not in unique_ids
+
+    async def test_it_claims_no_latin_name_of_its_own(self, hass):
+        entities = await self._setup(hass)
+        sensor = _by_type(entities, PolleninformationSensor)
+        assert sensor.extra_state_attributes["name_la"] == ""
+
+    async def test_a_named_entry_still_matches_the_map(self, hass):
+        # The guard may not cost the backfill its actual job.
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=GERMAN_BIRCH_RESPONSE_WITHOUT_LATIN,
+            language_block={"poll_titles": [{"name": "Birke", "latin": "Betula"}]},
+        )
+        sensor = _by_type(entities, PolleninformationSensor)
+        assert sensor.extra_state_attributes["name_la"] == "Betula"
 
 
 class TestReportedLatinNameAcrossAnOutage:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1495,6 +1495,63 @@ class TestTheRegistryRowRecordsWhichAllergenItIs:
             _recorded_latin(ent_reg, "sensor.polleninformation_hamburg_birch") is None
         )
 
+    async def test_a_disabled_row_is_recorded_too(self, hass):
+        # An entity disabled in the registry is aborted before it is added,
+        # so it never hears that it was added and could never record itself.
+        # The row is there and the response identifies its allergen; only the
+        # entity is missing. Left unrecorded it would stay unprotected for as
+        # long as it stayed disabled.
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        disabled = ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_mugwort",
+            suggested_object_id="polleninformation_hamburg_mugwort",
+            config_entry=entry,
+            disabled_by=er.RegistryEntryDisabler.USER,
+        )
+        assert disabled.disabled
+
+        await _setup_through_the_platform(
+            hass, "de", self._response("Beifu\u00df (Artemisia)"), entry=entry
+        )
+
+        row = ent_reg.async_get("sensor.polleninformation_hamburg_mugwort")
+        assert row.disabled
+        assert row.options[DOMAIN]["latin"] == "Artemisia"
+
+    async def test_a_legacy_row_is_not_recorded_before_the_migration_decides(
+        self, hass
+    ):
+        # Order, pinned. Recording first would overwrite what this row says
+        # about itself with the latin name of the allergen that is trying to
+        # claim it, and the guard would then be weighing evidence the rename
+        # made for itself. The row is refused and keeps its own record.
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        legacy = ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_foo",
+            suggested_object_id="polleninformation_hamburg_foo",
+            config_entry=entry,
+        )
+        ent_reg.async_update_entity_options(
+            legacy.entity_id, DOMAIN, {"latin": "Nonexistentia"}
+        )
+
+        await _setup_through_the_platform(
+            hass, "de", self._response("Foo (Betula)"), entry=entry
+        )
+
+        kept = ent_reg.async_get("sensor.polleninformation_hamburg_foo")
+        assert kept is not None
+        assert kept.id == legacy.id
+        assert kept.options[DOMAIN]["latin"] == "Nonexistentia"
+
     async def test_a_sensor_recreated_during_an_outage_records_nothing(self, hass):
         # Such a sensor derived its latin name from its own slug, so
         # recording it would write down the assumption the record exists to

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1522,13 +1522,39 @@ class TestTheRegistryRowRecordsWhichAllergenItIs:
         assert row.disabled
         assert row.options[DOMAIN]["latin"] == "Artemisia"
 
-    async def test_a_legacy_row_is_not_recorded_before_the_migration_decides(
-        self, hass
-    ):
-        # Order, pinned. Recording first would overwrite what this row says
-        # about itself with the latin name of the allergen that is trying to
-        # claim it, and the guard would then be weighing evidence the rename
-        # made for itself. The row is refused and keeps its own record.
+    async def test_a_disabled_row_migrated_in_this_pass_is_recorded_after(self, hass):
+        # The ordering pin. A disabled row is never added as an entity, so the
+        # setup-side write is its only chance, and it is renamed in this same
+        # pass. Only a write that runs AFTER the migration finds it: before,
+        # nothing carries the canonical unique_id this resolves rows by, and
+        # the row would be left unrecorded exactly as it was.
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        legacy = ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_foo",
+            suggested_object_id="polleninformation_hamburg_foo",
+            config_entry=entry,
+            disabled_by=er.RegistryEntryDisabler.USER,
+        )
+
+        await _setup_through_the_platform(
+            hass, "de", self._response("Foo (Betula)"), entry=entry
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert migrated is not None
+        assert migrated.id == legacy.id
+        assert migrated.disabled
+        assert migrated.options[DOMAIN]["latin"] == "Betula"
+
+    async def test_a_refused_row_keeps_its_own_record(self, hass):
+        # A refused row is not then recorded as the allergen that was refused
+        # it. Nothing looks it up under its own legacy slug, and the write
+        # site resolves rows by canonical unique_id only, so the record it
+        # carries is the one thing about it nothing in this pass can rewrite.
         entry = _make_entry("de")
         entry.add_to_hass(hass)
         ent_reg = er.async_get(hass)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1390,6 +1390,50 @@ class TestALegacyCandidateFromTheLiveResponse:
         assert kept is not None
         assert kept.id == birch_id
 
+    async def test_a_localized_name_normalizing_onto_another_allergen(self, hass):
+        # The realistic route, and the one that needs no English from the API
+        # at all: the shipped Latvian name for olive is "Olīve", which
+        # slugify folds to "olive", a canonical slug. It lands on its own
+        # allergen today. Sent for a DIFFERENT allergen it would claim the
+        # olive row, so the guard has to refuse it on the slug rather than on
+        # the language it looks like.
+        entry, ent_reg, olive_id = self._register(hass, "olive")
+
+        await _setup_with_shipped_blocks(
+            hass, "lv", self._response("Olīve (Betula)"), entry=entry
+        )
+
+        kept = ent_reg.async_get("sensor.polleninformation_hamburg_olive")
+        assert kept is not None
+        assert kept.id == olive_id
+        assert kept.unique_id == "polleninformation_hamburg_olive"
+
+    @pytest.mark.parametrize(
+        ("lang", "poll_title", "slug"),
+        [
+            # The three entries in the shipped map whose display name already
+            # slugifies to a canonical allergen slug. Each lands on its OWN
+            # allergen, so each must keep working: the guard refuses a
+            # candidate that names a DIFFERENT allergen, not one that agrees.
+            ("de", "Ragweed (Ambrosia)", "ragweed"),
+            ("sk", "Ragweed (Ambrosia)", "ragweed"),
+            ("lv", "Olīve (Olea)", "olive"),
+        ],
+    )
+    async def test_the_shipped_near_collisions_keep_their_own_row(
+        self, hass, lang, poll_title, slug
+    ):
+        entry, ent_reg, original_id = self._register(hass, slug)
+
+        await _setup_with_shipped_blocks(
+            hass, lang, self._response(poll_title), entry=entry
+        )
+
+        kept = ent_reg.async_get(f"sensor.polleninformation_hamburg_{slug}")
+        assert kept is not None
+        assert kept.id == original_id
+        assert kept.unique_id == f"polleninformation_hamburg_{slug}"
+
     async def test_an_ordinary_localized_name_is_still_migrated(self, hass):
         # The guard may not cost the migration its actual job: "Beifuß" is
         # nobody else's canonical slug, so it is still a candidate.

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2440,6 +2440,49 @@ class TestTheRiskGateAtSetup:
         assert "polleninformation_hamburg_allergy_risk_hourly" in unique_ids
 
 
+class TestTheHourlyReaderTakesAnyShape:
+    """A day of readings is a sequence, and the reader says so.
+
+    usable_risk_block answers the shared question, whether there is anything
+    here to read. What a value must LOOK like to be read is per reader: the
+    daily one wants a number and already swallows anything else, this one
+    wants a sequence of hours. A scalar has no length and a mapping is indexed
+    by key, so both used to raise inside the property, once per entity per
+    read.
+    """
+
+    @staticmethod
+    def _sensor(values):
+        return AllergyRiskHourlySensor(
+            coordinator=_make_coordinator(
+                {"allergyrisk_hourly": {"allergyrisk_hourly_1": values}}
+            ),
+            levels_current=["none", "low", "moderate", "high", "very high"],
+            location_slug="hamburg",
+            location_title="Hamburg",
+        )
+
+    @pytest.mark.parametrize("values", [5, 5.0, True, "abc", {"a": 1}, None, []])
+    def test_a_day_that_is_not_a_sequence_reports_unknown(self, values):
+        sensor = self._sensor(values)
+
+        assert sensor.native_value is None
+        # No forecast, whether the block was refused by the predicate or the
+        # day inside it turned out not to be a day.
+        assert sensor.extra_state_attributes.get("forecast", []) == []
+
+    def test_a_real_day_still_reads(self):
+        sensor = self._sensor([6.0] * 24)
+
+        assert sensor.native_value is not None
+        assert len(sensor.extra_state_attributes["forecast"]) == 24
+
+    def test_a_short_day_reads_the_hours_it_has(self):
+        sensor = self._sensor([6.0, 6.0, 6.0])
+
+        assert len(sensor.extra_state_attributes["forecast"]) == 3
+
+
 class TestARiskBlockWithNothingReadable:
     """Nonempty is not usable, one level deeper than last time.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
 
 import pytest
+from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -1299,6 +1300,225 @@ ITALIAN_RAGWEED_RESPONSE = {
     "allergyrisk": {"allergyrisk_1": 5.0},
     "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
 }
+
+
+async def _setup_through_the_platform(hass, lang, response, entry=None):
+    """Run setup the way Home Assistant does, so the entities are really added.
+
+    The helper above hands async_add_entities a list collector, which is
+    enough for anything decided during setup but never registers an entity or
+    runs its lifecycle. Anything an entity does on being added -- writing to
+    its own registry row, here -- is invisible to that helper and has to be
+    exercised through the platform.
+    """
+    if entry is None:
+        entry = _make_entry(lang)
+        entry.add_to_hass(hass)
+
+    async def _block(_hass, lang_code):
+        return shipped_block(lang_code)
+
+    with (
+        patch(
+            "custom_components.polleninformation.async_get_pollenat_data",
+            AsyncMock(return_value=response),
+        ),
+        patch(
+            "custom_components.polleninformation.sensor.async_get_language_block",
+            AsyncMock(side_effect=_block),
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _recorded_latin(ent_reg, entity_id):
+    """The latin name a registry row records for itself, or None."""
+    entry = ent_reg.async_get(entity_id)
+    assert entry is not None, entity_id
+    return (entry.options.get(DOMAIN) or {}).get("latin")
+
+
+class TestTheRegistryRowRecordsWhichAllergenItIs:
+    """The registry keeps nothing that says which allergen a row is.
+
+    A slug no map can place is checkable against nothing, so a rename
+    candidate has had to be trusted on its name alone. Per-entity options
+    under this integration's domain are where something of ours survives a
+    restart, so that is where the latin name goes.
+    """
+
+    @staticmethod
+    def _response(*poll_titles):
+        return {
+            "contamination": [
+                {"poll_title": title, "contamination_1": 2} for title in poll_titles
+            ],
+            "allergyrisk": {},
+            "allergyrisk_hourly": {},
+        }
+
+    async def test_a_newly_created_sensor_records_its_allergen(self, hass):
+        await _setup_through_the_platform(
+            hass, "de", self._response("Beifu\u00df (Artemisia)")
+        )
+
+        ent_reg = er.async_get(hass)
+        assert (
+            _recorded_latin(ent_reg, "sensor.polleninformation_hamburg_mugwort")
+            == "Artemisia"
+        )
+
+    async def test_a_row_that_already_existed_is_recorded_too(self, hass):
+        # The backfill. An installation upgrading into this has a row for
+        # every allergen it has ever seen and an option on none of them, so
+        # recording only what is created afterwards would leave the whole
+        # existing population unaccounted for.
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        existing = ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_mugwort",
+            suggested_object_id="polleninformation_hamburg_mugwort",
+            config_entry=entry,
+        )
+        assert existing.options.get(DOMAIN) is None
+
+        await _setup_through_the_platform(
+            hass, "de", self._response("Beifu\u00df (Artemisia)"), entry=entry
+        )
+
+        assert (
+            _recorded_latin(ent_reg, "sensor.polleninformation_hamburg_mugwort")
+            == "Artemisia"
+        )
+
+    async def test_recording_the_same_allergen_again_writes_nothing(self, hass):
+        entry = await _setup_through_the_platform(
+            hass, "de", self._response("Beifu\u00df (Artemisia)")
+        )
+        ent_reg = er.async_get(hass)
+        entity_id = "sensor.polleninformation_hamburg_mugwort"
+        before = ent_reg.async_get(entity_id).modified_at
+
+        writes = []
+
+        @callback
+        def _seen(event):
+            if "options" in event.data.get("changes", {}):
+                writes.append(event.data["entity_id"])
+
+        hass.bus.async_listen(er.EVENT_ENTITY_REGISTRY_UPDATED, _seen)
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await _setup_through_the_platform(
+            hass, "de", self._response("Beifu\u00df (Artemisia)"), entry=entry
+        )
+
+        assert writes == []
+        assert ent_reg.async_get(entity_id).modified_at == before
+
+    async def test_the_genus_a_recreated_sensor_knows_does_not_overwrite_a_species(
+        self, hass
+    ):
+        # The two paths that can name this allergen disagree in detail: the
+        # response can send a species, while a sensor rebuilt from its slug
+        # can only name the genus. They mean the same allergen, so neither
+        # may keep rewriting the other.
+        entry = await _setup_through_the_platform(
+            hass, "de", self._response("Beifu\u00df (Artemisia vulgaris)")
+        )
+        ent_reg = er.async_get(hass)
+        entity_id = "sensor.polleninformation_hamburg_mugwort"
+        assert _recorded_latin(ent_reg, entity_id) == "Artemisia vulgaris"
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await _setup_through_the_platform(
+            hass, "de", self._response("Beifu\u00df (Artemisia)"), entry=entry
+        )
+
+        assert _recorded_latin(ent_reg, entity_id) == "Artemisia vulgaris"
+
+    async def test_nothing_else_on_the_row_is_disturbed(self, hass):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_mugwort",
+            suggested_object_id="polleninformation_hamburg_mugwort",
+            config_entry=entry,
+        )
+        entity_id = "sensor.polleninformation_hamburg_mugwort"
+        ent_reg.async_update_entity(entity_id, name="My mugwort", icon="mdi:custom")
+        # Another integration's options, which this must carry across
+        # untouched: async_update_entity_options replaces one domain's key
+        # and leaves the rest of the mapping alone.
+        ent_reg.async_update_entity_options(
+            entity_id, "conversation", {"should_expose": False}
+        )
+
+        await _setup_through_the_platform(
+            hass, "de", self._response("Beifu\u00df (Artemisia)"), entry=entry
+        )
+
+        row = ent_reg.async_get(entity_id)
+        assert row.name == "My mugwort"
+        assert row.icon == "mdi:custom"
+        assert row.options["conversation"] == {"should_expose": False}
+        assert row.options[DOMAIN]["latin"] == "Artemisia"
+
+    async def test_an_allergen_this_response_does_not_carry_records_nothing(self, hass):
+        # Nothing identified this row's allergen in this response, so nothing
+        # is known about it that was not known before.
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_birch",
+            suggested_object_id="polleninformation_hamburg_birch",
+            config_entry=entry,
+        )
+
+        await _setup_through_the_platform(
+            hass, "de", self._response("Beifu\u00df (Artemisia)"), entry=entry
+        )
+
+        assert (
+            _recorded_latin(ent_reg, "sensor.polleninformation_hamburg_birch") is None
+        )
+
+    async def test_a_sensor_recreated_during_an_outage_records_nothing(self, hass):
+        # Such a sensor derived its latin name from its own slug, so
+        # recording it would write down the assumption the record exists to
+        # check rather than anything the API said.
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_mugwort",
+            suggested_object_id="polleninformation_hamburg_mugwort",
+            config_entry=entry,
+        )
+
+        await _setup_through_the_platform(
+            hass,
+            "de",
+            {"contamination": [], "allergyrisk": {}, "allergyrisk_hourly": {}},
+            entry=entry,
+        )
+
+        assert (
+            _recorded_latin(ent_reg, "sensor.polleninformation_hamburg_mugwort") is None
+        )
 
 
 class TestALegacyCandidateFromTheLiveResponse:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2280,6 +2280,71 @@ class TestABlockThatIsNotAnObject:
         assert sensor.native_value is None
 
 
+class TestTheRiskGateAtSetup:
+    """Risk sensors are gated on the API having SENT pollen data.
+
+    Not on our having read it. An empty contamination block means the API had
+    nothing to say and a risk number beside it is meaningless, which is what
+    the gate was written for. A block we could not parse is the opposite: the
+    forecast was there, we failed at it, and the risk reading is real.
+    """
+
+    @staticmethod
+    def _response(contamination, **blocks):
+        return {
+            "contamination": contamination,
+            "allergyrisk": {"allergyrisk_1": 7.0},
+            "allergyrisk_hourly": {"allergyrisk_hourly_1": [7.0] * 24},
+            **blocks,
+        }
+
+    async def _setup(self, hass, response):
+        return await _setup_entities(
+            hass, "de", response=response, language_block=EMPTY_LANGUAGE_BLOCK
+        )
+
+    async def test_a_real_reading_survives_a_block_we_could_not_parse(self, hass):
+        entities = await self._setup(
+            hass, self._response([{"poll_title": "()"}, {"poll_title": ""}])
+        )
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_allergy_risk" in unique_ids
+        assert "polleninformation_hamburg_allergy_risk_hourly" in unique_ids
+
+    async def test_the_reading_is_the_one_the_api_sent(self, hass):
+        entities = await self._setup(hass, self._response([{"poll_title": "()"}]))
+        sensor = _by_type(entities, AllergyRiskSensor)
+
+        # 7.0 on the API's 0-10 scale, scaled to the 0-4 level names.
+        assert sensor.native_value == "hoch"
+
+    async def test_an_empty_block_still_suppresses_them(self, hass):
+        # Unchanged, and the reason the gate exists: the API said nothing at
+        # all, so a risk number beside it means nothing either.
+        entities = await self._setup(hass, self._response([]))
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_allergy_risk" not in unique_ids
+
+    async def test_a_risk_block_that_is_not_an_object_builds_no_sensor(self, hass):
+        # The fifth emptiness site. This gate kept its own raw read, so a
+        # non-object block was truthy here and empty for every other reader:
+        # the entity was built and then reported unknown forever.
+        entities = await self._setup(
+            hass,
+            self._response(
+                [{"poll_title": "Birke (Betula)", "contamination_1": 1}],
+                allergyrisk=["x"],
+            ),
+        )
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_allergy_risk" not in unique_ids
+        # The hourly block is fine, so its sensor is unaffected.
+        assert "polleninformation_hamburg_allergy_risk_hourly" in unique_ids
+
+
 class TestEveryEntityReportsTheSameOutage:
     """The timestamp belongs to the response, so siblings must agree on it.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1558,3 +1558,78 @@ class TestStateMachineCollision:
             ent_reg.async_get_entity_id("sensor", DOMAIN, DAILY_UNIQUE_ID)
             == "sensor.polleninformation_hamburg_allergierisiko"
         )
+
+
+# --- Stale sensors recreated from the registry (issue #73) ---
+
+
+EMPTY_RESPONSE = {"contamination": [], "allergyrisk": {}, "allergyrisk_hourly": {}}
+
+GERMAN_BIRCH_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Birke (Betula)",
+            "contamination_1": 3,
+            "contamination_2": 2,
+            "contamination_3": 1,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {},
+    "allergyrisk_hourly": {},
+}
+
+ENGLISH_DOCK_SORREL_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Dock/Sorrel (Rumex)",
+            "contamination_1": 2,
+            "contamination_2": 2,
+            "contamination_3": 1,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {},
+    "allergyrisk_hourly": {},
+}
+
+
+class TestStaleSensorRecovery:
+    """A sensor recreated during an empty response must recover on any language."""
+
+    async def _recreate(self, hass, lang, unique_id):
+        entry = _make_entry(lang)
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            unique_id,
+            suggested_object_id=unique_id,
+            config_entry=entry,
+        )
+        entities = await _setup_entities(
+            hass,
+            lang,
+            entry=entry,
+            response=EMPTY_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        return _by_type(entities, PolleninformationSensor)
+
+    async def test_german_sensor_recovers_on_localized_poll_title(self, hass):
+        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
+        assert sensor.native_value == "hoch"
+
+    async def test_german_forecast_recovers(self, hass):
+        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
+        assert len(sensor.extra_state_attributes["forecast"]) == 4
+
+    async def test_english_dock_sorrel_recovers(self, hass):
+        sensor = await self._recreate(
+            hass, "en", "polleninformation_hamburg_dock_sorrel"
+        )
+        sensor.coordinator.data = ENGLISH_DOCK_SORREL_RESPONSE
+        assert sensor.native_value == "moderate"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1928,75 +1928,15 @@ class TestStaleSensorRecovery:
         assert sensor.native_value is None
 
 
-# A title with brackets but nothing in them, beside a language map entry whose
-# name is blank. The map can hold such an entry for an allergen the API named
-# by its latin name alone, which is the "(Poaceae)" shape the generator
-# records. The title is readable, so it still becomes a sensor; it just has no
-# name part, which is what the backfill compares on.
-NAMELESS_TITLE_RESPONSE = {
-    "contamination": [
-        {
-            "poll_title": "()",
-            "contamination_1": 1,
-            "contamination_2": 0,
-            "contamination_3": 0,
-            "contamination_4": 0,
-        }
-    ],
-    "allergyrisk": {"allergyrisk_1": 5.0},
-    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
-}
-
-BLANK_NAMED_LANGUAGE_BLOCK = {"poll_titles": [{"name": "", "latin": "Poaceae"}]}
-
-
-class TestABlankNameNeverMatchesABlankName:
-    """The backfill matches an API title against the language map by name.
-
-    Both sides can be blank: the API sends a title with no name part and no
-    brackets, and the map can hold an entry whose name is blank. Letting those
-    match would hand the nameless entry the other one's latin name and make it
-    that allergen, with nothing in the response saying so.
-    """
-
-    async def _setup(self, hass):
-        return await _setup_entities(
-            hass,
-            "de",
-            response=NAMELESS_TITLE_RESPONSE,
-            language_block=BLANK_NAMED_LANGUAGE_BLOCK,
-        )
-
-    async def test_the_nameless_entry_does_not_become_that_allergen(self, hass):
-        entities = await self._setup(hass)
-        unique_ids = {e.unique_id for e in entities if e.unique_id}
-        assert "polleninformation_hamburg_grasses" not in unique_ids
-
-    async def test_it_claims_no_latin_name_of_its_own(self, hass):
-        entities = await self._setup(hass)
-        sensor = _by_type(entities, PolleninformationSensor)
-        assert sensor.extra_state_attributes["name_la"] == ""
-
-    async def test_a_named_entry_still_matches_the_map(self, hass):
-        # The guard may not cost the backfill its actual job.
-        entities = await _setup_entities(
-            hass,
-            "de",
-            response=GERMAN_BIRCH_RESPONSE_WITHOUT_LATIN,
-            language_block={"poll_titles": [{"name": "Birke", "latin": "Betula"}]},
-        )
-        sensor = _by_type(entities, PolleninformationSensor)
-        assert sensor.extra_state_attributes["name_la"] == "Betula"
-
-
-class TestAnEntryWithNoReadableTitleGetsNoSensor:
+class TestAnEntryThatIdentifiesNothingGetsNoSensor:
     """The setup path agrees with the language map generator.
 
-    An entry with no readable title identifies nothing, so building a sensor
-    from it manufactures an entity with no name, no latin name and an
-    entity_id ending in nothing, which no later response and no restore path
-    can match back to an allergen. The generator refuses to record such an
-    entry; the runtime refuses to build one.
+    The test is what the entry identifies, not whether its title can be read:
+    "()" is a non-blank title with nothing in either half of it. Such an entry
+    names no allergen, so building a sensor from it manufactures an entity
+    with no name, no latin name and an entity_id ending in nothing, which no
+    later response and no restore path can match back to an allergen. The
+    generator refuses to record one; the runtime refuses to build one.
     """
 
     @staticmethod
@@ -2019,10 +1959,16 @@ class TestAnEntryWithNoReadableTitleGetsNoSensor:
     @pytest.mark.parametrize(
         "item",
         [
+            # Nothing to read at all.
             {"poll_title": "", "contamination_1": 1},
             {"poll_title": "   ", "contamination_1": 1},
             {"poll_title": 123, "contamination_1": 1},
             {"contamination_1": 1},
+            # Readable, and still naming nothing.
+            {"poll_title": "()", "contamination_1": 1},
+            {"poll_title": "( )", "contamination_1": 1},
+            {"poll_title": "  (  )  ", "contamination_1": 1},
+            {"poll_title": "()extra", "contamination_1": 1},
         ],
     )
     async def test_no_sensor_is_built_for_it(self, hass, item):
@@ -2038,16 +1984,30 @@ class TestAnEntryWithNoReadableTitleGetsNoSensor:
         assert len(pollen) == 1
         assert pollen[0].unique_id == "polleninformation_hamburg_birch"
 
-    async def test_no_entity_id_ending_in_nothing(self, hass):
+    @pytest.mark.parametrize("poll_title", ["", "()"])
+    async def test_no_entity_id_ending_in_nothing(self, hass, poll_title):
         entities = await _setup_entities(
             hass,
             "de",
-            response=self._response({"poll_title": "", "contamination_1": 1}),
+            response=self._response({"poll_title": poll_title, "contamination_1": 1}),
             language_block=EMPTY_LANGUAGE_BLOCK,
         )
         unique_ids = {e.unique_id for e in entities if e.unique_id}
 
         assert "polleninformation_hamburg_" not in unique_ids
+
+    async def test_a_latin_name_alone_is_still_an_allergen(self, hass):
+        # The other side of the rule: "(Poaceae)" has no display name in this
+        # language, but it identifies an allergen and keeps its sensor.
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=self._response({"poll_title": "(Poaceae)", "contamination_1": 1}),
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_grasses" in unique_ids
 
     async def test_it_is_warned_about(self, hass, caplog):
         with caplog.at_level(logging.WARNING):
@@ -2057,7 +2017,7 @@ class TestAnEntryWithNoReadableTitleGetsNoSensor:
                 response=self._response({"poll_title": "", "contamination_1": 1}),
                 language_block=EMPTY_LANGUAGE_BLOCK,
             )
-        assert [r for r in caplog.records if "no readable title" in r.getMessage()]
+        assert [r for r in caplog.records if "identifies no allergen" in r.getMessage()]
 
     async def test_a_readable_entry_is_untouched(self, hass):
         # The guard may not cost an ordinary allergen its sensor.

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -9,6 +9,9 @@ import pytest
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.polleninformation import (
+    PollenInformationDataUpdateCoordinator,
+)
 from custom_components.polleninformation.const import DOMAIN
 from custom_components.polleninformation.sensor import (
     ALLERGEN_ICON_MAP,
@@ -120,23 +123,33 @@ def _frozen(moment):
     )
 
 
+def _frozen_util(moment):
+    """Patch the coordinator module's clock to a fixed moment."""
+    return patch("custom_components.polleninformation.dt_util.now", return_value=moment)
+
+
 def _make_coordinator(
     data, last_updated=None, last_update_success=True, empty_since=_UNSET
 ):
     """Create a mock coordinator with the given data.
 
-    empty_since follows the rule the real coordinator applies in
-    _track_empty_response, so a response with no contamination looks stale
-    here too. A test that swaps .data afterwards sets it explicitly, which is
-    what the coordinator would do on the next refresh.
+    empty_since is set by the real coordinator method rather than by a copy
+    of its rule, so these tests cannot stay green against a production rule
+    that has changed. A test that swaps .data afterwards sets it explicitly,
+    which is what the next refresh would do.
     """
     coordinator = MagicMock()
     coordinator.data = data
     coordinator.last_updated = last_updated or datetime.now(timezone.utc)
     coordinator.last_update_success = last_update_success
+    coordinator.empty_since = None
     if empty_since is _UNSET:
-        empty_since = None if (data or {}).get("contamination") else T1.isoformat()
-    coordinator.empty_since = empty_since
+        with _frozen_util(T1):
+            PollenInformationDataUpdateCoordinator._track_empty_response(
+                coordinator, data or {}
+            )
+    else:
+        coordinator.empty_since = empty_since
     return coordinator
 
 
@@ -1920,6 +1933,29 @@ class TestAMissingReadingIsUnknownNotStale:
         assert sensor.native_value is None
         assert attrs["data_stale"] is True
         assert attrs["stale_since"] == T1.isoformat()
+
+    @pytest.mark.parametrize(
+        ("cls", "block"),
+        [
+            (AllergyRiskSensor, {"allergyrisk": {"allergyrisk_1": 7.5}}),
+            (
+                AllergyRiskHourlySensor,
+                {"allergyrisk_hourly": {"allergyrisk_hourly_1": [7.5] * 24}},
+            ),
+        ],
+    )
+    def test_a_risk_only_response_is_not_an_outage(self, cls, block):
+        """A reading and a stale marker must never appear together.
+
+        contamination can be empty while the risk blocks carry data, and a
+        sensor reporting a current level while advertising data_stale is the
+        contradiction the response-level definition exists to prevent.
+        """
+        sensor = self._risk(cls, block, contamination=[])
+        attrs = sensor.extra_state_attributes
+        assert sensor.native_value == "high"
+        assert "data_stale" not in attrs
+        assert "stale_since" not in attrs
 
     def test_an_unusable_pollen_level_is_unknown_without_a_marker(self):
         """A level the level names do not cover leaves no value either."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1893,3 +1893,55 @@ class TestStaleSinceFollowsTheCurrentOutage:
         assert attrs["data_stale"] is True
         assert attrs["stale_since"] == T2.isoformat()
 
+
+class TestGenusPrefixedNameOnTheSetupPath:
+    """Prose that begins with a latin genus must not be taken for that genus.
+
+    The setup path owns the entity_id and queues the rename, so resolving
+    "Ambrosia hojas" to ragweed there does more than mis-match a sensor.
+    """
+
+    async def _setup(self, hass, entry=None):
+        return await _setup_entities(
+            hass,
+            "es",
+            entry=entry,
+            response=GENUS_PREFIXED_NAME_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+
+    async def test_does_not_take_the_ragweed_slug(self, hass):
+        entities = await self._setup(hass)
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+        assert "polleninformation_hamburg_ragweed" not in unique_ids
+        assert "polleninformation_hamburg_ambrosia_hojas" in unique_ids
+
+    async def test_does_not_report_the_prose_as_a_latin_name(self, hass):
+        entities = await self._setup(hass)
+        sensor = _by_type(entities, PolleninformationSensor)
+        assert sensor.extra_state_attributes["name_la"] == ""
+
+    async def test_queues_no_rename_onto_ragweed(self, hass):
+        entry = _make_entry("es")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_ambrosia_hojas",
+            suggested_object_id="polleninformation_hamburg_ambrosia_hojas",
+            config_entry=entry,
+        )
+        await self._setup(hass, entry=entry)
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_ambrosia_hojas"
+            )
+            == "sensor.polleninformation_hamburg_ambrosia_hojas"
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_ragweed"
+            )
+            is None
+        )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1928,13 +1928,15 @@ class TestStaleSensorRecovery:
         assert sensor.native_value is None
 
 
-# A title with no name part and no brackets, beside a language map entry whose
-# name is blank. The map can hold one for an allergen the API named by its
-# latin name alone, which is the "(Poaceae)" shape the generator records.
+# A title with brackets but nothing in them, beside a language map entry whose
+# name is blank. The map can hold such an entry for an allergen the API named
+# by its latin name alone, which is the "(Poaceae)" shape the generator
+# records. The title is readable, so it still becomes a sensor; it just has no
+# name part, which is what the backfill compares on.
 NAMELESS_TITLE_RESPONSE = {
     "contamination": [
         {
-            "poll_title": "",
+            "poll_title": "()",
             "contamination_1": 1,
             "contamination_2": 0,
             "contamination_3": 0,
@@ -1985,6 +1987,83 @@ class TestABlankNameNeverMatchesABlankName:
         )
         sensor = _by_type(entities, PolleninformationSensor)
         assert sensor.extra_state_attributes["name_la"] == "Betula"
+
+
+class TestAnEntryWithNoReadableTitleGetsNoSensor:
+    """The setup path agrees with the language map generator.
+
+    An entry with no readable title identifies nothing, so building a sensor
+    from it manufactures an entity with no name, no latin name and an
+    entity_id ending in nothing, which no later response and no restore path
+    can match back to an allergen. The generator refuses to record such an
+    entry; the runtime refuses to build one.
+    """
+
+    @staticmethod
+    def _response(item):
+        return {
+            "contamination": [
+                item,
+                {
+                    "poll_title": "Birke (Betula)",
+                    "contamination_1": 3,
+                    "contamination_2": 2,
+                    "contamination_3": 1,
+                    "contamination_4": 0,
+                },
+            ],
+            "allergyrisk": {"allergyrisk_1": 5.0},
+            "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+        }
+
+    @pytest.mark.parametrize(
+        "item",
+        [
+            {"poll_title": "", "contamination_1": 1},
+            {"poll_title": "   ", "contamination_1": 1},
+            {"poll_title": 123, "contamination_1": 1},
+            {"contamination_1": 1},
+        ],
+    )
+    async def test_no_sensor_is_built_for_it(self, hass, item):
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=self._response(item),
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        pollen = [e for e in entities if isinstance(e, PolleninformationSensor)]
+
+        # Only the birch entry beside it became a sensor.
+        assert len(pollen) == 1
+        assert pollen[0].unique_id == "polleninformation_hamburg_birch"
+
+    async def test_no_entity_id_ending_in_nothing(self, hass):
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=self._response({"poll_title": "", "contamination_1": 1}),
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_" not in unique_ids
+
+    async def test_it_is_warned_about(self, hass, caplog):
+        with caplog.at_level(logging.WARNING):
+            await _setup_entities(
+                hass,
+                "de",
+                response=self._response({"poll_title": "", "contamination_1": 1}),
+                language_block=EMPTY_LANGUAGE_BLOCK,
+            )
+        assert [r for r in caplog.records if "no readable title" in r.getMessage()]
+
+    async def test_a_readable_entry_is_untouched(self, hass):
+        # The guard may not cost an ordinary allergen its sensor.
+        entities = await _setup_entities(hass, "de")
+        sensor = _by_type(entities, PolleninformationSensor)
+        assert sensor.unique_id == "polleninformation_hamburg_ragweed"
 
 
 class TestReportedLatinNameAcrossAnOutage:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1452,7 +1452,11 @@ class TestDeclaredLatinNameAliases:
         unique_ids = {e.unique_id for e in entities if e.unique_id}
         assert "polleninformation_hamburg_ragweed" in unique_ids
 
-    async def test_the_latin_name_is_reported_canonically(self, hass):
+    async def test_the_alias_is_reported_as_the_name_it_stands_for(self, hass):
+        # Not a canonicalization rule: the alias case is the one where what
+        # the API sent and the map key happen to coincide. What the two paths
+        # do with a latin name that is not an alias is pinned in
+        # TestReportedLatinNameAcrossAnOutage.
         entities = await self._setup(hass)
         sensor = _by_type(entities, PolleninformationSensor)
         assert sensor.extra_state_attributes["name_la"] == "Ambrosia"
@@ -1908,6 +1912,47 @@ class TestStaleSensorRecovery:
         sensor = await _recreate_stale(hass, "es", "polleninformation_hamburg_ragweed")
         sensor.coordinator.data = GENUS_PREFIXED_NAME_RESPONSE
         assert sensor.native_value is None
+
+
+class TestReportedLatinNameAcrossAnOutage:
+    """What name_la says on each path, including where they differ.
+
+    The setup path reports what the API sent about this allergen, species
+    included. The restore path has only the slug to work from, so the most it
+    can say is the key of LATIN_TO_ENGLISH_NAME. For an allergen the API
+    spells with a genus alone the two coincide; for one it spells with a
+    species they do not, and that difference is deliberate: matching them
+    would mean discarding a species the API did send.
+    """
+
+    async def test_the_setup_path_reports_the_species_the_api_sent(self, hass):
+        entities = await _setup_entities(hass, "de")
+        sensor = _by_type(entities, PolleninformationSensor)
+        assert sensor.extra_state_attributes["name_la"] == "Ambrosia artemisiifolia"
+
+    async def test_the_restore_path_reports_the_map_key(self, hass):
+        sensor = await _recreate_stale(hass, "de", "polleninformation_hamburg_ragweed")
+        assert sensor.extra_state_attributes["name_la"] == "Ambrosia"
+
+    async def test_the_difference_lasts_no_longer_than_the_outage(self, hass):
+        # The restore path only runs while the API is answering with nothing.
+        # The first answer that carries data goes through setup again, so the
+        # species comes back with it.
+        stale = await _recreate_stale(hass, "de", "polleninformation_hamburg_ragweed")
+        assert stale.extra_state_attributes["name_la"] == "Ambrosia"
+
+        entities = await _setup_entities(hass, "de")
+        recovered = _by_type(entities, PolleninformationSensor)
+        assert recovered.extra_state_attributes["name_la"] == "Ambrosia artemisiifolia"
+
+    async def test_the_paths_agree_when_the_api_sends_the_genus_alone(self, hass):
+        # Most allergens, and the reason the difference is easy to miss.
+        entities = await _setup_entities(hass, "de", response=GERMAN_BIRCH_RESPONSE)
+        setup_sensor = _by_type(entities, PolleninformationSensor)
+        stale = await _recreate_stale(hass, "de", "polleninformation_hamburg_birch")
+
+        assert setup_sensor.extra_state_attributes["name_la"] == "Betula"
+        assert stale.extra_state_attributes["name_la"] == "Betula"
 
 
 class TestEveryEntityReportsTheSameOutage:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -106,12 +106,37 @@ class TestExtractAllergenSlug:
 # --- Sensor class tests ---
 
 
-def _make_coordinator(data, last_updated=None, last_update_success=True):
-    """Create a mock coordinator with the given data."""
+T1 = datetime(2026, 8, 18, 6, 0, tzinfo=timezone.utc)
+T2 = datetime(2026, 8, 18, 18, 0, tzinfo=timezone.utc)
+
+_UNSET = object()
+
+
+def _frozen(moment):
+    """Patch the sensor module's clock to a fixed moment."""
+    return patch(
+        "custom_components.polleninformation.sensor.dt_util.now",
+        return_value=moment,
+    )
+
+
+def _make_coordinator(
+    data, last_updated=None, last_update_success=True, empty_since=_UNSET
+):
+    """Create a mock coordinator with the given data.
+
+    empty_since follows the rule the real coordinator applies in
+    _track_empty_response, so a response with no contamination looks stale
+    here too. A test that swaps .data afterwards sets it explicitly, which is
+    what the coordinator would do on the next refresh.
+    """
     coordinator = MagicMock()
     coordinator.data = data
     coordinator.last_updated = last_updated or datetime.now(timezone.utc)
     coordinator.last_update_success = last_update_success
+    if empty_since is _UNSET:
+        empty_since = None if (data or {}).get("contamination") else T1.isoformat()
+    coordinator.empty_since = empty_since
     return coordinator
 
 
@@ -165,12 +190,10 @@ class TestPolleninformationSensor:
             location_slug="hamburg",
             location_title="Hamburg",
             icon="mdi:tree-outline",
-            is_stale=True,
-            stale_since="2026-03-25T12:00:00",
         )
         attrs = sensor.extra_state_attributes
         assert attrs["data_stale"] is True
-        assert attrs["stale_since"] == "2026-03-25T12:00:00"
+        assert attrs["stale_since"] == T1.isoformat()
 
     def test_available_when_success(self, mock_api_response):
         sensor = self._make_sensor(
@@ -206,7 +229,6 @@ class TestAllergyRiskSensor:
             levels_current=["none", "low", "moderate", "high", "very high"],
             location_slug="hamburg",
             location_title="Hamburg",
-            is_stale=True,
         )
         assert sensor.native_value is None
 
@@ -217,9 +239,8 @@ class TestAllergyRiskSensor:
             levels_current=["none", "low", "moderate", "high", "very high"],
             location_slug="hamburg",
             location_title="Hamburg",
-            is_stale=True,
         )
-        # Even though created as stale, fresh coordinator data is used
+        # A sensor created during an outage still reads fresh data
         assert sensor.native_value == "moderate"
 
     def test_attributes_forecast(self, mock_api_response):
@@ -1723,26 +1744,28 @@ class TestStaleSensorRecovery:
         sensor.coordinator.data = LATIN_GENUS_AS_NAME_RESPONSE
         assert sensor.native_value == "bajo"
 
-    async def test_stale_flag_clears_once_the_allergen_is_found(self, hass):
-        """A recovered sensor must stop claiming its data is stale.
-
-        The flag is set in the constructor and async_setup_entry does not run
-        again when the API recovers, so it has to be derived from whether the
-        allergen was actually found.
-        """
+    async def test_the_marker_clears_when_the_response_carries_data(self, hass):
+        """The marker describes the response, so a response ends it."""
         sensor = await _recreate_stale(hass, "de", "polleninformation_hamburg_birch")
         sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
+        sensor.coordinator.empty_since = None
         attrs = sensor.extra_state_attributes
         assert "data_stale" not in attrs
         assert "stale_since" not in attrs
 
-    async def test_stale_flag_stays_while_the_allergen_is_missing(self, hass):
-        """Data for other allergens only is still no data for this one."""
+    async def test_an_allergen_missing_from_a_healthy_response_is_unknown(self, hass):
+        """One absent allergen is not an outage.
+
+        The response carried data, so nothing about it is stale. This sensor
+        simply has no reading, which Home Assistant expresses as unknown.
+        """
         sensor = await _recreate_stale(hass, "de", "polleninformation_hamburg_birch")
         sensor.coordinator.data = LATIN_GENUS_AS_NAME_RESPONSE
+        sensor.coordinator.empty_since = None
         attrs = sensor.extra_state_attributes
-        assert attrs["data_stale"] is True
-        assert attrs["stale_since"] is not None
+        assert sensor.native_value is None
+        assert "data_stale" not in attrs
+        assert "stale_since" not in attrs
 
     async def test_recovers_when_the_display_name_is_a_binomial_key(self, hass):
         """A binomial key in the latin map: "Ailanthus altissima".
@@ -1768,186 +1791,84 @@ class TestStaleSensorRecovery:
         assert sensor.native_value is None
 
 
-T1 = datetime(2026, 8, 18, 6, 0, tzinfo=timezone.utc)
-T2 = datetime(2026, 8, 18, 18, 0, tzinfo=timezone.utc)
+class TestEveryEntityReportsTheSameOutage:
+    """The timestamp belongs to the response, so siblings must agree on it.
 
-
-def _frozen(moment):
-    """Patch the sensor module's clock to a fixed moment."""
-    return patch(
-        "custom_components.polleninformation.sensor.dt_util.now",
-        return_value=moment,
-    )
-
-
-class TestStaleSinceFollowsTheCurrentOutage:
-    """stale_since must date the outage being reported, not the first one.
-
-    The timestamp is a constructor value, and setup does not run again when
-    the API recovers, so a second outage would otherwise republish the first
-    outage's timestamp and appear to have lasted for the whole gap.
+    The per-outage semantics themselves are the coordinator's, and are tested
+    in test_init.py. What matters here is that an entity reports the
+    coordinator's value rather than one of its own: a card reading
+    stale_since off whichever entity it reaches first must get one answer.
     """
 
-    async def _recreated_at(self, hass, moment):
+    async def _entities_during_an_outage(self, hass):
         entry = _make_entry("de")
         entry.add_to_hass(hass)
         ent_reg = er.async_get(hass)
-        ent_reg.async_get_or_create(
-            "sensor",
-            DOMAIN,
-            "polleninformation_hamburg_birch",
-            suggested_object_id="polleninformation_hamburg_birch",
-            config_entry=entry,
-        )
-        with _frozen(moment):
-            entities = await _setup_entities(
-                hass,
-                "de",
-                entry=entry,
-                response=EMPTY_RESPONSE,
-                language_block=EMPTY_LANGUAGE_BLOCK,
+        for slug in ("birch", "alder", "allergy_risk", "allergy_risk_hourly"):
+            ent_reg.async_get_or_create(
+                "sensor",
+                DOMAIN,
+                f"polleninformation_hamburg_{slug}",
+                suggested_object_id=f"polleninformation_hamburg_{slug}",
+                config_entry=entry,
             )
-        return _by_type(entities, PolleninformationSensor)
-
-    async def test_second_outage_gets_a_fresh_timestamp(self, hass):
-        sensor = await self._recreated_at(hass, T1)
-        with _frozen(T1):
-            assert sensor.extra_state_attributes["stale_since"] == T1.isoformat()
-
-        sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
-        with _frozen(T1):
-            assert "stale_since" not in sensor.extra_state_attributes
-
-        sensor.coordinator.data = EMPTY_RESPONSE
-        with _frozen(T2):
-            attrs = sensor.extra_state_attributes
-        assert attrs["data_stale"] is True
-        assert attrs["stale_since"] == T2.isoformat()
-
-    async def test_the_timestamp_does_not_drift_across_reads(self, hass):
-        """The property is read more than once per update."""
-        sensor = await self._recreated_at(hass, T1)
-        with _frozen(T1):
-            first = sensor.extra_state_attributes["stale_since"]
-        with _frozen(T2):
-            second = sensor.extra_state_attributes["stale_since"]
-        assert first == second == T1.isoformat()
-
-    @pytest.mark.parametrize(
-        ("cls", "key", "payload"),
-        [
-            (AllergyRiskSensor, "allergyrisk", {"allergyrisk_1": 5.0}),
-            (
-                AllergyRiskHourlySensor,
-                "allergyrisk_hourly",
-                {"allergyrisk_hourly_1": [5.0] * 24},
-            ),
-        ],
-    )
-    async def test_risk_sensors_date_the_current_outage(self, cls, key, payload):
-        """The risk sensors froze the same timestamp for the same reason."""
-        coordinator = _make_coordinator({key: {}})
-        sensor = cls(
-            coordinator=coordinator,
-            levels_current=["none", "low", "moderate", "high", "very high"],
-            location_slug="hamburg",
-            location_title="Hamburg",
-            is_stale=True,
-            stale_since=T1.isoformat(),
-        )
-        with _frozen(T1):
-            assert sensor.extra_state_attributes["stale_since"] == T1.isoformat()
-
-        coordinator.data = {key: payload}
-        with _frozen(T1):
-            assert "stale_since" not in sensor.extra_state_attributes
-
-        coordinator.data = {key: {}}
-        with _frozen(T2):
-            attrs = sensor.extra_state_attributes
-        assert attrs["data_stale"] is True
-        assert attrs["stale_since"] == T2.isoformat()
-
-
-class TestGenusPrefixedNameOnTheSetupPath:
-    """Prose that begins with a latin genus must not be taken for that genus.
-
-    The setup path owns the entity_id and queues the rename, so resolving
-    "Ambrosia hojas" to ragweed there does more than mis-match a sensor.
-    """
-
-    async def _setup(self, hass, entry=None):
         return await _setup_entities(
             hass,
-            "es",
+            "de",
             entry=entry,
-            response=GENUS_PREFIXED_NAME_RESPONSE,
+            response=EMPTY_RESPONSE,
             language_block=EMPTY_LANGUAGE_BLOCK,
         )
 
-    async def test_does_not_take_the_ragweed_slug(self, hass):
-        entities = await self._setup(hass)
-        unique_ids = {e.unique_id for e in entities if e.unique_id}
-        assert "polleninformation_hamburg_ragweed" not in unique_ids
-        assert "polleninformation_hamburg_ambrosia_hojas" in unique_ids
+    async def test_all_sensor_kinds_report_one_timestamp(self, hass):
+        entities = await self._entities_during_an_outage(hass)
+        assert len(entities) == 4
+        stamps = {e.extra_state_attributes["stale_since"] for e in entities}
+        assert stamps == {T1.isoformat()}
+        assert all(e.extra_state_attributes["data_stale"] is True for e in entities)
 
-    async def test_does_not_report_the_prose_as_a_latin_name(self, hass):
-        entities = await self._setup(hass)
-        sensor = _by_type(entities, PolleninformationSensor)
-        assert sensor.extra_state_attributes["name_la"] == ""
-
-    async def test_queues_no_rename_onto_ragweed(self, hass):
-        entry = _make_entry("es")
-        entry.add_to_hass(hass)
-        ent_reg = er.async_get(hass)
-        ent_reg.async_get_or_create(
-            "sensor",
-            DOMAIN,
-            "polleninformation_hamburg_ambrosia_hojas",
-            suggested_object_id="polleninformation_hamburg_ambrosia_hojas",
-            config_entry=entry,
-        )
-        await self._setup(hass, entry=entry)
-        assert (
-            ent_reg.async_get_entity_id(
-                "sensor", DOMAIN, "polleninformation_hamburg_ambrosia_hojas"
-            )
-            == "sensor.polleninformation_hamburg_ambrosia_hojas"
-        )
-        assert (
-            ent_reg.async_get_entity_id(
-                "sensor", DOMAIN, "polleninformation_hamburg_ragweed"
-            )
-            is None
-        )
+    async def test_the_marker_is_absent_once_the_coordinator_clears_it(self, hass):
+        entities = await self._entities_during_an_outage(hass)
+        for entity in entities:
+            entity.coordinator.data = RAGWEED_RESPONSE
+            entity.coordinator.empty_since = None
+        for entity in entities:
+            assert "data_stale" not in entity.extra_state_attributes
 
 
 EN_LEVELS = ["none", "low", "moderate", "high", "very high"]
 
+HEALTHY_CONTAMINATION = [{"poll_title": "Birch (Betula)", "contamination_1": 1}]
 
-class TestPartialDataIsNotFreshData:
-    """A sensor with no readable value must not report itself fresh.
 
-    A risk block that is present but carries nothing usable for right now,
-    only a later day, a null, or an empty hourly list, left native_value
-    unknown while clearing the stale marker.
+class TestAMissingReadingIsUnknownNotStale:
+    """A response that carried data is never stale, however thin it is.
+
+    A risk block with nothing usable for right now, only a later day, a null,
+    or an empty hourly list, leaves the sensor without a value. That is state
+    unknown, not an outage: the fetch succeeded and the response had data.
     """
 
-    def _risk(self, cls, data, is_stale=True):
+    def _risk(self, cls, block, contamination=None):
+        data = {
+            "contamination": HEALTHY_CONTAMINATION
+            if contamination is None
+            else contamination
+        }
+        data.update(block)
         return cls(
             coordinator=_make_coordinator(data),
             levels_current=EN_LEVELS,
             location_slug="hamburg",
             location_title="Hamburg",
-            is_stale=is_stale,
-            stale_since=T1.isoformat(),
         )
 
     @pytest.mark.parametrize(
-        ("cls", "data"),
+        ("cls", "block"),
         [
             (AllergyRiskSensor, {"allergyrisk": {"allergyrisk_2": 5.0}}),
             (AllergyRiskSensor, {"allergyrisk": {"allergyrisk_1": None}}),
+            (AllergyRiskSensor, {"allergyrisk": {}}),
             (
                 AllergyRiskHourlySensor,
                 {"allergyrisk_hourly": {"allergyrisk_hourly_2": [5.0] * 24}},
@@ -1959,16 +1880,15 @@ class TestPartialDataIsNotFreshData:
             ),
         ],
     )
-    def test_partial_risk_data_stays_stale(self, cls, data):
-        sensor = self._risk(cls, data)
-        with _frozen(T2):
-            attrs = sensor.extra_state_attributes
+    def test_a_thin_risk_block_is_unknown_without_a_marker(self, cls, block):
+        sensor = self._risk(cls, block)
+        attrs = sensor.extra_state_attributes
         assert sensor.native_value is None
-        assert attrs["data_stale"] is True
-        assert attrs["stale_since"] == T1.isoformat()
+        assert "data_stale" not in attrs
+        assert "stale_since" not in attrs
 
     @pytest.mark.parametrize(
-        ("cls", "data"),
+        ("cls", "block"),
         [
             (AllergyRiskSensor, {"allergyrisk": {"allergyrisk_1": 0.0}}),
             (
@@ -1977,34 +1897,29 @@ class TestPartialDataIsNotFreshData:
             ),
         ],
     )
-    def test_a_zero_reading_is_a_reading(self, cls, data):
+    def test_a_zero_reading_is_a_reading(self, cls, block):
         """No risk at all is a real value, not a missing one."""
-        sensor = self._risk(cls, data)
-        with _frozen(T2):
-            attrs = sensor.extra_state_attributes
+        sensor = self._risk(cls, block)
         assert sensor.native_value == "none"
-        assert "data_stale" not in attrs
-        assert "stale_since" not in attrs
+        assert "data_stale" not in sensor.extra_state_attributes
 
-    def test_repeated_partial_responses_keep_the_first_timestamp(self):
-        """Flickering between partial shapes is one outage, not several."""
-        sensor = self._risk(
-            AllergyRiskSensor, {"allergyrisk": {"allergyrisk_2": 5.0}}, is_stale=False
-        )
-        with _frozen(T1):
-            first = sensor.extra_state_attributes["stale_since"]
-        sensor.coordinator.data = {"allergyrisk": {"allergyrisk_1": None}}
-        with _frozen(T2):
-            second = sensor.extra_state_attributes["stale_since"]
-        assert first == second == T1.isoformat()
+    @pytest.mark.parametrize(
+        ("cls", "block"),
+        [
+            (AllergyRiskSensor, {"allergyrisk": {}}),
+            (AllergyRiskHourlySensor, {"allergyrisk_hourly": {}}),
+        ],
+    )
+    def test_an_empty_response_still_marks_the_risk_sensors(self, cls, block):
+        """The outage itself is response level, and does reach them."""
+        sensor = self._risk(cls, block, contamination=[])
+        attrs = sensor.extra_state_attributes
+        assert sensor.native_value is None
+        assert attrs["data_stale"] is True
+        assert attrs["stale_since"] == T1.isoformat()
 
-    def test_an_unusable_pollen_level_is_not_fresh(self):
-        """The pollen sensor answers the same question the same way.
-
-        A level outside the level names leaves native_value unknown while the
-        forecast is still built, so a forecast alone cannot stand for a
-        reading.
-        """
+    def test_an_unusable_pollen_level_is_unknown_without_a_marker(self):
+        """A level the level names do not cover leaves no value either."""
         sensor = PolleninformationSensor(
             coordinator=_make_coordinator(
                 {
@@ -2023,15 +1938,11 @@ class TestPartialDataIsNotFreshData:
             location_slug="hamburg",
             location_title="Hamburg",
             icon="mdi:tree-outline",
-            is_stale=True,
-            stale_since=T1.isoformat(),
         )
-        with _frozen(T2):
-            attrs = sensor.extra_state_attributes
+        attrs = sensor.extra_state_attributes
         assert sensor.native_value is None
         assert attrs["forecast"]
-        assert attrs["data_stale"] is True
-        assert attrs["stale_since"] == T1.isoformat()
+        assert "data_stale" not in attrs
 
 
 GERMAN_LANGUAGE_BLOCK = {"poll_titles": [{"name": "Birke", "latin": "Betula"}]}

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -32,6 +32,7 @@ from custom_components.polleninformation.sensor import (
     entity_id_available,
     extract_allergen_slug_from_unique_id,
     localized_risk_object_id_suffixes,
+    migrate_localized_allergen_ids,
     resolve_latin_alias,
     scale_allergy_risk,
 )
@@ -1519,6 +1520,128 @@ class TestTheRegistryRowRecordsWhichAllergenItIs:
         assert (
             _recorded_latin(ent_reg, "sensor.polleninformation_hamburg_mugwort") is None
         )
+
+
+class TestARenameThatContradictsWhatTheRowRecords:
+    """The slug guard covers known allergens; this covers the rest.
+
+    A candidate whose slug is another allergen's canonical slug is refused
+    already, because known is detectable. A slug no map can place is not, and
+    those are the rows the escape hatch keeps making: "Foo" was some allergen
+    when its row was created, and a response titled "Foo (Betula)" claims it
+    for birch now. What the row records about itself is the only thing that
+    can tell the two apart, and it is the only thing that outlives the
+    response.
+    """
+
+    @staticmethod
+    def _response(poll_title):
+        return {
+            "contamination": [{"poll_title": poll_title, "contamination_1": 2}],
+            "allergyrisk": {},
+            "allergyrisk_hourly": {},
+        }
+
+    @staticmethod
+    def _register(hass, slug, latin=None):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        registered = ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            f"polleninformation_hamburg_{slug}",
+            suggested_object_id=f"polleninformation_hamburg_{slug}",
+            config_entry=entry,
+        )
+        if latin is not None:
+            ent_reg.async_update_entity_options(
+                registered.entity_id, DOMAIN, {"latin": latin}
+            )
+        return entry, ent_reg, registered.id
+
+    async def test_the_recorded_allergen_keeps_its_row(self, hass):
+        # Nonexistentia is in no map, which is the point: this row belongs to
+        # the population the slug guard cannot speak for, and reading the
+        # record through the allergen slugs would call it unknown and migrate
+        # it anyway.
+        entry, ent_reg, foo_id = self._register(hass, "foo", latin="Nonexistentia")
+
+        await _setup_with_shipped_blocks(
+            hass, "de", self._response("Foo (Betula)"), entry=entry
+        )
+
+        kept = ent_reg.async_get("sensor.polleninformation_hamburg_foo")
+        assert kept is not None
+        assert kept.id == foo_id
+        assert kept.unique_id == "polleninformation_hamburg_foo"
+
+    async def test_the_refusal_is_logged(self, hass, caplog):
+        entry, _, _ = self._register(hass, "foo", latin="Nonexistentia")
+
+        with caplog.at_level(logging.WARNING):
+            await _setup_with_shipped_blocks(
+                hass, "de", self._response("Foo (Betula)"), entry=entry
+            )
+
+        assert [
+            r
+            for r in caplog.records
+            if "recorded as" in r.getMessage() and "Nonexistentia" in r.getMessage()
+        ]
+
+    async def test_a_row_that_records_nothing_is_migrated_as_before(self, hass):
+        # Every row on every installation that upgrades into this. Absent has
+        # to mean unknown, or the feature would arrive by breaking the
+        # migration for everyone who has not run it yet.
+        entry, ent_reg, foo_id = self._register(hass, "foo")
+
+        await _setup_with_shipped_blocks(
+            hass, "de", self._response("Foo (Betula)"), entry=entry
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert migrated is not None
+        assert migrated.id == foo_id
+
+    async def test_a_row_recording_this_same_allergen_is_migrated(self, hass):
+        entry, ent_reg, foo_id = self._register(hass, "foo", latin="Betula")
+
+        await _setup_with_shipped_blocks(
+            hass, "de", self._response("Foo (Betula)"), entry=entry
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert migrated is not None
+        assert migrated.id == foo_id
+
+    async def test_a_species_does_not_contradict_its_own_genus(self, hass):
+        # The response can name a species where the record holds the genus,
+        # or the reverse. They are the same allergen and must not read as a
+        # contradiction.
+        entry, ent_reg, foo_id = self._register(hass, "foo", latin="Betula pendula")
+
+        await _setup_with_shipped_blocks(
+            hass, "de", self._response("Foo (Betula)"), entry=entry
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert migrated is not None
+        assert migrated.id == foo_id
+
+    async def test_a_claim_that_names_no_allergen_is_not_a_contradiction(self, hass):
+        # Unknown on the claiming side is unknown too, never mismatch. Setup
+        # cannot currently queue such a rename -- an entry with no latin name
+        # is slugged from its display name, which is then the slug it already
+        # has -- so the migration is called directly rather than through a
+        # response that cannot produce this.
+        _, ent_reg, foo_id = self._register(hass, "foo", latin="Nonexistentia")
+
+        migrate_localized_allergen_ids(hass, "hamburg", [("foo", "birch", "")])
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert migrated is not None
+        assert migrated.id == foo_id
 
 
 class TestALegacyCandidateFromTheLiveResponse:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -29,6 +29,7 @@ from custom_components.polleninformation.sensor import (
     entity_id_available,
     extract_allergen_slug_from_unique_id,
     localized_risk_object_id_suffixes,
+    resolve_latin_alias,
     scale_allergy_risk,
 )
 from custom_components.polleninformation.utils import slugify
@@ -1393,10 +1394,29 @@ class TestDeclaredLatinNameAliases:
     def test_the_alias_is_matched_case_insensitively(self):
         assert english_name_for_latin("Ambrózia") == "ragweed"
 
-    def test_canonical_latin_rewrites_only_a_declared_alias(self):
+    def test_the_alias_resolver_rewrites_only_a_declared_alias(self):
+        # What the sensor reports as name_la: a declared spelling becomes the
+        # name it stands for, and everything else is left exactly as sent,
+        # species and all.
+        assert resolve_latin_alias("ambrózia") == "Ambrosia"
+        assert resolve_latin_alias("Asteraceae") == "Asteraceae"
+        assert resolve_latin_alias("Ambrosia artemisiifolia") == (
+            "Ambrosia artemisiifolia"
+        )
+        assert resolve_latin_alias("") == ""
+        assert resolve_latin_alias(None) is None
+
+    def test_canonical_latin_returns_the_map_key(self):
+        # What anything keyed by latin name has to store, since the language
+        # block lookups match exactly.
         assert canonical_latin("ambrózia") == "Ambrosia"
-        assert canonical_latin("Asteraceae") == "Asteraceae"
-        assert canonical_latin("") == ""
+        assert canonical_latin("poaceae") == "Poaceae"
+        assert canonical_latin(" Poaceae ") == "Poaceae"
+        assert canonical_latin("Ambrosia artemisiifolia") == "Ambrosia"
+
+    def test_canonical_latin_knows_nothing_it_should_not(self):
+        assert canonical_latin("Asteraceae") is None
+        assert canonical_latin("") is None
         assert canonical_latin(None) is None
 
     def test_every_alias_names_an_allergen_the_map_knows(self):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1286,6 +1286,73 @@ class TestEnglishBlockOutranksTheDisplayName:
         )
 
 
+class TestPresentLatinIsAuthoritative:
+    """A latin name the API sent wins even when nothing can resolve it.
+
+    The same response as above, but no language block knows the latin name
+    either. The display name must still not be read as a latin genus: the API
+    said this allergen is Asteraceae, so resolving it to mugwort would name the
+    entity after a different allergen and migrate an existing one onto it.
+    """
+
+    async def _setup(self, hass, entry=None):
+        return await _setup_entities(
+            hass,
+            "de",
+            entry=entry,
+            response=UNKNOWN_LATIN_WITH_GENUS_NAME_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+
+    async def test_falls_back_to_the_configured_language_name(self, hass):
+        entities = await self._setup(hass)
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+        assert "polleninformation_hamburg_artemisia" in unique_ids
+        assert "polleninformation_hamburg_mugwort" not in unique_ids
+
+    async def test_keeps_the_latin_name_the_api_sent(self, hass):
+        entities = await self._setup(hass)
+        sensor = next(
+            e
+            for e in entities
+            if isinstance(e, PolleninformationSensor)
+            and e.unique_id == "polleninformation_hamburg_artemisia"
+        )
+        assert sensor.extra_state_attributes["name_la"] == "Asteraceae"
+
+    async def test_warns_about_the_unknown_allergen(self, hass, caplog):
+        with caplog.at_level(logging.WARNING):
+            await self._setup(hass)
+        assert [r for r in caplog.records if "Unknown allergen" in r.getMessage()]
+
+    async def test_no_rename_is_queued(self, hass):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_artemisia",
+            suggested_object_id="polleninformation_hamburg_artemisia",
+            config_entry=entry,
+        )
+
+        await self._setup(hass, entry=entry)
+
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_artemisia"
+            )
+            == "sensor.polleninformation_hamburg_artemisia"
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_mugwort"
+            )
+            is None
+        )
+
+
 # The canonical slug for every allergen, pinned. These slugs are a public
 # contract: they are the entity_id suffix, they are in every unique_id, and
 # the pollen forecast card matches on them. A change to an API display name or

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2067,6 +2067,98 @@ class TestReportedLatinNameAcrossAnOutage:
         assert stale.extra_state_attributes["name_la"] == "Betula"
 
 
+# A response with entries in it, none of which identify an allergen. The raw
+# block is non-empty, so before the emptiness test was moved onto the usable
+# entries this looked like a response carrying data while building no sensors
+# at all.
+ALL_UNUSABLE_RESPONSE = {
+    "contamination": [
+        {"poll_title": "()", "contamination_1": 1},
+        {"poll_title": "", "contamination_1": 2},
+        {"contamination_1": 3},
+    ],
+    "allergyrisk": {},
+    "allergyrisk_hourly": {},
+}
+
+ALL_UNUSABLE_WITH_RISK_RESPONSE = {
+    "contamination": [{"poll_title": "()", "contamination_1": 1}],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+
+class TestABlockOfUnusableEntriesReadsAsEmpty:
+    """Entities are kept and marked stale, not lost.
+
+    Every entry in the block identifies nothing, so no sensor is built from
+    any of them. Counting the raw list would call that a response carrying
+    data, and the sensors this location already has would then simply not be
+    added: absent from Home Assistant rather than present and stale, which is
+    what the user sees.
+    """
+
+    async def _setup_with_registered(self, hass, response, slugs=("birch",)):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        for slug in slugs:
+            unique_id = f"polleninformation_hamburg_{slug}"
+            ent_reg.async_get_or_create(
+                "sensor",
+                DOMAIN,
+                unique_id,
+                suggested_object_id=unique_id,
+                config_entry=entry,
+            )
+        return await _setup_entities(
+            hass,
+            "de",
+            entry=entry,
+            response=response,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+
+    async def test_a_registered_sensor_is_recreated_rather_than_lost(self, hass):
+        entities = await self._setup_with_registered(hass, ALL_UNUSABLE_RESPONSE)
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_birch" in unique_ids
+
+    async def test_the_recreated_sensor_is_marked_stale(self, hass):
+        entities = await self._setup_with_registered(hass, ALL_UNUSABLE_RESPONSE)
+        sensor = _by_type(entities, PolleninformationSensor)
+
+        assert sensor.extra_state_attributes["data_stale"] is True
+
+    async def test_no_sensor_is_built_from_the_unusable_entries(self, hass):
+        entities = await self._setup_with_registered(hass, ALL_UNUSABLE_RESPONSE)
+        pollen = [e for e in entities if isinstance(e, PolleninformationSensor)]
+
+        # Only the recreated one, nothing manufactured from the junk.
+        assert len(pollen) == 1
+
+    async def test_risk_entities_are_recreated_too(self, hass):
+        entities = await self._setup_with_registered(
+            hass, ALL_UNUSABLE_RESPONSE, slugs=("birch", "allergy_risk")
+        )
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_allergy_risk" in unique_ids
+
+    async def test_risk_data_keeps_the_response_from_being_stale(self, hass):
+        # The two tests are not the same question and are allowed to disagree:
+        # the pollen block carried nothing usable, so its sensors are
+        # recreated, while the response as a whole did carry data, so nothing
+        # is marked stale and the risk sensors report real readings.
+        entities = await self._setup_with_registered(
+            hass, ALL_UNUSABLE_WITH_RISK_RESPONSE
+        )
+        sensor = _by_type(entities, PolleninformationSensor)
+
+        assert "data_stale" not in sensor.extra_state_attributes
+
+
 class TestEveryEntityReportsTheSameOutage:
     """The timestamp belongs to the response, so siblings must agree on it.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2125,3 +2125,76 @@ class TestLocalizedTitleWithoutLatin:
         )
         sensor.coordinator.data = BINOMIAL_NAME_RESPONSE
         assert sensor.native_value == "mäßig"
+
+
+MUGWORT_ENTRY = {
+    "poll_title": "Artemisia",
+    "contamination_1": 1,
+    "contamination_2": 1,
+    "contamination_3": 0,
+    "contamination_4": 0,
+}
+
+COMPOSITE_ENTRY = {
+    "poll_title": "Artemisia (Asteraceae)",
+    "contamination_1": 3,
+    "contamination_2": 2,
+    "contamination_3": 2,
+    "contamination_4": 1,
+}
+
+ASTERACEAE_LANGUAGE_BLOCK = {
+    "poll_titles": [
+        {"name": "composite family", "latin": "Asteraceae"},
+        {"name": "mugwort", "latin": "Artemisia"},
+    ]
+}
+
+
+class TestTwoEntriesSharingOneName:
+    """Two allergens can share a match key, so the name alone cannot decide.
+
+    "Artemisia (Asteraceae)" and a bare "Artemisia" resolve to different
+    slugs, but poll_title_local strips the parenthesized latin, so both
+    sensors keep "Artemisia" as their name match key.
+    """
+
+    @pytest.mark.parametrize(
+        "contamination",
+        [
+            [MUGWORT_ENTRY, COMPOSITE_ENTRY],
+            [COMPOSITE_ENTRY, MUGWORT_ENTRY],
+        ],
+        ids=["mugwort_first", "composite_first"],
+    )
+    async def test_each_sensor_reads_its_own_entry(self, hass, contamination):
+        entities = await _setup_entities(
+            hass,
+            "en",
+            response={
+                "contamination": contamination,
+                "allergyrisk": {},
+                "allergyrisk_hourly": {},
+            },
+            language_block=ASTERACEAE_LANGUAGE_BLOCK,
+        )
+        by_slug = {
+            e.unique_id: e for e in entities if isinstance(e, PolleninformationSensor)
+        }
+        mugwort = by_slug["polleninformation_hamburg_mugwort"]
+        composite = by_slug["polleninformation_hamburg_composite_family"]
+
+        assert mugwort.native_value == "low"
+        assert composite.native_value == "high"
+        assert [d["level"] for d in mugwort.extra_state_attributes["forecast"]] == [
+            1,
+            1,
+            0,
+            0,
+        ]
+        assert [d["level"] for d in composite.extra_state_attributes["forecast"]] == [
+            3,
+            2,
+            2,
+            1,
+        ]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -29,7 +29,6 @@ from custom_components.polleninformation.sensor import (
 )
 from custom_components.polleninformation.utils import slugify
 
-
 # --- Helper function tests (pure, no HA dependency) ---
 
 
@@ -1191,6 +1190,81 @@ class TestLatinGenusAsDisplayName:
         assert (
             ent_reg.async_get_entity_id(
                 "sensor", DOMAIN, "polleninformation_hamburg_artemisia"
+            )
+            is None
+        )
+
+
+# An allergen whose latin name the static map does not know, but whose display
+# name happens to be the latin genus of a different allergen. The English
+# language block knows the latin name, so it must win: the display name is only
+# a last resort.
+UNKNOWN_LATIN_WITH_GENUS_NAME_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Artemisia (Asteraceae)",
+            "contamination_1": 1,
+            "contamination_2": 0,
+            "contamination_3": 0,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+COMPOSITE_FAMILY_LANGUAGE_BLOCK = {
+    "poll_titles": [{"name": "Composite family", "latin": "Asteraceae"}]
+}
+
+
+class TestEnglishBlockOutranksTheDisplayName:
+    """The English language block wins over a display name that is a genus.
+
+    The display-name lookup exists for allergens whose latin name is missing.
+    It must not outrank the English language block, because slugging the
+    allergen from the wrong source both names the entity after a different
+    allergen and makes the migration rename an existing entity onto it.
+    """
+
+    async def _setup(self, hass, entry=None):
+        return await _setup_entities(
+            hass,
+            "de",
+            entry=entry,
+            response=UNKNOWN_LATIN_WITH_GENUS_NAME_RESPONSE,
+            language_block=COMPOSITE_FAMILY_LANGUAGE_BLOCK,
+        )
+
+    async def test_slug_comes_from_the_english_block(self, hass):
+        entities = await self._setup(hass)
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+        assert "polleninformation_hamburg_composite_family" in unique_ids
+        assert "polleninformation_hamburg_mugwort" not in unique_ids
+
+    async def test_no_rename_onto_another_allergen(self, hass):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_composite_family",
+            suggested_object_id="polleninformation_hamburg_composite_family",
+            config_entry=entry,
+        )
+
+        await self._setup(hass, entry=entry)
+
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_composite_family"
+            )
+            == "sensor.polleninformation_hamburg_composite_family"
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_mugwort"
             )
             is None
         )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1718,3 +1718,24 @@ class TestStaleSensorRecovery:
         sensor.coordinator.data = LATIN_GENUS_AS_NAME_RESPONSE
         assert sensor.native_value == "bajo"
 
+    async def test_stale_flag_clears_once_the_allergen_is_found(self, hass):
+        """A recovered sensor must stop claiming its data is stale.
+
+        The flag is set in the constructor and async_setup_entry does not run
+        again when the API recovers, so it has to be derived from whether the
+        allergen was actually found.
+        """
+        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
+        attrs = sensor.extra_state_attributes
+        assert "data_stale" not in attrs
+        assert "stale_since" not in attrs
+
+    async def test_stale_flag_stays_while_the_allergen_is_missing(self, hass):
+        """Data for other allergens only is still no data for this one."""
+        sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
+        sensor.coordinator.data = LATIN_GENUS_AS_NAME_RESPONSE
+        attrs = sensor.extra_state_attributes
+        assert attrs["data_stale"] is True
+        assert attrs["stale_since"] is not None
+

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2440,7 +2440,79 @@ class TestTheRiskGateAtSetup:
         assert "polleninformation_hamburg_allergy_risk_hourly" in unique_ids
 
 
-class TestEveryEntityReportsTheSameOutage:
+class TestARiskBlockWithNothingReadable:
+    """Nonempty is not usable, one level deeper than last time.
+
+    block_of answers whether there is a block; the callers were using it to
+    answer whether there is anything to read. {"error": "upstream failure"}
+    is an object, so the outage was cleared, the pollen sensors were
+    recreated for want of data, and nothing carried the marker.
+    """
+
+    UNREADABLE = {
+        "contamination": [{"poll_title": "()"}, {"poll_title": ""}],
+        "allergyrisk": {"error": "upstream failure"},
+        "allergyrisk_hourly": {},
+    }
+
+    READABLE = {
+        "contamination": [{"poll_title": "()"}],
+        "allergyrisk": {"allergyrisk_1": 7.0},
+        "allergyrisk_hourly": {"allergyrisk_hourly_1": [7.0] * 24},
+    }
+
+    async def _with_registered(self, hass, response):
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        for slug in ("birch", "allergy_risk"):
+            unique_id = f"polleninformation_hamburg_{slug}"
+            ent_reg.async_get_or_create(
+                "sensor",
+                DOMAIN,
+                unique_id,
+                suggested_object_id=unique_id,
+                config_entry=entry,
+            )
+        return await _setup_entities(
+            hass,
+            "de",
+            entry=entry,
+            response=response,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+
+    async def test_the_sensors_carry_the_marker(self, hass):
+        entities = await self._with_registered(hass, self.UNREADABLE)
+        sensor = _by_type(entities, PolleninformationSensor)
+
+        assert sensor.extra_state_attributes["data_stale"] is True
+
+    async def test_no_risk_sensor_is_built_from_it(self, hass):
+        entities = await _setup_entities(
+            hass, "de", response=self.UNREADABLE, language_block=EMPTY_LANGUAGE_BLOCK
+        )
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+
+        assert "polleninformation_hamburg_allergy_risk" not in unique_ids
+
+    async def test_a_readable_reading_beside_unusable_pollen_still_survives(self, hass):
+        # ORDER #21 A restored this; it must not regress.
+        entities = await _setup_entities(
+            hass, "de", response=self.READABLE, language_block=EMPTY_LANGUAGE_BLOCK
+        )
+        risk = _by_type(entities, AllergyRiskSensor)
+
+        assert risk.native_value == "hoch"
+        assert "data_stale" not in risk.extra_state_attributes
+
+    async def test_reading_an_unreadable_block_reports_unknown(self, hass):
+        entities = await _setup_entities(hass, "de")
+        risk = _by_type(entities, AllergyRiskSensor)
+        risk.coordinator.data = self.UNREADABLE
+
+        assert risk.native_value is None
+
     """The timestamp belongs to the response, so siblings must agree on it.
 
     The per-outage semantics themselves are the coordinator's, and are tested

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2442,6 +2442,13 @@ class TestANonObjectEntryCostsOnlyItself:
         assert len(sensor.extra_state_attributes["forecast"]) == 4
 
 
+NAMED_BIRCH_RESPONSE = {
+    "contamination": [{"poll_title": "Birke", "contamination_1": 3}],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+
 class TestTheLanguageMapIsReadDefensively:
     """The shipped map is an input too, and the only one nothing type checks.
 
@@ -2451,14 +2458,6 @@ class TestTheLanguageMapIsReadDefensively:
     inside setup and take the whole config entry down: every sensor for the
     location, for a bad row in a file the user can edit.
     """
-
-    RESPONSE = {
-        "contamination": [
-            {"poll_title": "Birke", "contamination_1": 3},
-        ],
-        "allergyrisk": {"allergyrisk_1": 5.0},
-        "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
-    }
 
     @pytest.mark.parametrize(
         "block",
@@ -2472,7 +2471,7 @@ class TestTheLanguageMapIsReadDefensively:
     )
     async def test_setup_survives_a_map_of_the_wrong_shape(self, hass, block):
         entities = await _setup_entities(
-            hass, "de", response=self.RESPONSE, language_block=block
+            hass, "de", response=NAMED_BIRCH_RESPONSE, language_block=block
         )
 
         # The entry still becomes a sensor; only its latin name is missing.
@@ -2482,7 +2481,7 @@ class TestTheLanguageMapIsReadDefensively:
         entities = await _setup_entities(
             hass,
             "de",
-            response=self.RESPONSE,
+            response=NAMED_BIRCH_RESPONSE,
             language_block={"poll_titles": [{"name": "Birke", "latin": "Betula"}]},
         )
         sensor = _by_type(entities, PolleninformationSensor)
@@ -2685,6 +2684,19 @@ class TestTheHourlyReaderTakesAnyShape:
         assert len(sensor.extra_state_attributes["forecast"]) == 3
 
 
+UNREADABLE_RISK_RESPONSE = {
+    "contamination": [{"poll_title": "()"}, {"poll_title": ""}],
+    "allergyrisk": {"error": "upstream failure"},
+    "allergyrisk_hourly": {},
+}
+
+READABLE_RISK_RESPONSE = {
+    "contamination": [{"poll_title": "()"}],
+    "allergyrisk": {"allergyrisk_1": 7.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [7.0] * 24},
+}
+
+
 class TestARiskBlockWithNothingReadable:
     """Nonempty is not usable, one level deeper than last time.
 
@@ -2693,18 +2705,6 @@ class TestARiskBlockWithNothingReadable:
     is an object, so the outage was cleared, the pollen sensors were
     recreated for want of data, and nothing carried the marker.
     """
-
-    UNREADABLE = {
-        "contamination": [{"poll_title": "()"}, {"poll_title": ""}],
-        "allergyrisk": {"error": "upstream failure"},
-        "allergyrisk_hourly": {},
-    }
-
-    READABLE = {
-        "contamination": [{"poll_title": "()"}],
-        "allergyrisk": {"allergyrisk_1": 7.0},
-        "allergyrisk_hourly": {"allergyrisk_hourly_1": [7.0] * 24},
-    }
 
     async def _with_registered(self, hass, response):
         entry = _make_entry("de")
@@ -2728,14 +2728,17 @@ class TestARiskBlockWithNothingReadable:
         )
 
     async def test_the_sensors_carry_the_marker(self, hass):
-        entities = await self._with_registered(hass, self.UNREADABLE)
+        entities = await self._with_registered(hass, UNREADABLE_RISK_RESPONSE)
         sensor = _by_type(entities, PolleninformationSensor)
 
         assert sensor.extra_state_attributes["data_stale"] is True
 
     async def test_no_risk_sensor_is_built_from_it(self, hass):
         entities = await _setup_entities(
-            hass, "de", response=self.UNREADABLE, language_block=EMPTY_LANGUAGE_BLOCK
+            hass,
+            "de",
+            response=UNREADABLE_RISK_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
         )
         unique_ids = {e.unique_id for e in entities if e.unique_id}
 
@@ -2744,7 +2747,10 @@ class TestARiskBlockWithNothingReadable:
     async def test_a_readable_reading_beside_unusable_pollen_still_survives(self, hass):
         # ORDER #21 A restored this; it must not regress.
         entities = await _setup_entities(
-            hass, "de", response=self.READABLE, language_block=EMPTY_LANGUAGE_BLOCK
+            hass,
+            "de",
+            response=READABLE_RISK_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
         )
         risk = _by_type(entities, AllergyRiskSensor)
 
@@ -2754,7 +2760,7 @@ class TestARiskBlockWithNothingReadable:
     async def test_reading_an_unreadable_block_reports_unknown(self, hass):
         entities = await _setup_entities(hass, "de")
         risk = _by_type(entities, AllergyRiskSensor)
-        risk.coordinator.data = self.UNREADABLE
+        risk.coordinator.data = UNREADABLE_RISK_RESPONSE
 
         assert risk.native_value is None
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1098,6 +1098,104 @@ class TestUnknownAllergenFallback:
         )
 
 
+# The API sometimes sends the latin genus as the display name and leaves the
+# latin field empty, e.g. "Artemisia" with no "(...)" in poll_title and no
+# matching entry in the language block. The name is nonetheless a known key in
+# LATIN_TO_ENGLISH_NAME.
+LATIN_GENUS_AS_NAME_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Artemisia",
+            "contamination_1": 1,
+            "contamination_2": 0,
+            "contamination_3": 0,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+
+class TestLatinGenusAsDisplayName:
+    """A latin genus arriving as the display name still resolves through the map.
+
+    Regression test for issue #71: "Artemisia" arrived as the poll_title with
+    an empty latin field, so the latin-keyed lookup missed it. The sensor was
+    slugged "artemisia" with the default icon and a spurious "Unknown allergen"
+    warning fired on every refresh -- even though "Artemisia" is a known key in
+    LATIN_TO_ENGLISH_NAME that resolves to "mugwort".
+    """
+
+    async def _setup(self, hass):
+        return await _setup_entities(
+            hass,
+            "de",
+            response=LATIN_GENUS_AS_NAME_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+
+    async def test_resolves_to_the_canonical_english_slug(self, hass):
+        entities = await self._setup(hass)
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+        assert "polleninformation_hamburg_mugwort" in unique_ids
+        assert "polleninformation_hamburg_artemisia" not in unique_ids
+
+    async def test_uses_the_mapped_icon(self, hass):
+        entities = await self._setup(hass)
+        sensor = next(
+            e
+            for e in entities
+            if isinstance(e, PolleninformationSensor)
+            and e.unique_id == "polleninformation_hamburg_mugwort"
+        )
+        assert sensor.icon == ALLERGEN_ICON_MAP["mugwort"]
+
+    async def test_no_unknown_allergen_warning(self, hass, caplog):
+        with caplog.at_level(logging.WARNING):
+            await self._setup(hass)
+        assert not [r for r in caplog.records if "Unknown allergen" in r.getMessage()]
+
+    async def test_existing_buggy_slug_entity_is_migrated(self, hass):
+        """An entity from the pre-fix "artemisia" slug is carried to "mugwort".
+
+        Before the fix this allergen was slugged "artemisia", so an upgrading
+        user already has that entity in the registry. The fix must rename it to
+        the canonical "mugwort" -- via the same migration path used for
+        localized slugs -- so history and automations survive instead of the
+        old sensor being orphaned beside a new one.
+        """
+        entry = _make_entry("de")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_artemisia",
+            suggested_object_id="polleninformation_hamburg_artemisia",
+            config_entry=entry,
+        )
+        await _setup_entities(
+            hass,
+            "de",
+            entry=entry,
+            response=LATIN_GENUS_AS_NAME_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_mugwort"
+            )
+            == "sensor.polleninformation_hamburg_mugwort"
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_artemisia"
+            )
+            is None
+        )
+
+
 # The canonical slug for every allergen, pinned. These slugs are a public
 # contract: they are the entity_id suffix, they are in every unique_id, and
 # the pollen forecast card matches on them. A change to an API display name or

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1676,6 +1676,21 @@ GENUS_PREFIXED_NAME_RESPONSE = {
 }
 
 
+BINOMIAL_NAME_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Ailanthus altissima",
+            "contamination_1": 2,
+            "contamination_2": 1,
+            "contamination_3": 0,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {},
+    "allergyrisk_hourly": {},
+}
+
+
 class TestStaleSensorRecovery:
     """A sensor recreated during an empty response must recover on any language."""
 
@@ -1753,6 +1768,18 @@ class TestStaleSensorRecovery:
         attrs = sensor.extra_state_attributes
         assert attrs["data_stale"] is True
         assert attrs["stale_since"] is not None
+
+    async def test_recovers_when_the_display_name_is_a_binomial_key(self, hass):
+        """A binomial key in the latin map: "Ailanthus altissima".
+
+        Counting words would reject it, but it is a latin name the map knows,
+        so a stale tree of heaven sensor must pick it up like any other.
+        """
+        sensor = await self._recreate(
+            hass, "de", "polleninformation_hamburg_tree_of_heaven"
+        )
+        sensor.coordinator.data = BINOMIAL_NAME_RESPONSE
+        assert sensor.native_value == "mäßig"
 
     async def test_a_two_word_name_starting_with_a_genus_does_not_match(self, hass):
         """The display-name lookup holds only for a name that IS the genus.
@@ -1865,3 +1892,4 @@ class TestStaleSinceFollowsTheCurrentOutage:
             attrs = sensor.extra_state_attributes
         assert attrs["data_stale"] is True
         assert attrs["stale_since"] == T2.isoformat()
+

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1922,6 +1922,9 @@ class TestGenusPrefixedNameOnTheSetupPath:
         )
 
 
+EN_LEVELS = ["none", "low", "moderate", "high", "very high"]
+
+
 class TestPartialDataIsNotFreshData:
     """A sensor with no readable value must not report itself fresh.
 
@@ -1930,12 +1933,10 @@ class TestPartialDataIsNotFreshData:
     unknown while clearing the stale marker.
     """
 
-    LEVELS = ["none", "low", "moderate", "high", "very high"]
-
     def _risk(self, cls, data, is_stale=True):
         return cls(
             coordinator=_make_coordinator(data),
-            levels_current=self.LEVELS,
+            levels_current=EN_LEVELS,
             location_slug="hamburg",
             location_title="Hamburg",
             is_stale=is_stale,
@@ -2017,8 +2018,8 @@ class TestPartialDataIsNotFreshData:
             allergen_en="birch",
             allergen_slug="birch",
             allergen_latin="Betula",
-            levels_current=self.LEVELS,
-            levels_en=self.LEVELS,
+            levels_current=EN_LEVELS,
+            levels_en=EN_LEVELS,
             location_slug="hamburg",
             location_title="Hamburg",
             icon="mdi:tree-outline",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1155,6 +1155,22 @@ class TestLatinGenusAsDisplayName:
             await self._setup(hass)
         assert not [r for r in caplog.records if "Unknown allergen" in r.getMessage()]
 
+    async def test_reports_the_genus_as_the_latin_name(self, hass):
+        """The display name is a proven latin genus, so it is the latin name.
+
+        The API left the latin field empty, but the map lookup that resolved
+        the slug proved the display name is a latin genus. Reporting an empty
+        name_la for exactly the allergens this resolves would waste that.
+        """
+        entities = await self._setup(hass)
+        sensor = next(
+            e
+            for e in entities
+            if isinstance(e, PolleninformationSensor)
+            and e.unique_id == "polleninformation_hamburg_mugwort"
+        )
+        assert sensor.extra_state_attributes["name_la"] == "Artemisia"
+
     async def test_existing_buggy_slug_entity_is_migrated(self, hass):
         """An entity from the pre-fix "artemisia" slug is carried to "mugwort".
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2240,6 +2240,55 @@ class TestANonObjectEntryCostsOnlyItself:
         assert len(sensor.extra_state_attributes["forecast"]) == 4
 
 
+class TestTheLanguageMapIsReadDefensively:
+    """The shipped map is an input too, and the only one nothing type checks.
+
+    The API's response is parsed and filtered before anything reads it. The
+    language block is loaded from a file and its latin name goes straight into
+    a lookup that calls .strip(), so a map holding the wrong shape would raise
+    inside setup and take the whole config entry down: every sensor for the
+    location, for a bad row in a file the user can edit.
+    """
+
+    RESPONSE = {
+        "contamination": [
+            {"poll_title": "Birke", "contamination_1": 3},
+        ],
+        "allergyrisk": {"allergyrisk_1": 5.0},
+        "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+    }
+
+    @pytest.mark.parametrize(
+        "block",
+        [
+            {"poll_titles": [{"name": "Birke", "latin": ["Betula"]}]},
+            {"poll_titles": [{"name": "Birke", "latin": 5}]},
+            {"poll_titles": ["oops", {"name": "Birke", "latin": "Betula"}]},
+            {"poll_titles": None},
+            {"poll_titles": {}},
+        ],
+    )
+    async def test_setup_survives_a_map_of_the_wrong_shape(self, hass, block):
+        entities = await _setup_entities(
+            hass, "de", response=self.RESPONSE, language_block=block
+        )
+
+        # The entry still becomes a sensor; only its latin name is missing.
+        assert [e for e in entities if isinstance(e, PolleninformationSensor)]
+
+    async def test_a_well_formed_map_still_supplies_the_latin_name(self, hass):
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response=self.RESPONSE,
+            language_block={"poll_titles": [{"name": "Birke", "latin": "Betula"}]},
+        )
+        sensor = _by_type(entities, PolleninformationSensor)
+
+        assert sensor.extra_state_attributes["name_la"] == "Betula"
+        assert sensor.unique_id == "polleninformation_hamburg_birch"
+
+
 class TestFindItemIsSafeWithoutItsCallers:
     """The block is filtered by _find_item itself, not by its callers.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1422,6 +1422,23 @@ class TestDeclaredLatinNameAliases:
     def test_every_alias_names_an_allergen_the_map_knows(self):
         assert set(LATIN_NAME_ALIASES.values()) <= set(LATIN_TO_ENGLISH_NAME)
 
+    def test_no_alias_shadows_a_latin_name_the_map_knows(self):
+        # The other half of the same property. Both indexes fold the aliases
+        # in with setdefault, so a real latin name wins there, while
+        # resolve_latin_alias reads the table directly and lets the alias win.
+        # A key that is also a real latin name would therefore make the file
+        # and the sensors disagree about the same string, with nothing to warn
+        # about it and every test green.
+        known = {latin.lower() for latin in LATIN_TO_ENGLISH_NAME}
+        known |= {latin.split()[0].lower() for latin in LATIN_TO_ENGLISH_NAME}
+        assert not (set(LATIN_NAME_ALIASES) & known)
+
+    def test_the_two_resolvers_agree_on_every_alias(self):
+        """What the shadowing rule is for, stated as the property itself."""
+        for alias, latin in LATIN_NAME_ALIASES.items():
+            assert resolve_latin_alias(alias) == latin
+            assert canonical_latin(alias) == latin
+
     async def _setup(self, hass):
         return await _setup_entities(
             hass,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,7 +1,9 @@
 """Tests for sensor helper functions and sensor classes."""
 
+import json
 import logging
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
 
@@ -446,6 +448,54 @@ def _make_entry(lang, options=None):
         },
         options=options or {},
     )
+
+
+SHIPPED_LANGUAGE_MAP = json.loads(
+    (
+        Path(__file__).resolve().parent.parent
+        / "custom_components"
+        / "polleninformation"
+        / "language_map.json"
+    ).read_text(encoding="utf-8")
+)
+
+
+def shipped_block(lang):
+    """The language block this integration actually ships for a language."""
+    return next(
+        block
+        for block in SHIPPED_LANGUAGE_MAP.values()
+        if block.get("lang_code") == lang
+    )
+
+
+async def _setup_with_shipped_blocks(hass, lang, response, entry=None):
+    """Run setup with the REAL map, one block per language, as at runtime.
+
+    Every other setup helper here hands the same block to both lookups, and
+    most migration tests hand them an empty one. The map is an input, and an
+    empty one is a configuration we never ship: the bug this exists for was
+    invisible until the block carried what the file carries.
+    """
+    if entry is None:
+        entry = _make_entry(lang)
+        entry.add_to_hass(hass)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _make_coordinator(response)
+
+    entities = []
+
+    def _add(new_entities, update_before_add=False):
+        entities.extend(new_entities)
+
+    async def _block(_hass, lang_code):
+        return shipped_block(lang_code)
+
+    with patch(
+        "custom_components.polleninformation.sensor.async_get_language_block",
+        AsyncMock(side_effect=_block),
+    ):
+        await async_setup_entry(hass, entry, _add)
+    return entities
 
 
 async def _setup_entities(
@@ -1219,6 +1269,158 @@ class TestLatinGenusAsDisplayName:
             )
             is None
         )
+
+
+# The Spanish response for mugwort, which the API sends as a bare latin genus.
+SPANISH_MUGWORT_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Artemisia",
+            "contamination_1": 2,
+            "contamination_2": 1,
+            "contamination_3": 0,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+ITALIAN_RAGWEED_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Ambrosia",
+            "contamination_1": 2,
+            "contamination_2": 1,
+            "contamination_3": 0,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {"allergyrisk_1": 5.0},
+    "allergyrisk_hourly": {"allergyrisk_hourly_1": [5.0] * 24},
+}
+
+
+class TestMigrationAgainstTheShippedMap:
+    """The migration under the configuration we actually ship.
+
+    Every other migration test hands setup an EMPTY language block, so the
+    latin backfill finds nothing and the legacy slug falls out of the display
+    name by default. With the real map the backfill DOES find a latin, the
+    English-block lookup then succeeds, and the legacy name becomes the
+    English one: identical to the canonical name, so no rename was queued and
+    the user's entity was orphaned beside a new one. The data changed what the
+    code did, which is why reading the code did not show it.
+    """
+
+    @staticmethod
+    def _register(hass, lang, slug):
+        entry = _make_entry(lang)
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        registered = ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            f"polleninformation_hamburg_{slug}",
+            suggested_object_id=f"polleninformation_hamburg_{slug}",
+            config_entry=entry,
+        )
+        return entry, ent_reg, registered.id
+
+    async def test_a_spanish_install_is_migrated(self, hass):
+        entry, ent_reg, _ = self._register(hass, "es", "artemisia")
+
+        await _setup_with_shipped_blocks(
+            hass, "es", SPANISH_MUGWORT_RESPONSE, entry=entry
+        )
+
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_mugwort"
+            )
+            == "sensor.polleninformation_hamburg_mugwort"
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_artemisia"
+            )
+            is None
+        )
+
+    async def test_the_registry_row_is_the_same_row(self, hass):
+        # The point of migrating rather than recreating: the history hangs off
+        # the registry id, so a new row beside the old one loses it.
+        entry, ent_reg, original_id = self._register(hass, "es", "artemisia")
+
+        await _setup_with_shipped_blocks(
+            hass, "es", SPANISH_MUGWORT_RESPONSE, entry=entry
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_mugwort")
+        assert migrated is not None
+        assert migrated.id == original_id
+
+    async def test_only_one_entity_remains_for_the_allergen(self, hass):
+        entry, ent_reg, _ = self._register(hass, "es", "artemisia")
+
+        await _setup_with_shipped_blocks(
+            hass, "es", SPANISH_MUGWORT_RESPONSE, entry=entry
+        )
+
+        rows = [
+            e
+            for e in er.async_entries_for_config_entry(ent_reg, entry.entry_id)
+            if e.unique_id
+            and e.unique_id.startswith("polleninformation_hamburg_")
+            and not e.unique_id.endswith(("allergy_risk", "allergy_risk_hourly"))
+        ]
+        assert len(rows) == 1
+
+    async def test_an_italian_install_is_migrated_too(self, hass):
+        # The same shape in another language: the API sends the latin genus as
+        # the display name, so a pre-0.5.5 install could hold "..._ambrosia".
+        entry, ent_reg, original_id = self._register(hass, "it", "ambrosia")
+
+        await _setup_with_shipped_blocks(
+            hass, "it", ITALIAN_RAGWEED_RESPONSE, entry=entry
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_ragweed")
+        assert migrated is not None
+        assert migrated.id == original_id
+
+    async def test_a_localized_name_is_still_migrated(self, hass):
+        # The case the old tests covered, re-run against the real map so the
+        # fix cannot buy the new case at its expense.
+        entry, ent_reg, original_id = self._register(hass, "de", "birke")
+
+        await _setup_with_shipped_blocks(
+            hass,
+            "de",
+            {
+                "contamination": [
+                    {"poll_title": "Birke (Betula)", "contamination_1": 2},
+                ],
+                "allergyrisk": {},
+                "allergyrisk_hourly": {},
+            },
+            entry=entry,
+        )
+
+        migrated = ent_reg.async_get("sensor.polleninformation_hamburg_birch")
+        assert migrated is not None
+        assert migrated.id == original_id
+
+    async def test_an_install_already_on_the_canonical_slug_is_left_alone(self, hass):
+        entry, ent_reg, original_id = self._register(hass, "es", "mugwort")
+
+        await _setup_with_shipped_blocks(
+            hass, "es", SPANISH_MUGWORT_RESPONSE, entry=entry
+        )
+
+        kept = ent_reg.async_get("sensor.polleninformation_hamburg_mugwort")
+        assert kept is not None
+        assert kept.id == original_id
 
 
 # An allergen whose latin name the static map does not know, but whose display

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2240,6 +2240,46 @@ class TestANonObjectEntryCostsOnlyItself:
         assert len(sensor.extra_state_attributes["forecast"]) == 4
 
 
+class TestABlockThatIsNotAnObject:
+    """The same assumption one level up, over the risk blocks.
+
+    allergyrisk and allergyrisk_hourly are read with .get, so a block that
+    arrives as a list or a string raised on the first read and took the
+    entity down with it. A block that is not an object carries nothing, which
+    is what an absent one means too.
+    """
+
+    @pytest.mark.parametrize("risk", [["oops"], "x", 42, None])
+    async def test_the_daily_risk_sensor_reports_nothing(self, hass, risk):
+        entities = await _setup_entities(
+            hass,
+            "de",
+            response={**RAGWEED_RESPONSE, "allergyrisk": risk},
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+        sensor = _by_type(entities, PolleninformationSensor)
+
+        # The pollen sensor is unaffected, and nothing raised on the way here.
+        assert sensor.native_value is not None
+
+    @pytest.mark.parametrize("risk", [["oops"], "x", 42])
+    async def test_reading_a_risk_sensor_survives_it(self, hass, risk):
+        entities = await _setup_entities(hass, "de")
+        sensor = _by_type(entities, AllergyRiskSensor)
+        sensor.coordinator.data = {**RAGWEED_RESPONSE, "allergyrisk": risk}
+
+        assert sensor.native_value is None
+        assert "forecast" not in sensor.extra_state_attributes
+
+    @pytest.mark.parametrize("risk", [["oops"], "x", 42])
+    async def test_reading_an_hourly_risk_sensor_survives_it(self, hass, risk):
+        entities = await _setup_entities(hass, "de")
+        sensor = _by_type(entities, AllergyRiskHourlySensor)
+        sensor.coordinator.data = {**RAGWEED_RESPONSE, "allergyrisk_hourly": risk}
+
+        assert sensor.native_value is None
+
+
 class TestEveryEntityReportsTheSameOutage:
     """The timestamp belongs to the response, so siblings must agree on it.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1692,7 +1692,8 @@ class TestStaleSensorRecovery:
     async def test_german_forecast_recovers(self, hass):
         sensor = await self._recreate(hass, "de", "polleninformation_hamburg_birch")
         sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
-        assert len(sensor.extra_state_attributes["forecast"]) == 4
+        forecast = sensor.extra_state_attributes["forecast"]
+        assert [day["level"] for day in forecast] == [3, 2, 1, 0]
 
     async def test_english_dock_sorrel_recovers(self, hass):
         sensor = await self._recreate(
@@ -1715,4 +1716,5 @@ class TestStaleSensorRecovery:
         """
         sensor = await self._recreate(hass, "es", "polleninformation_hamburg_mugwort")
         sensor.coordinator.data = LATIN_GENUS_AS_NAME_RESPONSE
-        assert sensor.native_value is not None
+        assert sensor.native_value == "bajo"
+

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2001,6 +2001,61 @@ LOCALIZED_TITLE_RESPONSE = {
 }
 
 
+class TestGenusPrefixedNameOnTheSetupPath:
+    """Prose that begins with a latin genus must not be taken for that genus.
+
+    The setup path owns the entity_id and queues the rename, so resolving
+    "Ambrosia hojas" to ragweed there does more than mis-match a sensor. The
+    stale-recovery direction is pinned in TestStaleSensorRecovery; this is
+    the setup direction of the same rule.
+    """
+
+    async def _setup(self, hass, entry=None):
+        return await _setup_entities(
+            hass,
+            "es",
+            entry=entry,
+            response=GENUS_PREFIXED_NAME_RESPONSE,
+            language_block=EMPTY_LANGUAGE_BLOCK,
+        )
+
+    async def test_does_not_take_the_ragweed_slug(self, hass):
+        entities = await self._setup(hass)
+        unique_ids = {e.unique_id for e in entities if e.unique_id}
+        assert "polleninformation_hamburg_ragweed" not in unique_ids
+        assert "polleninformation_hamburg_ambrosia_hojas" in unique_ids
+
+    async def test_does_not_report_the_prose_as_a_latin_name(self, hass):
+        entities = await self._setup(hass)
+        sensor = _by_type(entities, PolleninformationSensor)
+        assert sensor.extra_state_attributes["name_la"] == ""
+
+    async def test_queues_no_rename_onto_ragweed(self, hass):
+        entry = _make_entry("es")
+        entry.add_to_hass(hass)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            "polleninformation_hamburg_ambrosia_hojas",
+            suggested_object_id="polleninformation_hamburg_ambrosia_hojas",
+            config_entry=entry,
+        )
+        await self._setup(hass, entry=entry)
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_ambrosia_hojas"
+            )
+            == "sensor.polleninformation_hamburg_ambrosia_hojas"
+        )
+        assert (
+            ent_reg.async_get_entity_id(
+                "sensor", DOMAIN, "polleninformation_hamburg_ragweed"
+            )
+            is None
+        )
+
+
 class TestLocalizedTitleWithoutLatin:
     """The API also sends a localized title with no parenthesized latin name.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2059,3 +2059,69 @@ class TestPartialDataIsNotFreshData:
         assert attrs["data_stale"] is True
         assert attrs["stale_since"] == T1.isoformat()
 
+
+GERMAN_LANGUAGE_BLOCK = {"poll_titles": [{"name": "Birke", "latin": "Betula"}]}
+
+LOCALIZED_TITLE_RESPONSE = {
+    "contamination": [
+        {
+            "poll_title": "Birke",
+            "contamination_1": 3,
+            "contamination_2": 2,
+            "contamination_3": 1,
+            "contamination_4": 0,
+        }
+    ],
+    "allergyrisk": {},
+    "allergyrisk_hourly": {},
+}
+
+
+class TestLocalizedTitleWithoutLatin:
+    """The API also sends a localized title with no parenthesized latin name.
+
+    Setup resolves that shape through the language block. A recreated sensor
+    has no latin to read and the title is not a latin name either, so it has
+    to know the localized name the API will send.
+    """
+
+    async def _birch(self, hass):
+        return await _recreate_stale(
+            hass,
+            "de",
+            "polleninformation_hamburg_birch",
+            language_block=GERMAN_LANGUAGE_BLOCK,
+        )
+
+    async def test_recovers_from_a_localized_title(self, hass):
+        sensor = await self._birch(hass)
+        sensor.coordinator.data = LOCALIZED_TITLE_RESPONSE
+        assert sensor.native_value == "hoch"
+
+    async def test_forecast_recovers_from_a_localized_title(self, hass):
+        sensor = await self._birch(hass)
+        sensor.coordinator.data = LOCALIZED_TITLE_RESPONSE
+        forecast = sensor.extra_state_attributes["forecast"]
+        assert [day["level"] for day in forecast] == [3, 2, 1, 0]
+
+    async def test_the_recreated_sensor_is_named_in_the_configured_language(self, hass):
+        """The name the block carries is also the name the user should see."""
+        sensor = await self._birch(hass)
+        assert sensor.name == "Birke"
+
+    async def test_the_latin_shape_still_works(self, hass):
+        """The block must not displace the language independent match."""
+        sensor = await self._birch(hass)
+        sensor.coordinator.data = GERMAN_BIRCH_RESPONSE
+        assert sensor.native_value == "hoch"
+
+    async def test_an_allergen_the_block_does_not_carry_still_recovers(self, hass):
+        """Falling back to the English name keeps the slug match reachable."""
+        sensor = await _recreate_stale(
+            hass,
+            "de",
+            "polleninformation_hamburg_tree_of_heaven",
+            language_block=GERMAN_LANGUAGE_BLOCK,
+        )
+        sensor.coordinator.data = BINOMIAL_NAME_RESPONSE
+        assert sensor.native_value == "mäßig"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1301,6 +1301,61 @@ ITALIAN_RAGWEED_RESPONSE = {
 }
 
 
+class TestNoLegacyCandidateCanClaimAnotherAllergen:
+    """A rename candidate that does not exist is free; one that collides is not.
+
+    The legacy candidates include the slug of the raw display name, so if any
+    language called an allergen something that slugifies to a DIFFERENT
+    allergen's canonical slug, setup would queue a rename that moves that
+    other allergen's entity onto this one. Nothing in the map does that today.
+    It is pinned because the map is data and regenerating it is a data change
+    that no code review would show, which is how the bug this fixes arrived.
+    """
+
+    @staticmethod
+    def _entries():
+        for block in SHIPPED_LANGUAGE_MAP.values():
+            lang = block.get("lang_code")
+            for entry in block.get("poll_titles", []):
+                yield lang, entry
+
+    def test_no_display_name_slugs_to_another_allergen(self):
+        collisions = [
+            (lang, entry["name"], slugify(capitalize_first(entry["name"])))
+            for lang, entry in self._entries()
+            if slugify(capitalize_first(entry["name"])) in KNOWN_ALLERGEN_SLUGS
+            and slugify(capitalize_first(entry["name"]))
+            != slugify(english_name_for_latin(entry["latin"]) or "")
+        ]
+        assert collisions == []
+
+    def test_no_two_allergens_in_one_language_share_a_display_slug(self):
+        # The other way a candidate could move the wrong entity: two entries
+        # in one language producing the same legacy slug for two canonical
+        # slugs, so whichever renames first takes the other's entity.
+        for block in SHIPPED_LANGUAGE_MAP.values():
+            seen = {}
+            for entry in block.get("poll_titles", []):
+                seen.setdefault(slugify(capitalize_first(entry["name"])), []).append(
+                    entry["name"]
+                )
+            assert all(len(names) == 1 for names in seen.values()), (
+                block.get("lang_code"),
+                {k: v for k, v in seen.items() if len(v) > 1},
+            )
+
+    def test_every_recorded_latin_still_resolves_to_a_known_allergen(self):
+        # What the collision test rests on: a display name is compared against
+        # the canonical slug its latin name resolves to, so that resolution
+        # has to exist for every entry.
+        unresolved = [
+            (lang, entry["name"], entry["latin"])
+            for lang, entry in self._entries()
+            if english_name_for_latin(entry["latin"]) is None
+        ]
+        assert unresolved == []
+
+
 class TestMigrationAgainstTheShippedMap:
     """The migration under the configuration we actually ship.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -24,7 +24,6 @@ from custom_components.polleninformation.sensor import (
     entity_id_available,
     extract_allergen_slug_from_unique_id,
     localized_risk_object_id_suffixes,
-    pollen_forecast_for_allergen,
     scale_allergy_risk,
 )
 from custom_components.polleninformation.utils import slugify
@@ -102,32 +101,6 @@ class TestExtractAllergenSlug:
 
     def test_none(self):
         assert extract_allergen_slug_from_unique_id(None) is None
-
-
-class TestPollenForecast:
-    def test_match(self):
-        contamination = [
-            {
-                "poll_title": "Birke (Betula)",
-                "contamination_1": 0,
-                "contamination_2": 1,
-                "contamination_3": 2,
-                "contamination_4": 3,
-            }
-        ]
-        levels = ["none", "low", "moderate", "high", "very high"]
-        result = pollen_forecast_for_allergen(contamination, "Birke", levels)
-        assert len(result) == 4
-        assert result[0]["level"] == 0
-        assert result[0]["level_name"] == "none"
-        assert result[2]["level"] == 2
-        assert result[2]["level_name"] == "moderate"
-
-    def test_no_match(self):
-        contamination = [{"poll_title": "Birke (Betula)", "contamination_1": 1}]
-        levels = ["none", "low"]
-        result = pollen_forecast_for_allergen(contamination, "Unknown", levels)
-        assert result == []
 
 
 # --- Sensor class tests ---


### PR DESCRIPTION
This releases v0.5.5 with the allergen identification fixes: the latin-genus display name case (#71, #72), stale sensor recovery in every language (#73), a response-level stale marker, shared-name disambiguation (#74), Slovak ragweed and language map validation (#75, #76), and rename guards backed by registry latin names (#77). 100 commits against master; the test suite covers the lot.